### PR TITLE
Update launch tracking and npm registry docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project follows semantic versioning for tagged releases.
 
 ### Added
 
-- npm package metadata for installing from GitHub and publishing the
-  `codex-profile` package to the public npm registry.
+- npm package metadata and public install documentation for the published
+  `codex-profile` package.
 
 ### Tests
 

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -663,7 +663,7 @@ Awesome Gemini CLI:
 
 Awesome Vibe Coding Tools by jiji262:
 
-- Status: deferred on 2026-05-21.
+- Status: PR opened on 2026-05-21.
 - Why: focused vibe-coding tools catalogue with `Terminal-Based AI Agents` and
   `CLI Workflow Systems & Agent Enhancers` sections. It already lists Codex CLI
   and Codex-adjacent workflow enhancers such as `oh-my-codex`, so
@@ -674,11 +674,17 @@ Awesome Vibe Coding Tools by jiji262:
 - Contribution notes: README invites direct PRs, asks for an official URL,
   concise description, appropriate category, and AI coding/development
   relevance.
-- Suggested section: `CLI Workflow Systems & Agent Enhancers`.
+- Section: `CLI Workflow Systems & Agent Enhancers`.
+- Resume path: temporary clone at `/tmp/jiji-awesome-vibe-coding-tools`,
+  branch `pinzheng/add-codex-profiles`, commit `e1e637d` adds
+  `codex-profiles`.
 - Validation: reviewed repository metadata, README sections, contribution
-  notes, and duplicate history with GitHub CLI.
-- Deferred path: submit after the open-PR gate drops below 15, or use as the
-  one high-signal new PR in a later monthly pass if still current.
+  notes, and duplicate history with GitHub CLI; ran `git diff --check`.
+  `npx --yes markdownlint-cli README.md` reports existing repository-wide
+  README style issues in the target project, so it was recorded but not treated
+  as a blocker.
+- PR target: <https://github.com/jiji262/awesome-vibe-coding-tools>
+- PR: <https://github.com/jiji262/awesome-vibe-coding-tools/pull/22>
 - Reference: <https://github.com/jiji262/awesome-vibe-coding-tools>
 
 Awesome Vibe Coding by 0xWelt:
@@ -785,9 +791,13 @@ Awesome Vibe Coding CLI by vanna-ai:
   maintainer requests were opened.
 - Ledger-first addendum: after user follow-up, added seven additional
   candidates/skips to the ledger without submitting them.
+- Outreach addendum: after user requested outreach, opened one high-signal PR
+  to <https://github.com/jiji262/awesome-vibe-coding-tools/pull/22>; no other
+  new submissions were opened because the open-PR gate remains above 15.
 - Branch checked: `pinzheng/update-launch-pr-log`.
-- Why no new outreach: 20 recorded distribution PRs are still open, exceeding
-  the monthly gate of 15 open submitted PRs.
+- Outreach limit: 20 recorded distribution PRs are still open, exceeding the
+  monthly gate of 15 open submitted PRs; this pass used the allowed single new
+  high-signal outreach item and stopped there.
 - Validation: ran `git fetch --all --prune`; checked every recorded GitHub PR
   and issue URL with GitHub CLI; inspected maintainer comments on closed
   submissions; verified accepted entries in upstream READMEs where PRs were

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -171,7 +171,7 @@ right environment.
 6. Launch on Product Hunt after screenshots, demo video, README, and install
    path have all been click-tested.
 
-## Deferred Channels
+## Distribution Channel Tracking
 
 StackShare:
 
@@ -213,8 +213,8 @@ Awesome Codex CLI:
 
 - Status: replacement PR opened on 2026-05-18.
 - Why: highly relevant curated list with an existing `Account & Auth` section.
-- Branch: `Ducksss:pinzheng/add-codex-profiles-roggeohta`.
-- Commit: `8510a07` adds `Ducksss/codex-profiles`.
+- Submission source: branch `Ducksss:pinzheng/add-codex-profiles-roggeohta`,
+  commit `8510a07` adds `Ducksss/codex-profiles`.
 - PR target: <https://github.com/RoggeOhta/awesome-codex-cli>
 - PR: <https://github.com/RoggeOhta/awesome-codex-cli/pull/40>
 - Note: original PR <https://github.com/RoggeOhta/awesome-codex-cli/pull/33>
@@ -226,7 +226,7 @@ Awesome Codex CLI by milisp:
 - Status: merged on 2026-05-18.
 - Why: second Codex-specific curated list with an existing `Development Tools`
   section that already includes config/account switching tools.
-- Resume path: temporary clone at `/tmp/milisp-awesome-codex-cli`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `cd7b62d` adds `codex-profiles`.
 - PR target: <https://github.com/milisp/awesome-codex-cli>
 - PR: <https://github.com/milisp/awesome-codex-cli/pull/30>
@@ -252,7 +252,7 @@ Awesome DevTools:
 - Status: PR opened on 2026-05-18.
 - Why: developer-tool list with `AI Coding Tools` and `CLIs & Terminal Tools`
   sections; no visible age/star gate.
-- Resume path: temporary clone at `/tmp/awesome-devtools`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `c688e2a` adds `codex-profiles`.
 - PR target: <https://github.com/devtoolsd/awesome-devtools>
 - PR: <https://github.com/devtoolsd/awesome-devtools/pull/230>
@@ -262,7 +262,7 @@ Awesome AI-Driven Development:
 - Status: PR opened on 2026-05-18.
 - Why: active AI-development list with existing Codex, Codex Desktop, and
   Codex-adjacent CLI tools in `Terminal & CLI Agents`.
-- Resume path: temporary clone at `/tmp/awesome-AI-driven-development`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `19ed072` adds `codex-profiles`.
 - PR target: <https://github.com/eltociear/awesome-AI-driven-development>
 - PR: <https://github.com/eltociear/awesome-AI-driven-development/pull/52>
@@ -275,7 +275,7 @@ Awesome Vibe Coding by no-fluff:
 - Caveat: contribution notes ask users to open an issue first. Use the local
   candidate as source material, or open a PR if the maintainer accepts direct
   additions.
-- Resume path: temporary clone at `/tmp/awesome-vibe-coding`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `8c138eb` adds `codex-profiles`.
 - Issue target: <https://github.com/no-fluff/awesome-vibe-coding>
 - Issue: <https://github.com/no-fluff/awesome-vibe-coding/issues/115>
@@ -288,7 +288,7 @@ Awesome AI Coding Tools:
 - Caveat: contribution rules prefer tools that are AI-powered or AI-enhanced.
   This is a borderline but defensible entry because `codex-profiles` is a
   Codex workflow helper rather than a standalone AI model/tool.
-- Resume path: temporary clone at `/tmp/awesome-ai-coding-tools`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `e7634ee` adds `codex-profiles`.
 - PR target: <https://github.com/ai-for-developers/awesome-ai-coding-tools>
 - PR: <https://github.com/ai-for-developers/awesome-ai-coding-tools/pull/330>
@@ -298,7 +298,7 @@ AI IDEs & Coding Assistants:
 - Status: merged on 2026-05-19.
 - Why: small but current manually curated AI tools directory with a
   `Developer Productivity & Workflow` section.
-- Resume path: temporary clone at `/tmp/awesome-ai-tools`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `08da146` adds `codex-profiles`.
 - Follow-up: maintainer requested tracker submission instead of the direct PR,
   then generated and merged a directory PR from issue #53.
@@ -314,7 +314,7 @@ Awesome Dev Tools by t18n:
 - Status: not eligible on 2026-05-22.
 - Why: general developer-tool list accepting useful developer utilities; lower
   priority than Codex/AI-agent-specific channels, but still relevant.
-- Resume path: temporary clone at `/tmp/t18n-awesome-dev-tools`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `e3bb632` adds `codex-profiles`.
 - Follow-up: repository is now archived, so no PR was opened.
 - PR target: <https://github.com/t18n/awesome-dev-tools>
@@ -325,7 +325,7 @@ Awesome Terminals AI:
 - Why: AI terminal workflow catalogue with a `Shell Enhancements` section;
   `codex-profiles` is a shell-level helper for Codex account/profile
   separation.
-- Resume path: temporary clone at `/tmp/awesome-terminals-ai`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `b64abeb` adds `codex-profiles`.
 - PR target: <https://github.com/BNLNPPS/awesome-terminals-ai>
 - PR: <https://github.com/BNLNPPS/awesome-terminals-ai/pull/8>
@@ -335,7 +335,7 @@ Awesome Vibe Coding by Taskade:
 - Status: PR opened on 2026-05-18.
 - Why: active vibe-coding list with `CLI & Terminal Tools` and
   `Specialized CLI Tools` tables.
-- Resume path: temporary clone at `/tmp/taskade-awesome-vibe-coding`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `2804db2` adds `codex-profiles`.
 - PR target: <https://github.com/taskade/awesome-vibe-coding>
 - PR: <https://github.com/taskade/awesome-vibe-coding/pull/22>
@@ -345,8 +345,7 @@ Awesome Vibe Coding by bluegalaxy111:
 - Status: PR opened on 2026-05-18.
 - Why: terminal-agent-focused vibe-coding handbook with Codex already listed
   in `AI Coding Agents > Terminal / CLI`.
-- Resume path: temporary clone at `/tmp/bluegalaxy-awesome-vibe-coding`,
-  branch `pinzheng/add-codex-profiles`, commit `24b3077` adds
+- Submission source: branch `pinzheng/add-codex-profiles`, commit `24b3077` adds
   `codex-profiles`.
 - PR target: <https://github.com/bluegalaxy111/awesome-vibe-coding>
 - PR: <https://github.com/bluegalaxy111/awesome-vibe-coding/pull/8>
@@ -356,7 +355,7 @@ Awesome CLI Apps in a CSV:
 - Status: PR opened on 2026-05-18.
 - Why: high-reach CLI catalogue with an explicit `data/apps.csv` PR path and
   an existing `ai` category for terminal AI tools.
-- Resume path: temporary clone at `/tmp/awesome-cli-apps-in-a-csv`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `e359888` adds `codex-profiles`.
 - Validation: parsed `data/apps.csv` with Ruby CSV.
 - PR target: <https://github.com/toolleeo/awesome-cli-apps-in-a-csv>
@@ -367,7 +366,7 @@ Awesome OpenAI Codex:
 - Status: PR opened on 2026-05-18.
 - Why: Codex-specific list with a `Tools & Integrations` section and explicit
   contribution rules for direct Codex ecosystem tools.
-- Resume path: temporary clone at `/tmp/awesome-openai-codex`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `15322cb` adds `codex-profiles`.
 - PR target: <https://github.com/vaderyang/awesome-openai-codex>
 - PR: <https://github.com/vaderyang/awesome-openai-codex/pull/2>
@@ -377,8 +376,7 @@ Awesome Codex Plugins by darknorth-123:
 - Status: PR opened on 2026-05-18.
 - Why: Codex ecosystem list that explicitly accepts plugins, MCP servers,
   workflows, integrations, and developer tools for OpenAI Codex.
