### PR TITLE
cli(feat): add linked configuration profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,10 @@ log entry with the exact outcome, reason, and relevant link.
   compares, or migrates `auth.json` tokens or ChatGPT cookies.
 - `clone-config` copies only an allowlist of non-secret root config files and
   refuses sensitive-looking key names.
+- `init --share-with` links only the documented configuration allowlist. It
+  keeps auth, sessions, logs, Electron data, caches, skills, and connector/app
+  state separate and never reads or copies authentication data; linked config
+  and plugins remain mutually visible.
 - `status` is Codex-local. Account equality between CLI and Desktop is not
   inspected or verified.
 - Local-state separation is not an account, OS, or server-side boundary. SSH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows semantic versioning for tagged releases.
 
 ## Unreleased
 
+### Added
+
+- Added `init <profile> --share-with <source-profile>` for linked profiles that
+  share only an explicit configuration allowlist while keeping authentication,
+  sessions, logs, Desktop data, caches, and connector/app state separate.
+
 ### Changed
 
 - Added practical GitHub Q&A guides for separate Codex CLI profiles, named

--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ codex-profile login personal
 codex-profile login work
 ```
 
+To keep authentication and runtime state separate while sharing selected
+configuration, initialize a new linked profile from an existing one:
+
+```sh
+codex-profile init personal-2 --share-with personal
+codex-profile login personal-2
+```
+
 Run the upstream Codex CLI with either home:
 
 ```sh
