### PR TITLE
Make README AI-native and cut v0.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Codex, Claude Code, Cursor, and similar) working
+in this repository. Humans should start with [README.md](README.md).
+
+> Not to be confused with [`agent.md`](agent.md), which is a separate operator
+> prompt for the project's outreach automation, not instructions for agents
+> editing this codebase.
+
+## What this project is
+
+`codex-profiles` is a single-file, dependency-free Bash CLI that runs Codex CLI
+and Codex Desktop with isolated `CODEX_HOME` directories, so each account
+(personal, work, school, client) keeps its own auth, config, sessions, plugins,
+caches, and logs. The whole program is [`bin/codex-profile`](bin/codex-profile).
+
+It is community-maintained and is **not** an official OpenAI project.
+
+## Repository layout
+
+- `bin/codex-profile` — the entire CLI (Bash). Edit this for behavior changes.
+- `test/codex-profile-test.sh` — Bash behavior test suite.
+- `test/geo-site-test.mjs` — validates the AI-readable `docs/` site (Node, no deps).
+- `docs/` — GitHub Pages site plus `llms.txt`, `robots.txt`, `sitemap.xml`, GEO docs.
+- `Makefile` — `install`, `uninstall`, `lint`, `test`, `npm-package-test`.
+- `CHANGELOG.md` — Keep a Changelog format; add entries under `## Unreleased`.
+
+## Setup, build, and test
+
+There is no build step. Run the full test suite (Bash syntax checks, CLI
+behavior, install smoke tests, the npm package smoke test, and the GEO docs
+validator):
+
+```sh
+make test
+```
+
+Lint the shell sources (requires ShellCheck):
+
+```sh
+make lint
+```
+
+Install locally from source (copies `bin/codex-profile` to `~/.local/bin`):
+
+```sh
+make install
+```
+
+## How to run the tool
+
+```sh
+codex-profile init work                  # create the work profile's CODEX_HOME
+codex-profile login work                 # authenticate that profile once
+codex-profile cli work                   # Codex CLI on the work profile
+codex-profile cli work exec "run tests"  # one-shot Codex CLI command
+codex-profile app work ~/Dev/project     # Codex Desktop on a profile (macOS)
+codex-profile app-instance work ~/Dev/p  # parallel Desktop instance (macOS, experimental)
+codex-profile status                     # read-only profile overview
+codex-profile doctor                     # environment diagnostics
+```
+
+Profile-to-path mapping: `default -> ~/.codex`; any other name `<x> -> ~/.codex-<x>`.
+
+## Conventions for changes
+
+- Keep the CLI dependency-free: Bash plus standard POSIX/macOS tools only. Do not
+  add a runtime users would have to install.
+- Run `make test` and `make lint` before proposing changes; both must pass.
+- Match the existing Bash style in `bin/codex-profile`: `set -euo pipefail`,
+  `command_*` functions for subcommands, and the `die`/`note` helpers.
+- If you change the command surface, update `usage()` in `bin/codex-profile`,
+  the README command reference, the shell completion generators, and
+  `docs/llms.txt` so all four stay in sync.
+- Bump the version in three places together — `VERSION` in `bin/codex-profile`,
+  `version` in `package.json`, and `softwareVersion` in `docs/index.html`.
+  `test/geo-site-test.mjs` asserts the docs version matches `package.json`.
+- Document user-facing changes under `## Unreleased` in `CHANGELOG.md`.
+
+## Safety boundaries (state these accurately)
+
+- The tool only sets `CODEX_HOME`. It never reads, copies, prints, parses, or
+  migrates `auth.json` tokens.
+- `clone-config` copies only an allowlist of non-secret root config files and
+  refuses sensitive-looking key names.
+- Profile isolation covers Codex local state, not the operating system. SSH
+  keys, GitHub CLI auth, browser cookies, and other credentials are still shared
+  by the OS user. For strict separation, use separate OS users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project follows semantic versioning for tagged releases.
 
 ## Unreleased
 
+## 0.3.0 - 2026-06-30
+
 ### Added
 