-- Resume path: temporary clone at `/tmp/darknorth-awesome-codex-plugins`,
-  branch `pinzheng/add-codex-profiles`, commit `4985656` adds
+- Submission source: branch `pinzheng/add-codex-profiles`, commit `4985656` adds
   `codex-profiles` to `Developer Tools`.
 - PR target: <https://github.com/darknorth-123/Awesome-Codex-Plugins>
 - PR: <https://github.com/darknorth-123/Awesome-Codex-Plugins/pull/2>
@@ -387,8 +385,7 @@ Awesome OpenAI Codex CLI by taahro:
 
 - Status: PR opened on 2026-05-18.
 - Why: Codex CLI resource list with a `New Features & Integrations` section.
-- Resume path: temporary clone at `/tmp/taahro-awesome-openai-codex-cli`,
-  branch `pinzheng/add-codex-profiles`, commit `c919693` adds
+- Submission source: branch `pinzheng/add-codex-profiles`, commit `c919693` adds
   `codex-profiles`.
 - PR target: <https://github.com/taahro/awesome-openai-codex-cli>
 - PR: <https://github.com/taahro/awesome-openai-codex-cli/pull/3>
@@ -398,8 +395,7 @@ Awesome Agentic Coding by tranhoangpich:
 - Status: PR opened on 2026-05-18.
 - Why: open-source agentic-coding list already containing Codex and adjacent
   account/session workflow tools.
-- Resume path: temporary clone at `/tmp/awesome-agentic-coding-tranhoangpich`,
-  branch `pinzheng/add-codex-profiles`, commit `8838169` adds
+- Submission source: branch `pinzheng/add-codex-profiles`, commit `8838169` adds
   `codex-profiles`.
 - PR target: <https://github.com/tranhoangpich/awesome-agentic-coding>
 - PR: <https://github.com/tranhoangpich/awesome-agentic-coding/pull/3>
@@ -409,7 +405,7 @@ Awesome AI Coding Agent Tools:
 - Status: merged on 2026-05-20.
 - Why: AI coding-agent ecosystem catalogue; `codex-profiles` fits as focused
   Codex CLI/Desktop tooling around profile and account isolation.
-- Resume path: temporary clone at `/tmp/awesome-ai-coding-agent-tools`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `c031ecd` adds a `Codex CLI &
   Desktop Tooling` subsection.
 - Merge commit: `198d9f0322674ece7a56ee0741a0a999d8b79f5a`.
@@ -423,7 +419,7 @@ Awesome CLI Coding Agents:
 - Status: PR opened on 2026-05-18.
 - Why: terminal-native coding-agent list with an `Agent infrastructure` section
   for tools that extend or support CLI coding agents.
-- Resume path: temporary clone at `/tmp/awesome-cli-coding-agents`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `7c2b638` adds `codex-profiles`.
 - PR target: <https://github.com/bradAGI/awesome-cli-coding-agents>
 - PR: <https://github.com/bradAGI/awesome-cli-coding-agents/pull/90>
@@ -434,8 +430,7 @@ Awesome AI Dev Tools:
 - Why: broad AI developer-tools list that already includes OpenAI Codex and
   Codex CLI; `codex-profiles` is a Codex workflow utility rather than a
   generic promo entry.
-- Resume path: temporary clone at `/tmp/pierrunoyt-awesome-ai-dev-tools`,
-  branch `pinzheng/add-codex-profiles`, commit `135b228` adds
+- Submission source: branch `pinzheng/add-codex-profiles`, commit `135b228` adds
   `codex-profiles`.
 - PR target: <https://github.com/PierrunoYT/awesome-ai-dev-tools>
 - PR: <https://github.com/PierrunoYT/awesome-ai-dev-tools/pull/26>
@@ -446,8 +441,7 @@ Awesome AI Coding Assistants Playbook:
 - Why: assistant configuration/resource playbook; `codex-profiles` manages
   Codex CLI/Desktop configuration boundaries through isolated `CODEX_HOME`
   profiles.
-- Resume path: temporary clone at
-  `/tmp/codandotv-awesome-ai-coding-assistants-playbook`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `d3ab9f3` adds English and Portuguese
   entries.
 - Validation: ran `git diff --check`; default `markdownlint-cli` reports
@@ -460,7 +454,7 @@ Awesome AI Coding by dalisoft:
 - Status: merged on 2026-05-20.
 - Why: AI coding catalogue that already lists Codex; `codex-profiles` fits the
   `Resources` section as a companion utility, not the AI-agent CLI table.
-- Resume path: temporary clone at `/tmp/dalisoft-awesome-ai-coding`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `4b194bd` adds `codex-profiles`.
 - Follow-up: maintainer closed the original PR but said the tool would be
   added when a new category landed; it was then included in maintainer PR #65.
@@ -475,7 +469,7 @@ Awesome AI Coding by wsxiaoys:
 - Status: PR opened on 2026-05-18.
 - Why: high-reach AI-coding list whose `Projects` section includes open-source
   AI coding CLIs, editor tools, and workflow utilities.
-- Resume path: temporary clone at `/tmp/wsxiaoys-awesome-ai-coding`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `8a781d3` adds `codex-profiles`.
 - PR target: <https://github.com/wsxiaoys/awesome-ai-coding>
 - PR: <https://github.com/wsxiaoys/awesome-ai-coding/pull/103>
@@ -519,7 +513,7 @@ Awesome Harness Engineering:
 - Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
   `Ducksss/codex-profiles`, `CODEX_HOME`, and Codex profile terms; no prior
   submission found.
-- Resume path: temporary clone at `/tmp/awesome-harness-engineering`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles-harness`, commit `a1fb549` adds
   `codex-profiles` to `Runtimes, Harnesses & Reference Implementations`.
 - Validation: ran `git diff --check`.
@@ -537,8 +531,7 @@ Awesome Vibe Coding by ai-for-developers:
 - Note: README links a contribution guide, but `CONTRIBUTING.md` is absent/404;
   followed the existing simple bullet format and placed the entry at the end of
   the relevant category.
-- Resume path: temporary clone at `/tmp/ai-for-dev-awesome-vibe-coding-pr`,
-  branch `pinzheng/add-codex-profiles-ai-for-dev-vibe`, commit `19c0153`
+- Submission source: branch `pinzheng/add-codex-profiles-ai-for-dev-vibe`, commit `19c0153`
   adds `codex-profiles`.
 - Validation: ran `git diff --check`.
 - PR target: <https://github.com/ai-for-developers/awesome-vibe-coding>
@@ -552,7 +545,7 @@ Awesome Vibe Coding by filipecalegario:
 - Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
   `Ducksss/codex-profiles`, `CODEX_HOME`, and Codex profile terms; no prior
   submission found.
-- Resume path: temporary clone at `/tmp/filipe-awesome-vibe-coding`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles-filipe-vibe`, commit `62ad2bb` adds
   `codex-profiles` at the bottom of `Command Line Tools` per
   `contributing.md`.
@@ -569,7 +562,7 @@ Awesome AI DevTools by jamesmurdza:
 - Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
   `Ducksss/codex-profiles`, `CODEX_HOME`, and Codex profile terms; no prior
   submission found. An unrelated PR surfaced on broad terms only.
-- Resume path: temporary clone at `/tmp/awesome-ai-devtools`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles-ai-devtools`, commit `00832a2` adds
   `codex-profiles`.
 - Validation: ran `git diff --check`.
@@ -697,8 +690,7 @@ Awesome Vibe Coding Tools by jiji262:
   concise description, appropriate category, and AI coding/development
   relevance.
 - Section: `CLI Workflow Systems & Agent Enhancers`.
-- Resume path: temporary clone at `/tmp/jiji-awesome-vibe-coding-tools`,
-  branch `pinzheng/add-codex-profiles`, commit `e1e637d` adds
+- Submission source: branch `pinzheng/add-codex-profiles`, commit `e1e637d` adds
   `codex-profiles`.
 - Validation: reviewed repository metadata, README sections, contribution
   notes, and duplicate history with GitHub CLI; ran `git diff --check`.
@@ -721,7 +713,7 @@ Awesome Vibe Coding by 0xWelt:
 - Contribution notes: no separate contribution guide found during this pass;
   direct PR rules are not explicit from the inspected README.
 - Section: `CLI Tools` near `OpenAI Codex`.
-- Resume path: temporary clone at `/tmp/0xwelt-awesome-vibe-coding`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `55fb7c0` adds `codex-profiles`.
 - Validation: reviewed repository metadata, README structure, and duplicate
   history with GitHub CLI; ran `git diff --check`. `npx --yes
@@ -743,8 +735,7 @@ Awesome Vibe Coding Resources by acvnace:
 - Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
   `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
 - Section: `Command Line Tools`.
-- Resume path: temporary clone at
-  `/tmp/acvnace-awesome-vibe-coding-resources`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `d332134` adds `codex-profiles`.
 - Validation: reviewed repository metadata, README sections, and duplicate
   history with GitHub CLI; ran `git diff --check`. `npx --yes
@@ -765,7 +756,7 @@ Awesome OpenAI Codex by KarelDO:
 - Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
   `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
 - Section: `Products & tools`.
-- Resume path: temporary clone at `/tmp/kareldo-awesome-codex`, branch
+- Submission source: branch
   `pinzheng/add-codex-profiles`, commit `781f881` adds `codex-profiles`.
 - Validation: reviewed repository metadata, README scope, and duplicate history
   with GitHub CLI; ran `git diff --check`. `npx --yes markdownlint-cli
@@ -826,8 +817,7 @@ Awesome Vibe Coding Tools by furudo-erika:
   local state across contexts.
 - Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
   `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
-- Resume path: temporary clone at `/tmp/furudo-awesome-vibe-coding-tools`,
-  branch `pinzheng/add-codex-profiles`, commit `366d1f4` adds
+- Submission source: branch `pinzheng/add-codex-profiles`, commit `366d1f4` adds
   `codex-profiles`.
 - Validation: reviewed repository metadata, README scope, contribution notes,
   and duplicate history with GitHub CLI; ran `git diff --check`. `npx --yes

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -28,6 +28,7 @@ Avoid positioning it as:
 ## Launch Readiness
 
 - GitHub releases are published for tagged versions.
+- The npm registry package is published as `codex-profile`.
 - GitHub Discussions are enabled for questions and workflow feedback.
 - Public feedback thread:
   <https://github.com/Ducksss/codex-profiles/discussions/1>
@@ -38,7 +39,7 @@ Avoid positioning it as:
 - Install paths:
 
 ```sh
-npm install -g github:Ducksss/codex-profiles
+npm install -g codex-profile
 ```
 
 ```sh
@@ -51,6 +52,10 @@ cd codex-profiles
 make install
 ```
 
+The npm package is singular: `codex-profile`. It installs both
+`codex-profile` and `codex-profiles` commands. Do not point users at the
+plural npm package name because that package belongs to another project.
+
 Quick verification:
 
 ```sh
@@ -58,10 +63,9 @@ codex-profile doctor
 codex-profile path personal
 ```
 
-Npm registry launch:
+Npm registry verification:
 
 ```sh
-npm publish --access public
 npm install -g codex-profile
 codex-profile doctor
 ```
@@ -83,7 +87,7 @@ CODEX_HOME, so this small Bash wrapper gives each profile its own auth, config,
 sessions, plugins, logs, and local state.
 
 Install:
-npm install -g github:Ducksss/codex-profiles
+npm install -g codex-profile
 brew install Ducksss/tap/codex-profile
 
 Examples:
@@ -104,7 +108,7 @@ codex-profiles.
 Instead of copying auth.json around, it launches Codex CLI or Codex Desktop with
 a named CODEX_HOME:
 
-npm install -g github:Ducksss/codex-profiles
+npm install -g codex-profile
 brew install Ducksss/tap/codex-profile
 codex-profile login work
 codex-profile cli work exec "review this repo"
@@ -130,7 +134,7 @@ accounts with isolated CODEX_HOME directories.
 No token copying. Separate auth, config, sessions, plugins, logs, and local
 Codex state.
 
-npm install -g github:Ducksss/codex-profiles
+npm install -g codex-profile
 brew install Ducksss/tap/codex-profile
 https://github.com/Ducksss/codex-profiles
 ```
@@ -156,12 +160,12 @@ right environment.
 ## Launch Order
 
 1. Share in OpenAI/Codex developer spaces and collect practical feedback.
-2. Post `Show HN` after confirming the Homebrew install works from the public
-   tap.
+2. Post `Show HN` after confirming the npm registry install and Homebrew tap
+   install both work.
 3. Publish the DEV/Hashnode technical write-up and link back to the HN thread
    only as context, not as vote solicitation.
 4. Repost the short demo clip on X, Bluesky, Mastodon, and LinkedIn with the
-   Homebrew command and GitHub link.
+   npm or Homebrew command and GitHub link.
 5. Submit to relevant curated lists or tool directories only where the tool
    clearly fits.
 6. Launch on Product Hunt after screenshots, demo video, README, and install

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -249,7 +249,7 @@ Awesome AI-Driven Development:
 
 Awesome Vibe Coding by no-fluff:
 
-- Status: PR candidate prepared locally on 2026-05-18.
+- Status: issue opened on 2026-05-22.
 - Why: targeted list for agentic/vibe-coding workflows with an `Other tools`
   section for companion utilities around coding agents.
 - Caveat: contribution notes ask users to open an issue first. Use the local
@@ -257,7 +257,8 @@ Awesome Vibe Coding by no-fluff:
   additions.
 - Resume path: temporary clone at `/tmp/awesome-vibe-coding`, branch
   `pinzheng/add-codex-profiles`, commit `8c138eb` adds `codex-profiles`.
-- PR or issue target: <https://github.com/no-fluff/awesome-vibe-coding>
+- Issue target: <https://github.com/no-fluff/awesome-vibe-coding>
+- Issue: <https://github.com/no-fluff/awesome-vibe-coding/issues/115>
 
 Awesome AI Coding Tools:
 
@@ -290,11 +291,12 @@ AI IDEs & Coding Assistants:
 
 Awesome Dev Tools by t18n:
 
-- Status: PR candidate prepared locally on 2026-05-18.
+- Status: not eligible on 2026-05-22.
 - Why: general developer-tool list accepting useful developer utilities; lower
   priority than Codex/AI-agent-specific channels, but still relevant.
 - Resume path: temporary clone at `/tmp/t18n-awesome-dev-tools`, branch
   `pinzheng/add-codex-profiles`, commit `e3bb632` adds `codex-profiles`.
+- Follow-up: repository is now archived, so no PR was opened.
 - PR target: <https://github.com/t18n/awesome-dev-tools>
 
 Awesome Terminals AI:
@@ -689,7 +691,7 @@ Awesome Vibe Coding Tools by jiji262:
 
 Awesome Vibe Coding by 0xWelt:
 
-- Status: deferred on 2026-05-21.
+- Status: PR opened on 2026-05-22.
 - Why: active curated vibe-coding list with a detailed `CLI Tools` area that
   already includes OpenAI Codex and a later `Supporting Tools` section.
   `codex-profiles` could fit as a companion utility near Codex CLI or as
@@ -698,18 +700,21 @@ Awesome Vibe Coding by 0xWelt:
   `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
 - Contribution notes: no separate contribution guide found during this pass;
   direct PR rules are not explicit from the inspected README.
-- Suggested section: likely `CLI Tools` near `OpenAI Codex`; if maintainers
-  prefer stricter agent-only entries, open an issue first or place under
-  `Supporting Tools`.
+- Section: `CLI Tools` near `OpenAI Codex`.
+- Resume path: temporary clone at `/tmp/0xwelt-awesome-vibe-coding`, branch
+  `pinzheng/add-codex-profiles`, commit `55fb7c0` adds `codex-profiles`.
 - Validation: reviewed repository metadata, README structure, and duplicate
-  history with GitHub CLI.
-- Deferred path: revisit after higher-priority open PRs settle; prefer an
-  issue first if contribution expectations remain ambiguous.
+  history with GitHub CLI; ran `git diff --check`. `npx --yes
+  markdownlint-cli README.md` reports pre-existing repository-wide README style
+  issues, recorded as non-blocking. PR checks: no checks reported; GitHub merge
+  state was `UNSTABLE` immediately after opening.
+- PR target: <https://github.com/0xWelt/Awesome-Vibe-Coding>
+- PR: <https://github.com/0xWelt/Awesome-Vibe-Coding/pull/176>
 - Reference: <https://github.com/0xWelt/Awesome-Vibe-Coding>
 
 Awesome Vibe Coding Resources by acvnace:
 
-- Status: deferred on 2026-05-21.
+- Status: PR opened on 2026-05-22.
 - Why: active resource list with `Command Line Tools` entries for Codex-adjacent
   utilities such as Agent FM, MUSE, SwarmClaw, SwarmVault, and agenttrace.
   `codex-profiles` may fit as a command-line workflow utility for Codex users,
@@ -717,16 +722,21 @@ Awesome Vibe Coding Resources by acvnace:
   README.
 - Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
   `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
-- Suggested section: `Command Line Tools`.
+- Section: `Command Line Tools`.
+- Resume path: temporary clone at
+  `/tmp/acvnace-awesome-vibe-coding-resources`, branch
+  `pinzheng/add-codex-profiles`, commit `d332134` adds `codex-profiles`.
 - Validation: reviewed repository metadata, README sections, and duplicate
-  history with GitHub CLI.
-- Deferred path: revisit after stronger Codex/CLI targets respond; prefer an
-  issue first if direct PR expectations remain unclear.
+  history with GitHub CLI; ran `git diff --check`. `npx --yes
+  markdownlint-cli README.md` reports pre-existing repository-wide README style
+  issues, recorded as non-blocking. PR checks: no checks reported.
+- PR target: <https://github.com/acvnace/awesome-vibe-coding-resources>
+- PR: <https://github.com/acvnace/awesome-vibe-coding-resources/pull/20>
 - Reference: <https://github.com/acvnace/awesome-vibe-coding-resources>
 
 Awesome OpenAI Codex by KarelDO:
 
-- Status: deferred on 2026-05-21.
+- Status: PR opened on 2026-05-22.
 - Why: Codex-specific product/demo/tool list with a `Products & tools` section
   and README text inviting PRs for relevant links. However, the repository
   appears stale, with the latest push observed from 2023, and its positioning
@@ -734,11 +744,15 @@ Awesome OpenAI Codex by KarelDO:
   workflows.
 - Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
   `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
-- Suggested section: `Products & tools`.
+- Section: `Products & tools`.
+- Resume path: temporary clone at `/tmp/kareldo-awesome-codex`, branch
+  `pinzheng/add-codex-profiles`, commit `781f881` adds `codex-profiles`.
 - Validation: reviewed repository metadata, README scope, and duplicate history
-  with GitHub CLI.
-- Deferred path: low-priority fallback only; revisit if maintainer activity
-  resumes or after the current open PR queue drops materially.
+  with GitHub CLI; ran `git diff --check`. `npx --yes markdownlint-cli
+  README.md` reports pre-existing repository-wide README style issues, recorded
+  as non-blocking. PR checks: no checks reported.
+- PR target: <https://github.com/KarelDO/awesome-codex>
+- PR: <https://github.com/KarelDO/awesome-codex/pull/15>
 - Reference: <https://github.com/KarelDO/awesome-codex>
 
 Awesome Codex Automations:
@@ -783,6 +797,74 @@ Awesome Vibe Coding CLI by vanna-ai:
   duplicate history with GitHub CLI.
 - Reference: <https://github.com/vanna-ai/Awesome-Vibe-Coding-CLI>
 
+Awesome Vibe Coding Tools by furudo-erika:
+
+- Status: PR opened on 2026-05-22.
+- Why: vibe-coding tools list with a `Terminal & Command Line` section and
+  contribution guidance for direct PRs. `codex-profiles` fits as a
+  command-line Codex workflow helper for users separating Codex account and
+  local state across contexts.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Resume path: temporary clone at `/tmp/furudo-awesome-vibe-coding-tools`,
+  branch `pinzheng/add-codex-profiles`, commit `366d1f4` adds
+  `codex-profiles`.
+- Validation: reviewed repository metadata, README scope, contribution notes,
+  and duplicate history with GitHub CLI; ran `git diff --check`. `npx --yes
+  markdownlint-cli README.md` reports pre-existing repository-wide README style
+  issues, recorded as non-blocking.
+- PR target: <https://github.com/furudo-erika/awesome-vibe-coding-tools>
+- PR: <https://github.com/furudo-erika/awesome-vibe-coding-tools/pull/4>
+
+Awesome Vibe Coding by techiediaries:
+
+- Status: not a fit on 2026-05-22.
+- Why: list focuses on AI coding assistants, AI IDEs, prompt-driven code
+  generation tools, and UI generation products. `codex-profiles` is a Codex
+  state/profile utility rather than an AI coding assistant or generator.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Validation: reviewed repository metadata, README scope, and duplicate history
+  with GitHub CLI.
+- Reference: <https://github.com/techiediaries/awesome-vibe-coding>
+
+Awesome AI Coding Agents by brandonhimpfen:
+
+- Status: not a fit on 2026-05-22.
+- Why: contribution guidance emphasizes long-term relevance and strict taxonomy
+  fit for AI coding agents, platforms, and agent infrastructure.
+  `codex-profiles` is useful Codex workflow tooling but not itself an agent,
+  agent framework, benchmark, or infrastructure platform in that taxonomy.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Validation: reviewed repository metadata, README sections, contribution
+  guide, and duplicate history with GitHub CLI.
+- Reference: <https://github.com/brandonhimpfen/awesome-ai-coding-agents>
+
+Awesome AI Coding Agents by vinkius-labs:
+
+- Status: not a fit on 2026-05-22.
+- Why: table-based catalogue is for IDE-based, terminal-based, autonomous,
+  multi-agent, code-review, and specialized AI coding agents. `codex-profiles`
+  supports Codex account/profile switching but is not a coding agent.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Validation: reviewed repository metadata, README sections, and duplicate
+  history with GitHub CLI.
+- Reference: <https://github.com/vinkius-labs/awesome-ai-coding-agents>
+
+Awesome AI Coding Agents by BrethofAI:
+
+- Status: not a fit on 2026-05-22.
+- Why: repository is an opinionated comparison/review page for coding
+  assistants. `codex-profiles` is not a coding assistant and would not fit the
+  review table or tool-profile format.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Validation: reviewed repository metadata, README sections, and duplicate
+  history with GitHub CLI.
+- Reference: <https://github.com/BrethofAI/awesome-ai-coding-agents>
+
 ## Monthly Reconciliation
 
 2026-05-21 automation pass:
@@ -794,6 +876,14 @@ Awesome Vibe Coding CLI by vanna-ai:
 - Outreach addendum: after user requested outreach, opened one high-signal PR
   to <https://github.com/jiji262/awesome-vibe-coding-tools/pull/22>; no other
   new submissions were opened because the open-PR gate remains above 15.
+- Mass outreach addendum on 2026-05-22: after explicit user request to do mass
+  outreach, opened four additional PRs and one issue:
+  <https://github.com/0xWelt/Awesome-Vibe-Coding/pull/176>,
+  <https://github.com/acvnace/awesome-vibe-coding-resources/pull/20>,
+  <https://github.com/KarelDO/awesome-codex/pull/15>,
+  <https://github.com/furudo-erika/awesome-vibe-coding-tools/pull/4>, and
+  <https://github.com/no-fluff/awesome-vibe-coding/issues/115>. Also logged
+  five skipped or ineligible targets from the discovery sweep.
 - Branch checked: `pinzheng/update-launch-pr-log`.
 - Outreach limit: 20 recorded distribution PRs are still open, exceeding the
   monthly gate of 15 open submitted PRs; this pass used the allowed single new

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -274,13 +274,19 @@ Awesome AI Coding Tools:
 
 AI IDEs & Coding Assistants:
 
-- Status: PR opened on 2026-05-18.
+- Status: merged on 2026-05-19.
 - Why: small but current manually curated AI tools directory with a
   `Developer Productivity & Workflow` section.
 - Resume path: temporary clone at `/tmp/awesome-ai-tools`, branch
   `pinzheng/add-codex-profiles`, commit `08da146` adds `codex-profiles`.
+- Follow-up: maintainer requested tracker submission instead of the direct PR,
+  then generated and merged a directory PR from issue #53.
+- Issue: <https://github.com/QAInsights/awesome-ai-tools/issues/53>
+- Maintainer PR: <https://github.com/QAInsights/awesome-ai-tools/pull/54>
+- Merge commit: `32bc2b44e370a718134fd1d7a3910bcd9cd9cbb1`.
+- Validation: verified the upstream README lists `codex-profiles`.
 - PR target: <https://github.com/QAInsights/awesome-ai-tools>
-- PR: <https://github.com/QAInsights/awesome-ai-tools/pull/50>
+- Original PR: <https://github.com/QAInsights/awesome-ai-tools/pull/50>
 
 Awesome Dev Tools by t18n:
 
@@ -378,13 +384,15 @@ Awesome Agentic Coding by tranhoangpich:
 
 Awesome AI Coding Agent Tools:
 
-- Status: PR opened on 2026-05-18.
+- Status: merged on 2026-05-20.
 - Why: AI coding-agent ecosystem catalogue; `codex-profiles` fits as focused
   Codex CLI/Desktop tooling around profile and account isolation.
 - Resume path: temporary clone at `/tmp/awesome-ai-coding-agent-tools`, branch
   `pinzheng/add-codex-profiles`, commit `c031ecd` adds a `Codex CLI &
   Desktop Tooling` subsection.
-- Validation: ran `npx --yes markdownlint-cli README.md`.
+- Merge commit: `198d9f0322674ece7a56ee0741a0a999d8b79f5a`.
+- Validation: ran `npx --yes markdownlint-cli README.md`; later verified the
+  PR merged through GitHub CLI.
 - PR target: <https://github.com/namphuongtran/awesome-ai-coding-agent-tools>
 - PR: <https://github.com/namphuongtran/awesome-ai-coding-agent-tools/pull/4>
 
@@ -427,13 +435,18 @@ Awesome AI Coding Assistants Playbook:
 
 Awesome AI Coding by dalisoft:
 
-- Status: PR opened on 2026-05-18.
+- Status: merged on 2026-05-20.
 - Why: AI coding catalogue that already lists Codex; `codex-profiles` fits the
   `Resources` section as a companion utility, not the AI-agent CLI table.
 - Resume path: temporary clone at `/tmp/dalisoft-awesome-ai-coding`, branch
   `pinzheng/add-codex-profiles`, commit `4b194bd` adds `codex-profiles`.
+- Follow-up: maintainer closed the original PR but said the tool would be
+  added when a new category landed; it was then included in maintainer PR #65.
+- Maintainer PR: <https://github.com/dalisoft/awesome-ai-coding/pull/65>
+- Merge commit: `672e7123baf3cb0a84fed612f7f63e0310199e1f`.
+- Validation: verified the upstream README lists `codex-profiles`.
 - PR target: <https://github.com/dalisoft/awesome-ai-coding>
-- PR: <https://github.com/dalisoft/awesome-ai-coding/pull/64>
+- Original PR: <https://github.com/dalisoft/awesome-ai-coding/pull/64>
 
 Awesome AI Coding by wsxiaoys:
 
@@ -543,7 +556,7 @@ Awesome AI DevTools by jamesmurdza:
 
 Awesome Codex Workflows by shinpr:
 
-- Status: recommendation issue opened on 2026-05-18.
+- Status: closed on 2026-05-19.
 - Why: Codex-first workflow and orchestration list where contribution guidance
   prefers an issue before a PR for new repository suggestions. Fit is relevant
   but borderline because `codex-profiles` is workflow infrastructure rather
@@ -552,6 +565,11 @@ Awesome Codex Workflows by shinpr:
   `Ducksss/codex-profiles`, `codex profiles`, and `CODEX_HOME`; no prior
   submission found.
 - Suggested category: `Workflow Infrastructure & Design`.
+- Follow-up: maintainer passed because the list focuses on orchestration,
+  planning, review, handoff, runtime containment, and adjacent workflow
+  machinery; `codex-profiles` sits one layer below that as a focused profile
+  isolation utility. Acknowledged the scope boundary and left no replacement
+  action unless the list later adds lower-level Codex environment utilities.
 - Issue target: <https://github.com/shinpr/awesome-codex-workflows>
 - Issue: <https://github.com/shinpr/awesome-codex-workflows/issues/13>
 
@@ -644,6 +662,53 @@ Awesome Gemini CLI:
 - Reference: <https://github.com/Piebald-AI/awesome-gemini-cli>
 
 ## Monthly Reconciliation
+
+2026-05-21 automation pass:
+
+- Status: reconciliation-only pass; no new PRs, issues, listing requests, or
+  maintainer requests were opened.
+- Branch checked: `pinzheng/update-launch-pr-log`.
+- Why no new outreach: 20 recorded distribution PRs are still open, exceeding
+  the monthly gate of 15 open submitted PRs.
+- Validation: ran `git fetch --all --prune`; checked every recorded GitHub PR
+  and issue URL with GitHub CLI; inspected maintainer comments on closed
+  submissions; verified accepted entries in upstream READMEs where PRs were
+  closed but maintainer-side listings landed; ran `git diff --check`.
+- Open PRs confirmed:
+  <https://github.com/BNLNPPS/awesome-terminals-ai/pull/8>,
+  <https://github.com/CodandoTV/awesome-ai-coding-assistants-playbook/pull/8>,
+  <https://github.com/PierrunoYT/awesome-ai-dev-tools/pull/26>,
+  <https://github.com/RoggeOhta/awesome-codex-cli/pull/40>,
+  <https://github.com/ai-for-developers/awesome-ai-coding-tools/pull/330>,
+  <https://github.com/ai-for-developers/awesome-vibe-coding/pull/64>,
+  <https://github.com/bluegalaxy111/awesome-vibe-coding/pull/8>,
+  <https://github.com/bradAGI/awesome-cli-coding-agents/pull/90>,
+  <https://github.com/darknorth-123/Awesome-Codex-Plugins/pull/2>,
+  <https://github.com/devtoolsd/awesome-devtools/pull/230>,
+  <https://github.com/eltociear/awesome-AI-driven-development/pull/52>,
+  <https://github.com/filipecalegario/awesome-vibe-coding/pull/187>,
+  <https://github.com/jamesmurdza/awesome-ai-devtools/pull/554>,
+  <https://github.com/taahro/awesome-openai-codex-cli/pull/3>,
+  <https://github.com/taskade/awesome-vibe-coding/pull/22>,
+  <https://github.com/toolleeo/awesome-cli-apps-in-a-csv/pull/267>,
+  <https://github.com/tranhoangpich/awesome-agentic-coding/pull/3>,
+  <https://github.com/vaderyang/awesome-openai-codex/pull/2>,
+  <https://github.com/walkinglabs/awesome-harness-engineering/pull/28>,
+  and <https://github.com/wsxiaoys/awesome-ai-coding/pull/103>.
+- Newly accepted or merged since the prior ledger update:
+  <https://github.com/QAInsights/awesome-ai-tools/pull/54>,
+  <https://github.com/namphuongtran/awesome-ai-coding-agent-tools/pull/4>,
+  and <https://github.com/dalisoft/awesome-ai-coding/pull/65>.
+- Closed or superseded submissions reconciled:
+  <https://github.com/QAInsights/awesome-ai-tools/pull/50> was closed after
+  the maintainer requested issue-tracker submission;
+  <https://github.com/dalisoft/awesome-ai-coding/pull/64> was closed after the
+  maintainer added the tool through PR #65; and
+  <https://github.com/shinpr/awesome-codex-workflows/issues/13> was closed as
+  out of current list scope.
+- Deferred channels retained without action: StackShare, OpenAlternative,
+  LibHunt, SaaSHub, Awesome Shell, Antigravity Awesome Skills, Kyrolabs
+  Awesome Agents, and Awesome LLM Skills by Prat011.
 
 2026-05-18 automation pass:
 

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -643,6 +643,54 @@ Awesome Gemini CLI:
   and `Ducksss/codex-profiles`; no prior submission found.
 - Reference: <https://github.com/Piebald-AI/awesome-gemini-cli>
 