@@ -180,6 +188,7 @@ codex-profile path personal
 
 ```sh
 codex-profile init client-a
+codex-profile init client-b --share-with client-a
 codex-profile list
 codex-profile remove client-a
 codex-profile remove client-a --yes
@@ -188,6 +197,29 @@ codex-profile remove client-a --yes
 `list` and `status` are read-only. They do not create a directory for a typo.
 Removing a profile deletes its Codex home and, for a named Desktop profile, its
 local Electron data. Review the path and close the corresponding window first.
+
+#### Share configuration, not identity or runtime state
+
+`init <profile> --share-with <source-profile>` creates a new, private profile
+directory and symlinks only source entries that already exist in this explicit
+allowlist:
+
+```text
+config.toml
+AGENTS.md
+AGENTS.override.md
+instructions.md
+custom-instructions.md
+rules/
+plugins/
+```
+
+The target must not already exist. `auth.json`, `sessions/`, `logs/`,
+`electron-user-data/`, caches, skills, and connector/app state are never
+linked. The command does not read or copy authentication data. Allowlisted
+links are live: edits from either profile affect the same source configuration,
+and plugins or configuration can themselves contain sensitive or executable
+content. Review the source before linking across trust domains.
 
 ### Inspect Codex-local status
 
@@ -333,7 +365,7 @@ For Bash, save the output as
 codex-profile app <profile> [workspace]
 codex-profile cli <profile> [codex-args...]
 codex-profile login <profile> [codex-login-args...]
-codex-profile init <profile>
+codex-profile init <profile> [--share-with <source-profile>]
 codex-profile remove <profile> [--yes]
 codex-profile status [profile]
 codex-profile status --json [profile]
@@ -436,6 +468,10 @@ The tool does not read, copy, print, parse, upload, compare, or migrate token
 contents. It also cannot promise that OpenAI will never store some state in the
 macOS keychain or another location outside the selected directories. Use
 separate operating-system users when you require a stronger boundary.
+
+Linked profiles share only the documented configuration paths. They do not
+share authentication or runtime state, but linked configuration and plugins
+are mutually visible and may carry their own secrets or executable behavior.
 
 See [SECURITY.md](SECURITY.md) before using named profiles for regulated,
 privileged, or high-risk accounts.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,6 +78,20 @@ directories, and it refuses sensitive-looking keys. The heuristic is a safety
 guard, not a proof that arbitrary text is non-secret. Review source files
 before copying them between trust domains.
 
+## Configuration linking
+
+`init <profile> --share-with <source-profile>` creates a real, mode-`700`
+target directory and symlinks only existing paths from a fixed configuration
+allowlist: `config.toml`, `AGENTS.md`, `AGENTS.override.md`,
+`instructions.md`, `custom-instructions.md`, `rules/`, and `plugins/`. It
+rejects symlinked source homes and every pre-existing target path.
+
+The command never links or reads `auth.json`, sessions, logs, Electron data,
+caches, skills, or connector/app state. Linked configuration is live and may
+itself contain secrets or executable plugin behavior, so it is not a security
+boundary between the linked profiles. Review the source before linking across
+trust domains.
+
 ## Network activity
 
 The wrapper itself performs network access only for these project-maintenance

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -20,7 +20,7 @@ Usage:
   $PROGRAM app <profile> [--instance] [--rebuild] [workspace]
   $PROGRAM cli <profile> [codex-args...]
   $PROGRAM login <profile> [codex-login-args...]
-  $PROGRAM init <profile>
+  $PROGRAM init <profile> [--share-with <source-profile>]
   $PROGRAM remove <profile> [--yes]
   $PROGRAM status [profile]
   $PROGRAM status --json [profile]
@@ -40,6 +40,7 @@ Usage:
 Examples:
   $PROGRAM login personal
   $PROGRAM init work
+  $PROGRAM init personal-2 --share-with personal
   $PROGRAM app personal ~/Dev/my-project
   $PROGRAM app work ~/Dev/client-project
   $PROGRAM cli personal exec "review this repo"
@@ -162,6 +163,60 @@ ensure_home() {
   mkdir -p "$codex_home" || die "Cannot create directory: $codex_home"
   [[ -d "$codex_home" ]] || die "Not a directory: $codex_home"
   chmod 700 "$codex_home" || die "Cannot set private permissions on: $codex_home"
+}
+
+shared_profile_config_entries() {
+  printf '%s\n' \
+    config.toml \
+    AGENTS.md \
+    AGENTS.override.md \
+    instructions.md \
+    custom-instructions.md \
+    rules \
+    plugins
+}
+
+initialize_shared_profile() {
+  local target_profile="$1"
+  local source_profile="$2"
+  local target_home source_home entry source_entry target_entry
+
+  [[ "$target_profile" != "$source_profile" ]] ||
+    die "Source and target profiles must be different."
+
+  target_home="$(codex_home_for_profile "$target_profile")"
+  source_home="$(codex_home_for_profile "$source_profile")"
+
+  [[ ! -L "$source_home" ]] ||
+    die "Refusing symlinked shared profile source: $source_home"
+  [[ -d "$source_home" ]] ||
+    die "Shared profile source is not initialized: $source_profile ($source_home)"
+  [[ ! -e "$target_home" && ! -L "$target_home" ]] ||
+    die "Target profile path already exists: $target_profile ($target_home)"
+
+  mkdir "$target_home" || die "Cannot create directory: $target_home"
+  if ! chmod 700 "$target_home"; then
+    if ! rm -rf "$target_home"; then
+      die "Cannot set private permissions on: $target_home; cleanup also failed."
+    fi
+    die "Cannot set private permissions on: $target_home"
+  fi
+
+  while IFS= read -r entry; do
+    source_entry="$source_home/$entry"
+    target_entry="$target_home/$entry"
+    [[ -e "$source_entry" || -L "$source_entry" ]] || continue
+
+    if ! ln -s "$source_entry" "$target_entry"; then
+      if ! rm -rf "$target_home"; then
+        die "Cannot link shared entry $entry into $target_home; cleanup also failed."
+      fi
+      die "Cannot link shared entry $entry into $target_home"
+    fi
+  done < <(shared_profile_config_entries)
+
+  note "Initialized $target_profile ($target_home)"
+  note "Sharing configuration with $source_profile ($source_home)"
 }
 
 desktop_plist_value() {
@@ -545,9 +600,30 @@ command_login() {
 
 command_init() {
   local profile="${1:-}"
-  [[ -n "$profile" ]] || die "Usage: $PROGRAM init <profile>"
+  [[ -n "$profile" && "$profile" != -* ]] ||
+    die "Usage: $PROGRAM init <profile> [--share-with <source-profile>]"
   shift || true
-  [[ "$#" -eq 0 ]] || die "Usage: $PROGRAM init <profile>"
+
+  local source_profile=""
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --share-with)
+        [[ -z "$source_profile" && -n "${2:-}" ]] ||
+          die "Usage: $PROGRAM init <profile> [--share-with <source-profile>]"
+        source_profile="$2"
+        shift
+        ;;
+      *)
+        die "Usage: $PROGRAM init <profile> [--share-with <source-profile>]"
+        ;;
+    esac
+    shift
+  done
+
+  if [[ -n "$source_profile" ]]; then
+    initialize_shared_profile "$profile" "$source_profile"
+    return 0
+  fi
 
   local codex_home existed
   codex_home="$(codex_home_for_profile "$profile")"
@@ -1380,10 +1456,11 @@ command_completions() {
       cat <<'EOF'
 _codex_profile()
 {
-  local cur command profiles
+  local cur command prev profiles
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   command="${COMP_WORDS[1]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
 
   if [[ "$COMP_CWORD" -eq 1 ]]; then
     COMPREPLY=( $(compgen -W "app app-instance cli login init remove status path env use logs clone-config list doctor completions shell-init upgrade version help" -- "$cur") )
@@ -1399,10 +1476,18 @@ _codex_profile()
         COMPREPLY=( $(compgen -W "default personal work $profiles" -- "$cur") )
       fi
       ;;
-    app-instance|cli|login|init|remove|status|path|env|use|logs)
+    app-instance|cli|login|remove|status|path|env|use|logs)
       if [[ "$COMP_CWORD" -eq 2 ]]; then
         profiles="$(codex-profile list 2>/dev/null)"
         COMPREPLY=( $(compgen -W "default personal work $profiles" -- "$cur") )
+      fi
+      ;;
+    init)
+      if [[ "$COMP_CWORD" -eq 2 || "$prev" == "--share-with" ]]; then
+        profiles="$(codex-profile list 2>/dev/null)"
+        COMPREPLY=( $(compgen -W "default personal work $profiles" -- "$cur") )
+      else
+        COMPREPLY=( $(compgen -W "--share-with" -- "$cur") )
       fi
       ;;
     clone-config)
@@ -1426,13 +1511,14 @@ EOF
 #compdef codex-profile codex-profiles
 
 _codex_profile() {
-  local -a commands profiles shells app_flags
+  local -a commands profiles shells app_flags init_flags
   commands=(
     app app-instance cli login init remove status path env use logs clone-config list doctor completions shell-init upgrade version help
   )
   profiles=(${(f)"$(codex-profile list 2>/dev/null)"} default personal work)
   shells=(bash zsh fish)
   app_flags=(--instance --rebuild)
+  init_flags=(--share-with)
 
   if (( CURRENT == 2 )); then
     _describe 'command' commands
@@ -1447,9 +1533,16 @@ _codex_profile() {
         _describe 'profile' profiles
       fi
       ;;
-    app-instance|cli|login|init|remove|status|path|env|use|logs)
+    app-instance|cli|login|remove|status|path|env|use|logs)
       if (( CURRENT == 3 )); then
         _describe 'profile' profiles
+      fi
+      ;;
+    init)
+      if (( CURRENT == 3 )) || [[ "$words[CURRENT-1]" == "--share-with" ]]; then
+        _describe 'profile' profiles
+      else
+        _describe 'flag' init_flags
       fi
       ;;
     clone-config)
@@ -1476,6 +1569,7 @@ for codex_profile_command in codex-profile codex-profiles
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from app app-instance cli login init remove status path env use logs' -a '(codex-profile list 2>/dev/null) default personal work'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from app' -l instance -d 'Compatibility flag; named ChatGPT windows already use separate local state'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from app' -l rebuild -d 'Compatibility no-op; the signed app is never cloned'
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from init' -l share-with -r -a '(codex-profile list 2>/dev/null) default personal work' -d 'Link the configuration allowlist from another profile'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from clone-config' -a '(codex-profile list 2>/dev/null) default personal work'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from completions shell-init' -a 'bash zsh fish'
 end

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -25,6 +25,10 @@ homes and, on macOS, named ChatGPT windows with separate local state.
   verify whether a CLI login and ChatGPT Desktop window use the same account.
 - The project never reads, copies, prints, parses, uploads, compares, or
   migrates auth tokens or ChatGPT cookies.
+- `init <name> --share-with <source>` creates a real private profile directory
+  and links only existing `config.toml`, instruction files, `rules/`, and
+  `plugins/` entries. Auth, sessions, logs, Desktop data, caches, skills, and
+  connector/app state remain separate.
 - Desktop launch refuses an inherited CODEX_ACCESS_TOKEN so a shell access
   token cannot silently override the selected window.
 - CLI-oriented commands support macOS and Linux. Desktop launching is
@@ -54,6 +58,7 @@ codex-profile doctor
 ```sh
 codex-profile init personal
 codex-profile init work