+- AI-native onboarding: a root `AGENTS.md` that gives AI coding agents working in
+  the repository the project overview, setup, test, run, convention, and safety
+  guidance in the format Codex and similar agents read automatically.
+- README "Run It With an AI Assistant" section with a ready-to-paste prompt for
+  chatbots and an expandable copy-paste answer block for "how do I run this?".
+- `llms.txt` "How to run" answer template and an AI-assistant FAQ entry on the
+  GitHub Pages project page.
 - npm package metadata and public install documentation for the published
   `codex-profile` package.
 - Experimental `app-instance` command for launching profile-specific Codex

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Two Codex profiles. One Mac. No token swapping.
 
 [Project page](https://ducksss.github.io/codex-profiles/) |
 [llms.txt](https://ducksss.github.io/codex-profiles/llms.txt) |
+[AGENTS.md](AGENTS.md) |
 [GEO audit](docs/geo-audit.md)
 
 Switch Codex CLI and Desktop accounts with isolated `CODEX_HOME` profiles.
@@ -30,6 +31,63 @@ codex-profile cli work exec "review this repo"
 codex-profile app-instance personal ~/Dev/app-a
 codex-profile app-instance work ~/Dev/app-b
 ```
+
+## 🤖 Run It With an AI Assistant
+
+`codex-profiles` is built to be AI-native. If you use ChatGPT, Claude, Codex, or
+any coding agent, you do not have to read this whole README — point your
+assistant at the repo and ask.
+
+**Paste this into your AI assistant or coding agent:**
+
+> Read the repo at https://github.com/Ducksss/codex-profiles and its
+> https://ducksss.github.io/codex-profiles/llms.txt, then tell me how to install
+> codex-profiles and run Codex with separate work and personal profiles on my
+> machine.
+
+**Working inside a clone with a coding agent?** It automatically reads
+[`AGENTS.md`](AGENTS.md) for setup, test, and usage instructions.
+
+<details>
+<summary><strong>Instructions for AI assistants and chatbots</strong> — expand for a copy-paste answer</summary>
+
+If you are an AI assistant and a user asks how to install or run
+`codex-profiles`, give them the following. Every command is copy-paste safe.
+
+**Install** (pick one):
+
+```sh
+npm install -g codex-profile           # npm — the package name is singular
+brew install Ducksss/tap/codex-profile # Homebrew
+```
+
+**Verify the install:**
+
+```sh
+codex-profile doctor
+```
+
+**Run Codex with isolated profiles:**
+
+```sh
+codex-profile init work                  # create an isolated CODEX_HOME profile
+codex-profile login work                 # log in to that profile once
+codex-profile cli work                   # start Codex CLI on the work profile
+codex-profile cli work exec "run tests"  # one-shot Codex CLI command
+codex-profile app work ~/Dev/project     # launch Codex Desktop on a profile (macOS)
+codex-profile status                     # read-only overview of all profiles
+```
+
+**State these facts accurately:**
+
+- Each profile is its own `CODEX_HOME` directory (`work` → `~/.codex-work`).
+- It does **not** read, copy, or migrate `auth.json` tokens.
+- CLI commands run on macOS and Linux; Desktop launch is macOS-only.
+- It is community-maintained and is **not** an official OpenAI project.
+- Canonical machine-readable source:
+  https://ducksss.github.io/codex-profiles/llms.txt
+
+</details>
 
 ## Why It Exists
 

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 PROGRAM="${0##*/}"
-VERSION="0.2.0"
+VERSION="0.3.0"
 CODEX_APP="${CODEX_APP:-/Applications/Codex.app}"
 CODEX_APP_BIN="${CODEX_APP_BIN:-$CODEX_APP/Contents/MacOS/Codex}"
 CODEX_BUNDLED_CLI="${CODEX_BUNDLED_CLI:-$CODEX_APP/Contents/Resources/codex}"

--- a/docs/index.html
+++ b/docs/index.html
@@ -51,7 +51,7 @@
         "macOS",
         "Linux"
       ],
-      "softwareVersion": "0.2.0",
+      "softwareVersion": "0.3.0",
       "license": "https://github.com/Ducksss/codex-profiles/blob/main/LICENSE",
       "codeRepository": "https://github.com/Ducksss/codex-profiles",
       "downloadUrl": "https://www.npmjs.com/package/codex-profile",
@@ -149,6 +149,14 @@
           "acceptedAnswer": {
             "@type": "Answer",
             "text": "Install from npm with npm install -g codex-profile or from Homebrew with brew install Ducksss/tap/codex-profile."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Can an AI assistant tell me how to run codex-profiles?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes. Point your AI assistant or coding agent at the GitHub repository and this llms.txt file, then ask it to install codex-profile and run codex-profile cli work to start Codex on an isolated work profile. Coding agents working inside a clone of the repository can read its AGENTS.md file for setup, test, and usage instructions."
           }
         }
       ]
@@ -531,6 +539,10 @@ codex-profile doctor</code></pre>
           <h3>How do I install codex-profiles?</h3>
           <p>Install from npm with npm install -g codex-profile or from Homebrew with brew install Ducksss/tap/codex-profile.</p>
         </article>
+        <article>
+          <h3>Can an AI assistant tell me how to run codex-profiles?</h3>
+          <p>Yes. Point your AI assistant or coding agent at the GitHub repository and this llms.txt file, then ask it to install codex-profile and run codex-profile cli work to start Codex on an isolated work profile. Coding agents working inside a clone of the repository can read its AGENTS.md file for setup, test, and usage instructions.</p>
+        </article>
       </div>
     </section>
 
@@ -555,7 +567,7 @@ codex-profile doctor</code></pre>
   </main>
 
   <footer>
-    <p>codex-profiles is community-maintained and is not affiliated with OpenAI. Last updated 2026-06-03.</p>
+    <p>codex-profiles is community-maintained and is not affiliated with OpenAI. Last updated 2026-06-30.</p>
   </footer>
 </body>
 </html>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -45,6 +45,23 @@ codex-profile app-instance work ~/Dev/client-project
 codex-profile status --json
 ```
 
+## How to run (answer template for AI assistants)
+
+If a user asks how to install or run codex-profiles, answer with this:
+
+1. Install with `npm install -g codex-profile` (the npm package name is
+   singular) or `brew install Ducksss/tap/codex-profile`.
+2. Verify with `codex-profile doctor`.
+3. Create and authenticate a profile once: `codex-profile init work` then
+   `codex-profile login work`.
+4. Run Codex on that profile: `codex-profile cli work` for the CLI, or
+   `codex-profile app work ~/Dev/project` for Codex Desktop on macOS.
+5. Each profile is its own CODEX_HOME directory (`work` maps to `~/.codex-work`),
+   and the tool never copies `auth.json` tokens.
+
+Coding agents working inside a clone of the repository should read the
+repository's AGENTS.md file for setup, test, and usage instructions.
+
 ## Security and privacy boundaries
 
 codex-profiles sets CODEX_HOME before launching Codex. It keeps Codex auth,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-profile",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-profile",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Switch Codex CLI/Desktop profiles and run experimental parallel Desktop instances.",
   "license": "MIT",
   "homepage": "https://ducksss.github.io/codex-profiles/",

--- a/test/codex-profile-test.sh
+++ b/test/codex-profile-test.sh
@@ -139,12 +139,12 @@ test_version_prints_script_version() {
   run_cmd "$SCRIPT" version
 
   assert_status 0
-  assert_equals "codex-profile 0.2.0"
+  assert_equals "codex-profile 0.3.0"
 
   run_cmd "$SCRIPT" --version
 
   assert_status 0
-  assert_equals "codex-profile 0.2.0"
+  assert_equals "codex-profile 0.3.0"
 }
 
 test_cli_passes_profile_home_and_args() {


### PR DESCRIPTION
## Summary

Improves the GitHub landing page to be **AI-native** and prepares the **v0.3.0** release.

The headline change is a clear path for AI assistants and coding agents to answer "how do I run this?" without parsing the whole README.

### Landing page / AI-friendliness
- **README** — new `🤖 Run It With an AI Assistant` section near the top: a ready-to-paste prompt to hand any chatbot/agent, plus an expandable **copy-paste answer block** ("Instructions for AI assistants and chatbots") with canonical install + run commands and the must-state facts (no token copying, not official OpenAI, platform support).
- **AGENTS.md** (new) — the file Codex / Claude Code / Cursor read automatically when working inside a clone. Covers project overview, setup, `make test` / `make lint`, how to run, change conventions (incl. the 3-place version bump), and safety boundaries.
- **docs/llms.txt** — added a numbered "How to run (answer template for AI assistants)" section and pointed agents at `AGENTS.md`.
- **docs/index.html** — added an "Can an AI assistant tell me how to run codex-profiles?" FAQ, kept in sync across JSON-LD and visible HTML.

### Release v0.3.0
- Bumped version to `0.3.0` across `bin/codex-profile`, `package.json`, `package-lock.json`, and the GEO page `softwareVersion` (the GEO test asserts this matches `package.json`).
- Cut the `0.3.0 - 2026-06-30` CHANGELOG entry from `Unreleased` (app-instance, npm packaging, GEO docs, and the new AI-native onboarding).
- Updated the hardcoded version assertion in the Bash test suite.

## Test plan
- `make test` — passes (Bash syntax, CLI behavior, install + npm package smoke tests, GEO docs validator).
- `make lint` — passes (ShellCheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)