+## Monthly Reconciliation
+
+2026-05-18 automation pass:
+
+- Status: reconciliation-only pass; no new PRs, issues, listing requests, or
+  maintainer requests were opened.
+- Branch checked: `pinzheng/update-launch-pr-log`.
+- Why no new outreach: 23 recorded distribution PRs are still open, exceeding
+  the monthly gate of 15 open submitted PRs.
+- Validation: ran `git fetch --all --prune`; checked every recorded GitHub PR
+  and issue URL with GitHub CLI; ran `git diff --check`.
+- Open PRs confirmed:
+  <https://github.com/BNLNPPS/awesome-terminals-ai/pull/8>,
+  <https://github.com/CodandoTV/awesome-ai-coding-assistants-playbook/pull/8>,
+  <https://github.com/PierrunoYT/awesome-ai-dev-tools/pull/26>,
+  <https://github.com/QAInsights/awesome-ai-tools/pull/50>,
+  <https://github.com/RoggeOhta/awesome-codex-cli/pull/40>,
+  <https://github.com/ai-for-developers/awesome-ai-coding-tools/pull/330>,
+  <https://github.com/ai-for-developers/awesome-vibe-coding/pull/64>,
+  <https://github.com/bluegalaxy111/awesome-vibe-coding/pull/8>,
+  <https://github.com/bradAGI/awesome-cli-coding-agents/pull/90>,
+  <https://github.com/dalisoft/awesome-ai-coding/pull/64>,
+  <https://github.com/darknorth-123/Awesome-Codex-Plugins/pull/2>,
+  <https://github.com/devtoolsd/awesome-devtools/pull/230>,
+  <https://github.com/eltociear/awesome-AI-driven-development/pull/52>,
+  <https://github.com/filipecalegario/awesome-vibe-coding/pull/187>,
+  <https://github.com/jamesmurdza/awesome-ai-devtools/pull/554>,
+  <https://github.com/namphuongtran/awesome-ai-coding-agent-tools/pull/4>,
+  <https://github.com/taahro/awesome-openai-codex-cli/pull/3>,
+  <https://github.com/taskade/awesome-vibe-coding/pull/22>,
+  <https://github.com/toolleeo/awesome-cli-apps-in-a-csv/pull/267>,
+  <https://github.com/tranhoangpich/awesome-agentic-coding/pull/3>,
+  <https://github.com/vaderyang/awesome-openai-codex/pull/2>,
+  <https://github.com/walkinglabs/awesome-harness-engineering/pull/28>,
+  and <https://github.com/wsxiaoys/awesome-ai-coding/pull/103>.
+- Open issue confirmed:
+  <https://github.com/shinpr/awesome-codex-workflows/issues/13>.
+- Merged PR confirmed:
+  <https://github.com/milisp/awesome-codex-cli/pull/30>.
+- Closed superseded PR confirmed:
+  <https://github.com/RoggeOhta/awesome-codex-cli/pull/33>.
+- Follow-up note: <https://github.com/QAInsights/awesome-ai-tools/pull/50>
+  has a Vercel deployment authorization bot comment only; no maintainer action
+  or reply is needed from `codex-profiles`.
+- Deferred channels retained without action: StackShare, OpenAlternative,
+  LibHunt, SaaSHub, Awesome Shell, Antigravity Awesome Skills, Kyrolabs
+  Awesome Agents, and Awesome LLM Skills by Prat011.
+
 ## Metrics
 
 Track these for each channel:

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -475,6 +475,174 @@ Terminals Are Sexy:
   audience than Codex and AI-agent lists.
 - Reference: <https://github.com/k4m4/terminals-are-sexy>
 