+codex-profile init personal-2 --share-with personal
 codex-profile login work
 codex-profile cli work exec "review this repo"
 codex-profile app default ~/Dev/main-project
@@ -95,6 +100,20 @@ histories, memories, connectors, plans, limits, or cloud tasks.
   `codex-profile use <profile>` in the current shell.
 - Activation affects subsequent Codex commands in that shell only. It does not
   launch or switch ChatGPT Desktop.
+
+## Linked configuration profiles
+
+Use `codex-profile init <target> --share-with <source>` only when the target
+does not exist and the source is an initialized, real profile directory. The
+target links existing entries from this fixed allowlist: `config.toml`,
+`AGENTS.md`, `AGENTS.override.md`, `instructions.md`,
+`custom-instructions.md`, `rules/`, and `plugins/`.
+
+The target keeps its own `auth.json`, sessions, logs, Electron user data,
+caches, skills, and connector/app state. The command never reads or copies
+authentication data. The links are live, so both profiles see edits to shared
+configuration; review linked files and plugins before using them across trust
+domains.
 
 ## How to answer installation questions
 

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -8,7 +8,7 @@ pkgbase = codex-profile
 	depends = bash
 	source = codex-profile-0.7.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.7.0/bin/codex-profile
 	source = LICENSE-0.7.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.7.0/LICENSE
