### PR TITLE
ci: publish codex-profile to npm on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # required for npm provenance
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Run smoke tests
+        run: make test
+
+      - name: Verify tag matches package.json (tag pushes only)
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          pkg_version="v$(node -p "require('./package.json').version")"
+          if [ "$pkg_version" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match package.json ($pkg_version)." >&2
+            exit 1
+          fi
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project follows semantic versioning for tagged releases.
 
 ## Unreleased
 
+### Added
+
+- GitHub Actions workflow that publishes the `codex-profile` npm package on
+  `v*` tag pushes (or manual dispatch), gated on `make test` and verifying the
+  tag matches `package.json`, with npm provenance.
+
 ## 0.3.0 - 2026-06-30
 
 ### Added


### PR DESCRIPTION
## Summary

npm is currently stuck on **0.2.0** while the repo source and the GitHub release are on **0.3.0** — there was no publish automation. This adds a workflow so npm tracks the tags automatically.

`.github/workflows/publish.yml`:
- Triggers on **`v*` tag pushes** and **manual `workflow_dispatch`**.
- Gates the publish on `make test`.
- On tag pushes, **verifies the tag matches `package.json`** before publishing (prevents mismatched releases).
- Publishes with **npm provenance** (`id-token: write`) and `--access public`.

## Required before it can publish
Add a repository secret **`NPM_TOKEN`** = an npm **automation** access token for an account with publish rights to `codex-profile` (Settings → Secrets and variables → Actions). Automation tokens bypass 2FA prompts, which is required for CI publishing.

## Publishing 0.3.0
The `v0.3.0` tag already existed before this workflow, so it won't auto-fire for 0.3.0. After merging + adding the secret, publish 0.3.0 by either:
- running this workflow via **"Run workflow"** (workflow_dispatch), or
- re-pushing the tag: `git push origin :v0.3.0 && git push origin v0.3.0`.

Future tags (`v0.3.1`, …) publish automatically.

## Test plan
- `make test` passes locally; the workflow re-runs it as the publish gate.
- YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)