+Awesome Harness Engineering:
+
+- Status: PR opened on 2026-05-18.
+- Why: harness-engineering list focused on context, environment control,
+  state, resumability, and reliable agent operation. `codex-profiles` fits as
+  Codex-specific profile/state isolation for repeatable CLI and Desktop runs.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, `CODEX_HOME`, and Codex profile terms; no prior
+  submission found.
+- Resume path: temporary clone at `/tmp/awesome-harness-engineering`, branch
+  `pinzheng/add-codex-profiles-harness`, commit `a1fb549` adds
+  `codex-profiles` to `Runtimes, Harnesses & Reference Implementations`.
+- Validation: ran `git diff --check`.
+- PR target: <https://github.com/walkinglabs/awesome-harness-engineering>
+- PR: <https://github.com/walkinglabs/awesome-harness-engineering/pull/28>
+
+Awesome Vibe Coding by ai-for-developers:
+
+- Status: PR opened on 2026-05-18.
+- Why: active vibe-coding tool list with a `CLI Tools` section already listing
+  OpenAI Codex CLI and terminal coding-agent companions.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, `CODEX_HOME`, and Codex profile terms; no prior
+  submission found.
+- Note: README links a contribution guide, but `CONTRIBUTING.md` is absent/404;
+  followed the existing simple bullet format and placed the entry at the end of
+  the relevant category.
+- Resume path: temporary clone at `/tmp/ai-for-dev-awesome-vibe-coding-pr`,
+  branch `pinzheng/add-codex-profiles-ai-for-dev-vibe`, commit `19c0153`
+  adds `codex-profiles`.
+- Validation: ran `git diff --check`.
+- PR target: <https://github.com/ai-for-developers/awesome-vibe-coding>
+- PR: <https://github.com/ai-for-developers/awesome-vibe-coding/pull/64>
+
+Awesome Vibe Coding by filipecalegario:
+
+- Status: PR opened on 2026-05-18.
+- Why: high-reach vibe-coding list with a `Command Line Tools` section that
+  already includes OpenAI Codex CLI and adjacent terminal coding agents.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, `CODEX_HOME`, and Codex profile terms; no prior
+  submission found.
+- Resume path: temporary clone at `/tmp/filipe-awesome-vibe-coding`, branch
+  `pinzheng/add-codex-profiles-filipe-vibe`, commit `62ad2bb` adds
+  `codex-profiles` at the bottom of `Command Line Tools` per
+  `contributing.md`.
+- Validation: ran `git diff --check`.
+- PR target: <https://github.com/filipecalegario/awesome-vibe-coding>
+- PR: <https://github.com/filipecalegario/awesome-vibe-coding/pull/187>
+
+Awesome AI DevTools by jamesmurdza:
+
+- Status: PR opened on 2026-05-18.
+- Why: active AI developer-tools list with an `Agent Infrastructure >
+  Configuration & Context Management` section. `codex-profiles` fits as a
+  developer-focused Codex runtime-state/profile utility.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, `CODEX_HOME`, and Codex profile terms; no prior
+  submission found. An unrelated PR surfaced on broad terms only.
+- Resume path: temporary clone at `/tmp/awesome-ai-devtools`, branch
+  `pinzheng/add-codex-profiles-ai-devtools`, commit `00832a2` adds
+  `codex-profiles`.
+- Validation: ran `git diff --check`.
+- PR target: <https://github.com/jamesmurdza/awesome-ai-devtools>
+- PR: <https://github.com/jamesmurdza/awesome-ai-devtools/pull/554>
+
+Awesome Codex Workflows by shinpr:
+
+- Status: recommendation issue opened on 2026-05-18.
+- Why: Codex-first workflow and orchestration list where contribution guidance
+  prefers an issue before a PR for new repository suggestions. Fit is relevant
+  but borderline because `codex-profiles` is workflow infrastructure rather
+  than an orchestration model.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, `codex profiles`, and `CODEX_HOME`; no prior
+  submission found.
+- Suggested category: `Workflow Infrastructure & Design`.
+- Issue target: <https://github.com/shinpr/awesome-codex-workflows>
+- Issue: <https://github.com/shinpr/awesome-codex-workflows/issues/13>
+
+ComposioHQ Awesome Codex Skills:
+
+- Status: skipped on 2026-05-18.
+- Why: large and active Codex skill catalogue, but the contribution shape is a
+  real reusable skill with `SKILL.md`. A plain `codex-profiles` product link
+  would not satisfy the list's skill-centered scope.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`
+  and `Ducksss/codex-profiles`; no real prior submission found.
+- Deferred path: revisit only if creating an actual Codex skill wrapper around
+  profile/account switching is desired.
+- Reference: <https://github.com/ComposioHQ/awesome-codex-skills>
+
+VoltAgent Awesome Codex Subagents:
+
+- Status: skipped on 2026-05-18.
+- Why: catalogue is for Codex-native subagent definitions. `codex-profiles` is
+  a CLI/profile manager, not a subagent.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`
+  and `Ducksss/codex-profiles`; no prior submission found.
+- Reference: <https://github.com/VoltAgent/awesome-codex-subagents>
+
+Antigravity Awesome Skills:
+
+- Status: deferred on 2026-05-18.
+- Why: very active cross-agent skill library, but a valid submission would need
+  a source-only skill under `skills/<name>/SKILL.md`; that is a new agent skill
+  artifact rather than a direct curated-list entry for the existing project.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`
+  and `Ducksss/codex-profiles`; no real prior submission found.
+- Deferred path: create and validate a dedicated "Codex profile switching"
+  skill only if the project owner wants codex-profiles distributed as an
+  installable agent skill.
+- Reference: <https://github.com/sickn33/antigravity-awesome-skills>
+
+Sourcegraph Awesome Code AI:
+
+- Status: skipped on 2026-05-18.
+- Why: relevant AI coding tools list, but the repository is archived and the
+  README explicitly says submissions are closed.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, `CODEX_HOME`, and Codex profile terms; no prior
+  submission found.
+- Reference: <https://github.com/sourcegraph/awesome-code-ai>
+
+Kyrolabs Awesome Agents:
+
+- Status: deferred on 2026-05-18.
+- Why: active AI-agent list, but mostly catalogs agent frameworks and products.
+  `codex-profiles` is a narrow Codex profile manager rather than an agent, and
+  the repo's stated bar is higher for brand-new/low-traction projects.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, `CODEX_HOME`, and Codex profile terms; no prior
+  submission found.
+- Deferred path: revisit after `codex-profiles` has more traction or if the
+  list adds an explicit tooling/configuration category.
+- Reference: <https://github.com/kyrolabs/awesome-agents>
+
+E2B Awesome AI Agents:
+
+- Status: skipped on 2026-05-18.
+- Why: high-reach AI-agent list, but it is explicitly for AI assistants and
+  agents. Tool/framework additions belong in a separate E2B SDK/tool list, and
+  `codex-profiles` is not an autonomous agent.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`
+  and `Ducksss/codex-profiles`; no prior submission found. Broad Codex/profile
+  terms matched unrelated open PRs only.
+- Reference: <https://github.com/e2b-dev/awesome-ai-agents>
+
+Awesome LLM Skills by Prat011:
+
+- Status: deferred on 2026-05-18.
+- Why: skill-centric contribution process requires a documented and portable
+  skill folder plus README update. A direct product link would not fit.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`
+  and `Ducksss/codex-profiles`; no prior submission found.
+- Deferred path: revisit only if building an actual "Codex profile switching"
+  skill.
+- Reference: <https://github.com/Prat011/awesome-llm-skills>
+
+Awesome Gemini CLI:
+
+- Status: skipped on 2026-05-18.
+- Why: active Gemini CLI list, but `codex-profiles` is Codex-specific and does
+  not currently support Gemini CLI.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`
+  and `Ducksss/codex-profiles`; no prior submission found.
+- Reference: <https://github.com/Piebald-AI/awesome-gemini-cli>
+
 ## Metrics
 
 Track these for each channel:

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -661,12 +661,130 @@ Awesome Gemini CLI:
   and `Ducksss/codex-profiles`; no prior submission found.
 - Reference: <https://github.com/Piebald-AI/awesome-gemini-cli>
 
+Awesome Vibe Coding Tools by jiji262:
+
+- Status: deferred on 2026-05-21.
+- Why: focused vibe-coding tools catalogue with `Terminal-Based AI Agents` and
+  `CLI Workflow Systems & Agent Enhancers` sections. It already lists Codex CLI
+  and Codex-adjacent workflow enhancers such as `oh-my-codex`, so
+  `codex-profiles` is a plausible fit as a small Codex CLI/Desktop profile
+  isolation utility.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Contribution notes: README invites direct PRs, asks for an official URL,
+  concise description, appropriate category, and AI coding/development
+  relevance.
+- Suggested section: `CLI Workflow Systems & Agent Enhancers`.
+- Validation: reviewed repository metadata, README sections, contribution
+  notes, and duplicate history with GitHub CLI.
+- Deferred path: submit after the open-PR gate drops below 15, or use as the
+  one high-signal new PR in a later monthly pass if still current.
+- Reference: <https://github.com/jiji262/awesome-vibe-coding-tools>
+
+Awesome Vibe Coding by 0xWelt:
+
+- Status: deferred on 2026-05-21.
+- Why: active curated vibe-coding list with a detailed `CLI Tools` area that
+  already includes OpenAI Codex and a later `Supporting Tools` section.
+  `codex-profiles` could fit as a companion utility near Codex CLI or as
+  supporting tooling for developers switching Codex accounts/contexts.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Contribution notes: no separate contribution guide found during this pass;
+  direct PR rules are not explicit from the inspected README.
+- Suggested section: likely `CLI Tools` near `OpenAI Codex`; if maintainers
+  prefer stricter agent-only entries, open an issue first or place under
+  `Supporting Tools`.
+- Validation: reviewed repository metadata, README structure, and duplicate
+  history with GitHub CLI.
+- Deferred path: revisit after higher-priority open PRs settle; prefer an
+  issue first if contribution expectations remain ambiguous.
+- Reference: <https://github.com/0xWelt/Awesome-Vibe-Coding>
+
+Awesome Vibe Coding Resources by acvnace:
+
+- Status: deferred on 2026-05-21.
+- Why: active resource list with `Command Line Tools` entries for Codex-adjacent
+  utilities such as Agent FM, MUSE, SwarmClaw, SwarmVault, and agenttrace.
+  `codex-profiles` may fit as a command-line workflow utility for Codex users,
+  but the list is broad and no contribution rules were visible in the inspected
+  README.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Suggested section: `Command Line Tools`.
+- Validation: reviewed repository metadata, README sections, and duplicate
+  history with GitHub CLI.
+- Deferred path: revisit after stronger Codex/CLI targets respond; prefer an
+  issue first if direct PR expectations remain unclear.
+- Reference: <https://github.com/acvnace/awesome-vibe-coding-resources>
+
+Awesome OpenAI Codex by KarelDO:
+
+- Status: deferred on 2026-05-21.
+- Why: Codex-specific product/demo/tool list with a `Products & tools` section
+  and README text inviting PRs for relevant links. However, the repository
+  appears stale, with the latest push observed from 2023, and its positioning
+  is rooted in the older OpenAI Codex era rather than current Codex CLI/Desktop
+  workflows.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Suggested section: `Products & tools`.
+- Validation: reviewed repository metadata, README scope, and duplicate history
+  with GitHub CLI.
+- Deferred path: low-priority fallback only; revisit if maintainer activity
+  resumes or after the current open PR queue drops materially.
+- Reference: <https://github.com/KarelDO/awesome-codex>
+
+Awesome Codex Automations:
+
+- Status: not a fit on 2026-05-21.
+- Why: repository accepts Codex automation definitions with grounding rules and
+  a specific automation template. `codex-profiles` is a standalone Bash CLI
+  helper, not an automation definition.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Deferred path: revisit only if creating a real automation that uses
+  `codex-profiles` as supporting context, such as a profile hygiene or
+  multi-account setup checker.
+- Validation: reviewed repository metadata, README, contribution guide, and
+  duplicate history with GitHub CLI.
+- Reference: <https://github.com/onurkanbakirci/awesome-codex-automations>
+
+Awesome Vibe Coding Guide by analyticalrohit:
+
+- Status: not a fit on 2026-05-21.
+- Why: repository is a best-practices guide with contribution folders for
+  planning, prompting, testing, debugging, version control, and deployment.
+  Although it has a small `Top 10 Vibe Coding Tools` section, the contribution
+  model is guide content rather than a durable tool catalogue, and adding a
+  narrow Codex profile manager would be forced.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Validation: reviewed repository metadata, README, contribution section, and
+  duplicate history with GitHub CLI.
+- Reference: <https://github.com/analyticalrohit/awesome-vibe-coding-guide>
+
+Awesome Vibe Coding CLI by vanna-ai:
+
+- Status: not a fit on 2026-05-21.
+- Why: repository tracks AI coding CLI agents compatible with Remote-Code and
+  summarizes provider/sample-output behavior. `codex-profiles` wraps Codex
+  profile state but is not itself a coding agent, provider-compatible CLI, or
+  benchmarkable Remote-Code target.
+- Duplicate check: searched open and closed PRs/issues for `codex-profiles`,
+  `Ducksss/codex-profiles`, and `CODEX_HOME`; no prior submission found.
+- Validation: reviewed repository metadata, README scope, sections, and
+  duplicate history with GitHub CLI.
+- Reference: <https://github.com/vanna-ai/Awesome-Vibe-Coding-CLI>
+
 ## Monthly Reconciliation
 
 2026-05-21 automation pass:
 
 - Status: reconciliation-only pass; no new PRs, issues, listing requests, or
   maintainer requests were opened.
+- Ledger-first addendum: after user follow-up, added seven additional
+  candidates/skips to the ledger without submitting them.
 - Branch checked: `pinzheng/update-launch-pr-log`.
 - Why no new outreach: 20 recorded distribution PRs are still open, exceeding
   the monthly gate of 15 open submitted PRs.

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -151,6 +151,208 @@ right environment.
 6. Launch on Product Hunt after screenshots, demo video, README, and install
    path have all been click-tested.
 
+## Deferred Channels
+
+StackShare:
+
+- Status: deferred on 2026-05-14.
+- Why: StackShare requires sign-in before listing a tool. The GitHub OAuth flow
+  opened, but the Codex in-app browser became unreliable for visibility/state,
+  so the login could not be completed cleanly in-session.
+- Resume path: use Chrome or a stable browser, sign in with GitHub, approve only
+  the basic StackShare OAuth request for GitHub profile/email access, then use
+  `List a Tool`.
+- Listing angle: developer tool / AI coding agent utility for switching Codex
+  CLI and Desktop accounts with isolated `CODEX_HOME` profiles.
+- Listing URL: <https://stackshare.io/tools/new>
+
+OpenAlternative:
+
+- Status: deferred on 2026-05-14.
+- Why: submit flow requires sign-in before reaching the listing form.
+- Resume path: use a stable browser, sign in by email magic link, GitHub, or
+  Google, then continue from <https://openalternative.co/submit>.
+
+LibHunt:
+
+- Status: deferred on 2026-05-14.
+- Why: direct submit page stalled on Cloudflare verification in the Codex
+  in-app browser.
+- Resume path: open <https://www.libhunt.com/repo/submit> in a stable browser
+  and submit `https://github.com/Ducksss/codex-profiles`.
+
+SaaSHub:
+
+- Status: deferred on 2026-05-14.
+- Why: submit page also stalled on Cloudflare verification in the Codex in-app
+  browser.
+- Resume path: open <https://www.saashub.com/services/submit> in a stable
+  browser and start with the GitHub repository URL.
+
+Awesome Codex CLI:
+
+- Status: replacement PR opened on 2026-05-18.
+- Why: highly relevant curated list with an existing `Account & Auth` section.
+- Branch: `Ducksss:pinzheng/add-codex-profiles-roggeohta`.
+- Commit: `8510a07` adds `Ducksss/codex-profiles`.
+- PR target: <https://github.com/RoggeOhta/awesome-codex-cli>
+- PR: <https://github.com/RoggeOhta/awesome-codex-cli/pull/40>
+- Note: original PR <https://github.com/RoggeOhta/awesome-codex-cli/pull/33>
+  was closed and replaced after a fork-name collision with another
+  `awesome-codex-cli` repository.
+
+Awesome Codex CLI by milisp:
+
+- Status: merged on 2026-05-18.
+- Why: second Codex-specific curated list with an existing `Development Tools`
+  section that already includes config/account switching tools.
+- Resume path: temporary clone at `/tmp/milisp-awesome-codex-cli`, branch
+  `pinzheng/add-codex-profiles`, commit `cd7b62d` adds `codex-profiles`.
+- PR target: <https://github.com/milisp/awesome-codex-cli>
+- PR: <https://github.com/milisp/awesome-codex-cli/pull/30>
+
+Awesome CLI Apps:
+
+- Status: not eligible yet as of 2026-05-18.
+- Why: contribution rules require GitHub-hosted tools to be older than 90 days
+  and have more than 20 stars. `codex-profiles` currently has 1 star.
+- Resume path: revisit after the repo crosses the age/star threshold, then
+  submit to <https://github.com/agarrharr/awesome-cli-apps>.
+
+Awesome Codex Plugins:
+
+- Status: not a fit as of 2026-05-18.
+- Why: contribution rules require a real Codex plugin bundle under
+  `plugins/<owner>/<repo>/` with `.codex-plugin/plugin.json` and an icon.
+  `codex-profiles` is a standalone CLI helper, not a Codex plugin.
+- Reference: <https://github.com/hashgraph-online/awesome-codex-plugins>
+
+Awesome DevTools:
+
+- Status: PR opened on 2026-05-18.
+- Why: developer-tool list with `AI Coding Tools` and `CLIs & Terminal Tools`
+  sections; no visible age/star gate.
+- Resume path: temporary clone at `/tmp/awesome-devtools`, branch
+  `pinzheng/add-codex-profiles`, commit `c688e2a` adds `codex-profiles`.
+- PR target: <https://github.com/devtoolsd/awesome-devtools>
+- PR: <https://github.com/devtoolsd/awesome-devtools/pull/230>
+
+Awesome AI-Driven Development:
+
+- Status: PR opened on 2026-05-18.
+- Why: active AI-development list with existing Codex, Codex Desktop, and
+  Codex-adjacent CLI tools in `Terminal & CLI Agents`.
+- Resume path: temporary clone at `/tmp/awesome-AI-driven-development`, branch
+  `pinzheng/add-codex-profiles`, commit `19ed072` adds `codex-profiles`.
+- PR target: <https://github.com/eltociear/awesome-AI-driven-development>
+- PR: <https://github.com/eltociear/awesome-AI-driven-development/pull/52>
+
+Awesome Vibe Coding by no-fluff:
+
+- Status: PR candidate prepared locally on 2026-05-18.
+- Why: targeted list for agentic/vibe-coding workflows with an `Other tools`
+  section for companion utilities around coding agents.
+- Caveat: contribution notes ask users to open an issue first. Use the local
+  candidate as source material, or open a PR if the maintainer accepts direct
+  additions.
+- Resume path: temporary clone at `/tmp/awesome-vibe-coding`, branch
+  `pinzheng/add-codex-profiles`, commit `8c138eb` adds `codex-profiles`.
+- PR or issue target: <https://github.com/no-fluff/awesome-vibe-coding>
+
+Awesome AI Coding Tools:
+
+- Status: PR opened on 2026-05-18.
+- Why: high-reach AI coding tools list with existing Codex CLI and
+  Codex-adjacent developer productivity tools.
+- Caveat: contribution rules prefer tools that are AI-powered or AI-enhanced.
+  This is a borderline but defensible entry because `codex-profiles` is a
+  Codex workflow helper rather than a standalone AI model/tool.
+- Resume path: temporary clone at `/tmp/awesome-ai-coding-tools`, branch
+  `pinzheng/add-codex-profiles`, commit `e7634ee` adds `codex-profiles`.
+- PR target: <https://github.com/ai-for-developers/awesome-ai-coding-tools>
+- PR: <https://github.com/ai-for-developers/awesome-ai-coding-tools/pull/330>
+
+AI IDEs & Coding Assistants:
+
+- Status: PR opened on 2026-05-18.
+- Why: small but current manually curated AI tools directory with a
+  `Developer Productivity & Workflow` section.
+- Resume path: temporary clone at `/tmp/awesome-ai-tools`, branch
+  `pinzheng/add-codex-profiles`, commit `08da146` adds `codex-profiles`.
+- PR target: <https://github.com/QAInsights/awesome-ai-tools>
+- PR: <https://github.com/QAInsights/awesome-ai-tools/pull/50>
+
+Awesome Dev Tools by t18n:
+
+- Status: PR candidate prepared locally on 2026-05-18.
+- Why: general developer-tool list accepting useful developer utilities; lower
+  priority than Codex/AI-agent-specific channels, but still relevant.
+- Resume path: temporary clone at `/tmp/t18n-awesome-dev-tools`, branch
+  `pinzheng/add-codex-profiles`, commit `e3bb632` adds `codex-profiles`.
+- PR target: <https://github.com/t18n/awesome-dev-tools>
+
+Awesome Terminals AI:
+
+- Status: PR opened on 2026-05-18.
+- Why: AI terminal workflow catalogue with a `Shell Enhancements` section;
+  `codex-profiles` is a shell-level helper for Codex account/profile
+  separation.
+- Resume path: temporary clone at `/tmp/awesome-terminals-ai`, branch
+  `pinzheng/add-codex-profiles`, commit `b64abeb` adds `codex-profiles`.
+- PR target: <https://github.com/BNLNPPS/awesome-terminals-ai>
+- PR: <https://github.com/BNLNPPS/awesome-terminals-ai/pull/8>
+
+Awesome Vibe Coding by Taskade:
+
+- Status: PR opened on 2026-05-18.
+- Why: active vibe-coding list with `CLI & Terminal Tools` and
+  `Specialized CLI Tools` tables.
+- Resume path: temporary clone at `/tmp/taskade-awesome-vibe-coding`, branch
+  `pinzheng/add-codex-profiles`, commit `2804db2` adds `codex-profiles`.
+- PR target: <https://github.com/taskade/awesome-vibe-coding>
+- PR: <https://github.com/taskade/awesome-vibe-coding/pull/22>
+
+Awesome Vibe Coding by bluegalaxy111:
+
+- Status: PR opened on 2026-05-18.
+- Why: terminal-agent-focused vibe-coding handbook with Codex already listed
+  in `AI Coding Agents > Terminal / CLI`.
+- Resume path: temporary clone at `/tmp/bluegalaxy-awesome-vibe-coding`,
+  branch `pinzheng/add-codex-profiles`, commit `24b3077` adds
+  `codex-profiles`.
+- PR target: <https://github.com/bluegalaxy111/awesome-vibe-coding>
+- PR: <https://github.com/bluegalaxy111/awesome-vibe-coding/pull/8>
+
+Awesome CLI Apps in a CSV:
+
+- Status: PR opened on 2026-05-18.
+- Why: high-reach CLI catalogue with an explicit `data/apps.csv` PR path and
+  an existing `ai` category for terminal AI tools.
+- Resume path: temporary clone at `/tmp/awesome-cli-apps-in-a-csv`, branch
+  `pinzheng/add-codex-profiles`, commit `e359888` adds `codex-profiles`.
+- Validation: parsed `data/apps.csv` with Ruby CSV.
+- PR target: <https://github.com/toolleeo/awesome-cli-apps-in-a-csv>
+- PR: <https://github.com/toolleeo/awesome-cli-apps-in-a-csv/pull/267>
+
+Awesome OpenAI Codex:
+
+- Status: PR opened on 2026-05-18.
+- Why: Codex-specific list with a `Tools & Integrations` section and explicit
+  contribution rules for direct Codex ecosystem tools.
+- Resume path: temporary clone at `/tmp/awesome-openai-codex`, branch
+  `pinzheng/add-codex-profiles`, commit `15322cb` adds `codex-profiles`.
+- PR target: <https://github.com/vaderyang/awesome-openai-codex>
+- PR: <https://github.com/vaderyang/awesome-openai-codex/pull/2>
+
+Everything AI Coding:
+
+- Status: deferred on 2026-05-18.
+- Why: relevant structured AI-coding catalogue, but full and sparse clone
+  attempts were unreliable in-session (`early EOF` / long sparse checkout).
+- Resume path: revisit <https://github.com/zgsm-ai/everything-ai-coding>,
+  inspect `catalog/schema.json`, and add a schema-valid entry under `catalog/`
+  if the repository can be cloned cleanly.
+
 ## Metrics
 
 Track these for each channel:

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -344,14 +344,136 @@ Awesome OpenAI Codex:
 - PR target: <https://github.com/vaderyang/awesome-openai-codex>
 - PR: <https://github.com/vaderyang/awesome-openai-codex/pull/2>
 