-	sha256sums = d85f8a3cb479578d7d8cb436daec6c57f36b7a9a139558ed756501896ea58b2b
+	sha256sums = 5333d2fed3bbd9e9c4fe53db259a89815ec93f8c5a81e1bdaa3650a54c757f2c
 	sha256sums = 9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364
 
 pkgname = codex-profile

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -12,7 +12,7 @@ source=(
   "LICENSE-$pkgver::https://raw.githubusercontent.com/Ducksss/codex-profiles/v$pkgver/LICENSE"
 )
 sha256sums=(
-  'd85f8a3cb479578d7d8cb436daec6c57f36b7a9a139558ed756501896ea58b2b'
+  '5333d2fed3bbd9e9c4fe53db259a89815ec93f8c5a81e1bdaa3650a54c757f2c'
   '9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364'
 )
 

--- a/test/codex-profile-test.sh
+++ b/test/codex-profile-test.sh
@@ -879,6 +879,195 @@ test_init_creates_private_profile_home_without_codex() {
   rm -rf "$tmp"
 }
 
+test_init_share_with_links_only_existing_allowlisted_config() {
+  local tmp source_home target_home source_override minimal_source minimal_target
+  tmp="$(mktemp -d)"
+  source_home="$tmp/home/.codex-personal"
+  target_home="$tmp/home/.codex-personal-2"
+  source_override="$source_home/shared-override.md"
+  mkdir -p "$source_home/rules" "$source_home/plugins" \
+    "$source_home/sessions" "$source_home/logs" \
+    "$source_home/electron-user-data" "$source_home/cache" \
+    "$source_home/caches" "$source_home/connectors" \
+    "$source_home/connector-data" "$source_home/apps" \
+    "$source_home/skills"
+  printf 'model = "gpt-5"\n' > "$source_home/config.toml"
+  printf '# Shared agents\n' > "$source_home/AGENTS.md"
+  printf '# Shared override\n' > "$source_override"
+  ln -s "$source_override" "$source_home/AGENTS.override.md"
+  printf '# Legacy instructions\n' > "$source_home/instructions.md"
+  printf '# Legacy shared instructions\n' > "$source_home/custom-instructions.md"
+  printf 'allow_rule = true\n' > "$source_home/rules/default.rules"
+  printf 'plugin\n' > "$source_home/plugins/example.txt"
+  printf '{"token":"source-secret"}\n' > "$source_home/auth.json"
+  printf 'private session\n' > "$source_home/sessions/session.json"
+  printf 'private log\n' > "$source_home/logs/codex.log"
+  printf 'private desktop state\n' > "$source_home/electron-user-data/state"
+  printf 'private cache\n' > "$source_home/cache/state"
+  printf 'private caches\n' > "$source_home/caches/state"
+  printf 'private connector\n' > "$source_home/connectors/state"
+  printf 'private connector data\n' > "$source_home/connector-data/state"
+  printf 'private app data\n' > "$source_home/apps/state"
+  printf 'not allowlisted\n' > "$source_home/skills/example.txt"
+
+  run_cmd env HOME="$tmp/home" CODEX_CLI=/no/such/codex \
+    "$SCRIPT" init personal-2 --share-with personal
+
+  assert_status 0
+  assert_contains "Initialized personal-2 ($target_home)"
+  assert_contains "Sharing configuration with personal ($source_home)"
+  [[ -d "$target_home" && ! -L "$target_home" ]] ||
+    fail "shared init target must be a real directory"
+  [[ "$(mode_of "$target_home")" == "700" ]] ||
+    fail "shared init target is not private"
+
+  local entry
+  for entry in config.toml AGENTS.md AGENTS.override.md instructions.md custom-instructions.md rules plugins; do
+    [[ -L "$target_home/$entry" ]] || fail "shared init did not link $entry"
+    [[ "$(readlink "$target_home/$entry")" == "$source_home/$entry" ]] ||
+      fail "shared init linked $entry to the wrong source"
+  done
+
+  for entry in auth.json sessions logs electron-user-data cache caches connectors connector-data apps skills; do
+    [[ ! -e "$target_home/$entry" && ! -L "$target_home/$entry" ]] ||
+      fail "shared init linked private or non-allowlisted state: $entry"
+  done
+
+  printf '{"token":"target-secret"}\n' > "$target_home/auth.json"
+  [[ "$(cat "$source_home/auth.json")" == '{"token":"source-secret"}' ]] ||
+    fail "target auth write changed source auth"
+
+  minimal_source="$tmp/home/.codex-minimal"
+  minimal_target="$tmp/home/.codex-minimal-2"
+  mkdir -p "$minimal_source"
+  printf 'model = "gpt-5"\n' > "$minimal_source/config.toml"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" init minimal-2 --share-with minimal
+
+  assert_status 0
+  [[ -L "$minimal_target/config.toml" ]] ||
+    fail "minimal shared init did not link existing config.toml"
+  for entry in AGENTS.md AGENTS.override.md instructions.md custom-instructions.md rules plugins; do
+    [[ ! -e "$minimal_target/$entry" && ! -L "$minimal_target/$entry" ]] ||
+      fail "minimal shared init created a dangling link: $entry"
+  done
+
+  rm -rf "$tmp"
+}
+
+test_init_share_with_rejects_invalid_sources_and_usage() {
+  local tmp source_home outside
+  tmp="$(mktemp -d)"
+  source_home="$tmp/home/.codex-personal"
+  outside="$tmp/outside-source"
+  mkdir -p "$source_home" "$outside"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" init personal --share-with personal
+
+  assert_status 1
+  assert_contains "Source and target profiles must be different"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" init personal-2 --share-with missing
+
+  assert_status 1
+  assert_contains "Shared profile source is not initialized"
+  [[ ! -e "$tmp/home/.codex-personal-2" ]] ||
+    fail "missing source created target profile"
+
+  rm -rf "$source_home"
+  ln -s "$outside" "$source_home"
+  run_cmd env HOME="$tmp/home" "$SCRIPT" init personal-2 --share-with personal
+
+  assert_status 1
+  assert_contains "Refusing symlinked shared profile source"
+  [[ ! -e "$tmp/home/.codex-personal-2" ]] ||
+    fail "symlinked source created target profile"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" init personal-2 --share-with
+
+  assert_status 1
+  assert_contains "Usage:"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" init personal-2 --unknown
+
+  assert_status 1
+  assert_contains "Usage:"
+
+  rm -rf "$tmp"
+}
+
+test_init_share_with_refuses_every_existing_target_path() {
+  local tmp source_home target_home
+  tmp="$(mktemp -d)"
+  source_home="$tmp/home/.codex-personal"
+  target_home="$tmp/home/.codex-personal-2"
+  mkdir -p "$source_home" "$target_home"
+  printf 'model = "gpt-5"\n' > "$source_home/config.toml"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" init personal-2 --share-with personal
+
+  assert_status 1
+  assert_contains "Target profile path already exists"
+  [[ -d "$target_home" ]] || fail "shared init removed existing target directory"
+
+  rmdir "$target_home"
+  printf 'existing file\n' > "$target_home"
+  run_cmd env HOME="$tmp/home" "$SCRIPT" init personal-2 --share-with personal
+
+  assert_status 1
+  assert_contains "Target profile path already exists"
+  [[ "$(cat "$target_home")" == "existing file" ]] ||
+    fail "shared init changed existing target file"
+
+  rm -f "$target_home"
+  ln -s "$tmp/missing-target" "$target_home"
+  run_cmd env HOME="$tmp/home" "$SCRIPT" init personal-2 --share-with personal
+
+  assert_status 1
+  assert_contains "Target profile path already exists"
+  [[ -L "$target_home" ]] || fail "shared init removed existing dangling target symlink"
+
+  rm -rf "$tmp"
+}
+
+test_init_share_with_cleans_up_after_link_failure() {
+  local tmp source_home target_home real_ln
+  tmp="$(mktemp -d)"
+  source_home="$tmp/home/.codex-personal"
+  target_home="$tmp/home/.codex-personal-2"
+  real_ln="$(command -v ln)"
+  mkdir -p "$source_home" "$tmp/bin"
+  printf 'model = "gpt-5"\n' > "$source_home/config.toml"
+  printf '# Shared agents\n' > "$source_home/AGENTS.md"
+  cat > "$tmp/bin/ln" <<'FAKE_LN'
+#!/usr/bin/env bash
+count=0
+if [[ -f "$FAKE_LN_COUNT" ]]; then
+  read -r count < "$FAKE_LN_COUNT"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$FAKE_LN_COUNT"
+if [[ "$count" -eq 2 ]]; then
+  exit 73
+fi
+exec "$REAL_LN" "$@"
+FAKE_LN
+  chmod 755 "$tmp/bin/ln"
+
+  run_cmd env HOME="$tmp/home" PATH="$tmp/bin:$PATH" \
+    REAL_LN="$real_ln" FAKE_LN_COUNT="$tmp/ln-count" \
+    "$SCRIPT" init personal-2 --share-with personal
+
+  assert_status 1
+  assert_contains "Cannot link shared entry AGENTS.md"
+  [[ ! -e "$target_home" && ! -L "$target_home" ]] ||
+    fail "shared init left a partially populated target after link failure"
+  [[ -f "$source_home/config.toml" && -f "$source_home/AGENTS.md" ]] ||
+    fail "shared init cleanup changed the source profile"
+
+  rm -rf "$tmp"
+}
+
 test_remove_aborts_when_confirmation_does_not_match() {
   local tmp profile_home
   tmp="$(mktemp -d)"
@@ -1075,6 +1264,7 @@ test_completions_generate_shell_scripts() {
 
   assert_status 0
   assert_contains "--instance"
+  assert_contains "--share-with"
 
   run_cmd "$SCRIPT" completions bash
 
@@ -1088,6 +1278,7 @@ test_completions_generate_shell_scripts() {
   assert_contains "env"
   assert_contains "use"
   assert_contains "shell-init"
+  assert_contains "--share-with"
 
   run_cmd "$SCRIPT" completions zsh
 
@@ -1099,6 +1290,7 @@ test_completions_generate_shell_scripts() {
   assert_contains "--instance"
   assert_contains "app-instance"
   assert_contains "shell-init"
+  assert_contains "--share-with"
 
   run_cmd "$SCRIPT" completions fish
 
@@ -1112,6 +1304,7 @@ test_completions_generate_shell_scripts() {
   assert_contains "-l rebuild"
   assert_contains "app-instance"
   assert_contains "shell-init"
+  assert_contains "-l share-with"
   assert_not_contains "Codex Desktop clone"
   assert_not_contains "Rebuild the app --instance clone"
 }
@@ -1775,6 +1968,10 @@ test_app_propagates_open_failures
 test_doctor_skips_status_when_cli_missing
 test_doctor_reports_desktop_and_cli_when_present
 test_init_creates_private_profile_home_without_codex
+test_init_share_with_links_only_existing_allowlisted_config
+test_init_share_with_rejects_invalid_sources_and_usage
+test_init_share_with_refuses_every_existing_target_path
+test_init_share_with_cleans_up_after_link_failure
 test_remove_aborts_when_confirmation_does_not_match
 test_remove_yes_deletes_profile_home
 test_remove_yes_deletes_profiles_named_like_common_aliases


### PR DESCRIPTION
## Summary

- Add `codex-profile init <target> --share-with <source>` for linked configuration profiles.
- Create the target as a real mode-`700` directory and link only existing allowlisted paths: `config.toml`, Codex instruction files, `rules/`, and `plugins/`.
- Keep `auth.json`, sessions, logs, Electron data, caches, skills, and connector/app state separate.

## Review revisions

- Rebased the PR from its v0.2-era base onto current `main` without restoring removed Desktop clone or global-quit behavior.
- Replaced broad top-level discovery with an explicit seven-path allowlist.
- Added strict source/target validation, dangling-symlink checks, and cleanup after link or permission failures.
- Restored stock macOS Bash 3.2 compatibility by removing the associative-array design.
- Synchronized help, Bash/Zsh/Fish completions, README, `docs/llms.txt`, security guidance, changelog, agent guidance, and AUR metadata.
- Preserved Jacques Marais as the feature commit author.

## Validation

- `make test`
- `make lint`
- `git diff --check`
- Full behavior coverage for the allowlist, missing entries, source symlinks, private state exclusions, existing targets, usage errors, and partial-failure cleanup.

Closes #3