+Awesome Codex Plugins by darknorth-123:
+
+- Status: PR opened on 2026-05-18.
+- Why: Codex ecosystem list that explicitly accepts plugins, MCP servers,
+  workflows, integrations, and developer tools for OpenAI Codex.
+- Resume path: temporary clone at `/tmp/darknorth-awesome-codex-plugins`,
+  branch `pinzheng/add-codex-profiles`, commit `4985656` adds
+  `codex-profiles` to `Developer Tools`.
+- PR target: <https://github.com/darknorth-123/Awesome-Codex-Plugins>
+- PR: <https://github.com/darknorth-123/Awesome-Codex-Plugins/pull/2>
+
+Awesome OpenAI Codex CLI by taahro:
+
+- Status: PR opened on 2026-05-18.
+- Why: Codex CLI resource list with a `New Features & Integrations` section.
+- Resume path: temporary clone at `/tmp/taahro-awesome-openai-codex-cli`,
+  branch `pinzheng/add-codex-profiles`, commit `c919693` adds
+  `codex-profiles`.
+- PR target: <https://github.com/taahro/awesome-openai-codex-cli>
+- PR: <https://github.com/taahro/awesome-openai-codex-cli/pull/3>
+
+Awesome Agentic Coding by tranhoangpich:
+
+- Status: PR opened on 2026-05-18.
+- Why: open-source agentic-coding list already containing Codex and adjacent
+  account/session workflow tools.
+- Resume path: temporary clone at `/tmp/awesome-agentic-coding-tranhoangpich`,
+  branch `pinzheng/add-codex-profiles`, commit `8838169` adds
+  `codex-profiles`.
+- PR target: <https://github.com/tranhoangpich/awesome-agentic-coding>
+- PR: <https://github.com/tranhoangpich/awesome-agentic-coding/pull/3>
+
+Awesome AI Coding Agent Tools:
+
+- Status: PR opened on 2026-05-18.
+- Why: AI coding-agent ecosystem catalogue; `codex-profiles` fits as focused
+  Codex CLI/Desktop tooling around profile and account isolation.
+- Resume path: temporary clone at `/tmp/awesome-ai-coding-agent-tools`, branch
+  `pinzheng/add-codex-profiles`, commit `c031ecd` adds a `Codex CLI &
+  Desktop Tooling` subsection.
+- Validation: ran `npx --yes markdownlint-cli README.md`.
+- PR target: <https://github.com/namphuongtran/awesome-ai-coding-agent-tools>
+- PR: <https://github.com/namphuongtran/awesome-ai-coding-agent-tools/pull/4>
+
+Awesome CLI Coding Agents:
+
+- Status: PR opened on 2026-05-18.
+- Why: terminal-native coding-agent list with an `Agent infrastructure` section
+  for tools that extend or support CLI coding agents.
+- Resume path: temporary clone at `/tmp/awesome-cli-coding-agents`, branch
+  `pinzheng/add-codex-profiles`, commit `7c2b638` adds `codex-profiles`.
+- PR target: <https://github.com/bradAGI/awesome-cli-coding-agents>
+- PR: <https://github.com/bradAGI/awesome-cli-coding-agents/pull/90>
+
+Awesome AI Dev Tools:
+
+- Status: PR opened on 2026-05-18.
+- Why: broad AI developer-tools list that already includes OpenAI Codex and
+  Codex CLI; `codex-profiles` is a Codex workflow utility rather than a
+  generic promo entry.
+- Resume path: temporary clone at `/tmp/pierrunoyt-awesome-ai-dev-tools`,
+  branch `pinzheng/add-codex-profiles`, commit `135b228` adds
+  `codex-profiles`.
+- PR target: <https://github.com/PierrunoYT/awesome-ai-dev-tools>
+- PR: <https://github.com/PierrunoYT/awesome-ai-dev-tools/pull/26>
+
+Awesome AI Coding Assistants Playbook:
+
+- Status: PR opened on 2026-05-18.
+- Why: assistant configuration/resource playbook; `codex-profiles` manages
+  Codex CLI/Desktop configuration boundaries through isolated `CODEX_HOME`
+  profiles.
+- Resume path: temporary clone at
+  `/tmp/codandotv-awesome-ai-coding-assistants-playbook`, branch
+  `pinzheng/add-codex-profiles`, commit `d3ab9f3` adds English and Portuguese
+  entries.
+- Validation: ran `git diff --check`; default `markdownlint-cli` reports
+  pre-existing repository-wide README issues unrelated to this entry.
+- PR target: <https://github.com/CodandoTV/awesome-ai-coding-assistants-playbook>
+- PR: <https://github.com/CodandoTV/awesome-ai-coding-assistants-playbook/pull/8>
+
+Awesome AI Coding by dalisoft:
+
+- Status: PR opened on 2026-05-18.
+- Why: AI coding catalogue that already lists Codex; `codex-profiles` fits the
+  `Resources` section as a companion utility, not the AI-agent CLI table.
+- Resume path: temporary clone at `/tmp/dalisoft-awesome-ai-coding`, branch
+  `pinzheng/add-codex-profiles`, commit `4b194bd` adds `codex-profiles`.
+- PR target: <https://github.com/dalisoft/awesome-ai-coding>
+- PR: <https://github.com/dalisoft/awesome-ai-coding/pull/64>
+
+Awesome AI Coding by wsxiaoys:
+
+- Status: PR opened on 2026-05-18.
+- Why: high-reach AI-coding list whose `Projects` section includes open-source
+  AI coding CLIs, editor tools, and workflow utilities.
+- Resume path: temporary clone at `/tmp/wsxiaoys-awesome-ai-coding`, branch
+  `pinzheng/add-codex-profiles`, commit `8a781d3` adds `codex-profiles`.
+- PR target: <https://github.com/wsxiaoys/awesome-ai-coding>
+- PR: <https://github.com/wsxiaoys/awesome-ai-coding/pull/103>
+
 Everything AI Coding:
 
+- Status: skipped on 2026-05-18.
+- Why: relevant AI-coding catalogue, but manual curated submissions are
+  structured around MCP servers, skills, rules, and prompts. Adding
+  `codex-profiles` as a Bash CLI helper would misclassify the project.
+- Reference: <https://github.com/zgsm-ai/everything-ai-coding>
+
+Awesome Coding Agents by wshobson:
+
+- Status: skipped on 2026-05-18.
+- Why: `wshobson/awesome-coding-agents` could not be resolved through GitHub,
+  and no matching public repository was found under that owner.
+
+Awesome Shell:
+
 - Status: deferred on 2026-05-18.
-- Why: relevant structured AI-coding catalogue, but full and sparse clone
-  attempts were unreliable in-session (`early EOF` / long sparse checkout).
-- Resume path: revisit <https://github.com/zgsm-ai/everything-ai-coding>,
-  inspect `catalog/schema.json`, and add a schema-valid entry under `catalog/`
-  if the repository can be cloned cleanly.
+- Why: `codex-profiles` is Bash shell software, but the list is broad and has
+  older open PRs. Keep it as a lower-priority target after Codex/AI-agent
+  directories respond.
+- Candidate target: <https://github.com/uhub/awesome-shell>
+
+Terminals Are Sexy:
+
+- Status: skipped on 2026-05-18.
+- Why: broad terminal resource list with an endorsement gate and many stale
+  additions; `codex-profiles` is CLI-adjacent but less high-signal for that
+  audience than Codex and AI-agent lists.
+- Reference: <https://github.com/k4m4/terminals-are-sexy>
 
 ## Metrics
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/Ducksss/codex-profiles/actions/workflows/ci.yml/badge.svg)](https://github.com/Ducksss/codex-profiles/actions/workflows/ci.yml)
 [![Latest release](https://img.shields.io/github/v/release/Ducksss/codex-profiles?sort=semver)](https://github.com/Ducksss/codex-profiles/releases)
+[![npm](https://img.shields.io/npm/v/codex-profile.svg)](https://www.npmjs.com/package/codex-profile)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Shell: Bash](https://img.shields.io/badge/shell-bash-4EAA25.svg)](bin/codex-profile)
 [![Platform: macOS + Linux](https://img.shields.io/badge/platform-macOS%20%2B%20Linux-lightgrey.svg)](#platform-support)
@@ -76,16 +77,26 @@ where local Codex state should not bleed between contexts.
 
 ## Install
 
-With npm from this GitHub repo:
+With npm:
 
 ```sh
-npm install -g github:Ducksss/codex-profiles
+npm install -g codex-profile
 ```
+
+The npm package is `codex-profile` (singular). It installs both the
+`codex-profile` and `codex-profiles` commands. Use the singular package name;
+the plural `codex-profiles` package on npm is a different project.
 
 With Homebrew:
 
 ```sh
 brew install Ducksss/tap/codex-profile
+```
+
+With npm directly from this GitHub repo:
+
+```sh
+npm install -g github:Ducksss/codex-profiles
 ```
 
 From source:
@@ -103,13 +114,6 @@ Verify the install:
 
 ```sh
 codex-profile doctor
-```
-
-The package is also prepared for the public npm registry as `codex-profile`.
-After the registry package is published, npm users can install it with:
-
-```sh
-npm install -g codex-profile
 ```
 
 ## Quick Start

--- a/agent.md
+++ b/agent.md
@@ -1,0 +1,202 @@
+# codex-profiles Developer-Cred Distribution Agent
+
+## Mission
+
+Run a developer-cred distribution pass for
+<https://github.com/Ducksss/codex-profiles>.
+
+Find genuinely relevant GitHub repositories, curated lists, directories, and
+developer-tool catalogs where `codex-profiles` belongs. Open high-quality PRs,
+issues, listing requests, or maintainer requests whenever the fit is clear and
+the target's contribution rules allow it.
+
+## Project Context
+
+`codex-profiles` is a small Bash tool for switching Codex CLI/Desktop profiles
+with isolated `CODEX_HOME` directories. It avoids copying auth files, supports
+macOS/Linux, has no third-party runtime dependencies, and installs with:
+
+```sh
+brew install Ducksss/tap/codex-profile
+```
+
+Start every run by reading:
+
+- `README.md` for the current product surface, install path, and positioning.
+- `LAUNCH.md` for prior PRs, missed channels, deferred channels, ineligible
+  repositories, and launch notes.
+
+Do not duplicate prior submissions unless there is a clear reason, such as a
+closed PR that needs a replacement.
+
+## Run Preconditions
+
+Before researching or submitting anything:
+
+- Verify `agent.md`, `README.md`, and `LAUNCH.md` exist in the repository root.
+- Run `git status --porcelain=v1 --branch` and record the branch in the final
+  report.
+- Work only from a clean automation worktree. If unrelated dirty files are
+  present, stop and report the exact paths instead of mixing launch-log edits
+  into them.
+- Fetch the latest remote refs before checking open PRs or preparing new
+  branches.
+- Reconcile existing `LAUNCH.md` PR and issue links before discovering new
+  targets.
+
+## Monthly Operating Mode
+
+This automation runs monthly. Treat each run as a quality and follow-up pass,
+not a daily volume pass.
+
+At the start of every run:
+
+- Check the state of all PRs and issues already recorded in `LAUNCH.md`.
+- Update merged, closed, stale, replied-to, or blocked entries before looking
+  for new targets.
+- If 15 or more submitted PRs are still open, do not open more than one new
+  PR or issue unless the new target is Codex-specific and clearly high-signal.
+- Otherwise, cap new PRs/issues/listing requests at three per run.
+- Prefer maintainer follow-up, status cleanup, and eligibility revisits over
+  expanding into weak directories.
+
+## Autonomy
+
+You have full execution authority for this distribution pass. Do not ask the
+project owner for permission before opening PRs, issues, listing requests, or
+similar submissions that satisfy this file's quality bar.
+
+Use available authenticated GitHub CLI access, GitHub API access, browser
+sessions, local credentials, and repository permissions that are already
+configured in the environment. Do not print, copy, or expose secrets.
+
+Use subagents freely for parallel repository discovery, fit checks,
+contribution-rule review, implementation, validation, and final reporting.
+
+Act without waiting for manual approval when:
+
+- The repository is clearly relevant.
+- The contribution rules allow a direct PR or issue.
+- The edit is small, truthful, and consistent with the target repository.
+- Any required validation can be run locally.
+- A listing, issue, PR, or request can be submitted through already available
+  authenticated access.
+
+Defer when:
+
+- Access is blocked by missing authentication, MFA, CAPTCHA, OAuth approval, or
+  paid access that cannot be completed non-interactively with the available
+  session.
+- The target rules forbid the submission.
+- `codex-profiles` does not clearly fit the target scope.
+- Eligibility requirements are not met.
+- A browser form asks for credentials, OAuth consent, payment, private profile
+  information, or anything that cannot be safely completed from the existing
+  authenticated session.
+
+When contribution rules are ambiguous but the repository is relevant, make a
+best-effort judgment. Prefer opening an issue over a PR for borderline cases,
+and document the rationale in `LAUNCH.md`.
+
+## Candidate Priorities
+
+Prioritize:
+
+- Codex and OpenAI Codex lists.
+- AI coding and agentic development lists.
+- CLI and terminal tool catalogs.
+- Developer-tool directories.
+- Workflow automation and productivity catalogs.
+
+Avoid:
+
+- Generic or low-quality lists submitted only for backlinks.
+- Unmaintained repositories unless they are highly relevant and still accept
+  submissions.
+- Broad "awesome" lists where `codex-profiles` would be a weak or forced fit.
+- Any mass-produced, spammy, or promotional submission pattern.
+
+## Submission Rules
+
+- Only open a PR when `codex-profiles` clearly fits the repository scope and
+  contribution rules.
+- If contribution rules ask for an issue first, open an issue instead of a PR.
+- If eligibility is not met, skip it and document why in `LAUNCH.md`.
+- Keep every edit minimal and consistent with the target repository's style.
+- Validate structured files before opening a PR, especially CSV, JSON, YAML,
+  Markdown tables, or generated indexes.
+- Use GitHub CLI if available to fork, branch, push, and open PRs.
+- Use branch name `pinzheng/add-codex-profiles` unless a collision requires a
+  suffix.
+- Use direct PR titles, usually `Add codex-profiles`.
+- Make each PR body specific to the target repository. Explain why
+  `codex-profiles` fits that repository, not generic promotion.
+- Do not send DMs, manipulate stars, request votes, mass-comment, or post the
+  same generic pitch across multiple targets.
+
+## PR Body Template
+
+Use this as a starting point and tailor it to the target repository:
+
+````md
+Adds codex-profiles, a small Bash utility for switching Codex CLI/Desktop
+profiles with isolated CODEX_HOME directories.
+
+I think it fits this list because [specific reason tied to the target
+repository's scope or section].
+
+Install:
+
+```sh
+brew install Ducksss/tap/codex-profile
+```
+
+Repo: https://github.com/Ducksss/codex-profiles
+````
+
+## Required Logging
+
+For every candidate considered, update `LAUNCH.md` with:
+
+- Repository or channel URL.
+- Status: `PR opened`, `issue opened`, `merged`, `closed`, `not eligible`,
+  `not a fit`, `deferred`, or `failed`.
+- Why it fits or why it was skipped.
+- PR or issue URL if opened.
+- Branch and commit if applicable.
+- Validation performed.
+- Any blocker requiring non-interactive authentication, maintainer interaction,
+  or a later retry.
+
+Preserve existing `LAUNCH.md` history. Add new entries under the most relevant
+section, and do not remove prior notes.
+
+## Durable State
+
+Before finishing:
+
+- Run `git diff --check`.
+- Verify `LAUNCH.md` contains every PR, issue, listing request, skipped target,
+  and deferred follow-up from the run.
+- Commit only scoped `LAUNCH.md` updates and any intentional automation
+  instruction changes.
+- Push the commit to the current automation branch.
+- If committing or pushing is blocked, leave `LAUNCH.md` updated and report the
+  exact blocker, command, and error.
+
+## Final Report
+
+End each run with a concise report containing:
+
+- PRs opened.
+- Issues opened.
+- Listing or maintainer requests submitted.
+- Existing PRs/issues reconciled.
+- Candidates skipped with reasons.
+- Deferred follow-ups.
+- Blockers requiring non-interactive authentication, maintainer interaction, or
+  a later retry.
+- Validation performed.
+- Commit hash and pushed branch, or the exact reason no commit was pushed.
+
+Include links for every PR, issue, or deferred channel.


### PR DESCRIPTION
## Summary

Updates the launch ledger and public npm-facing GitHub docs for `codex-profiles`.

## Details

- Records the latest distribution outreach state in `LAUNCH.md`, including new PRs, issue-first targets, skipped targets, and reconciliation notes.
- Merges the current `main` packaging work into this branch so the PR includes the `codex-profile` npm package metadata and package smoke tests.
- Updates README and launch copy now that the public npm registry package is live as `codex-profile`.
- Calls out the singular npm package name because the plural `codex-profiles` package belongs to another project.

## Validation

- Ran `make test`
- Ran `make lint`
- Ran `git diff --check`
- Verified npm registry version with `npm view codex-profile version`
- Installed `codex-profile@0.2.0` into a temporary global npm prefix and checked both `codex-profile` and `codex-profiles` binaries