### PR TITLE
release(fix): finalize v0.7.0 distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 # Releases are deliberate. Prepare and review every version change on main,
 # then dispatch this workflow with that exact tracked version. The workflow
 # validates repository state; it never edits or commits a version bump.
+# Immutable releases are an operator prerequisite for every live dispatch.
+# The workflow token cannot read that Administration-only repository setting,
+# so the operator verifies it before dispatch; final verification enforces the
+# immutable result.
 
 on:
   workflow_dispatch:
@@ -677,7 +681,7 @@ jobs:
             create_error="$tmp/release-create.err"
             release_create_succeeded=false
             if gh release create "$TAG" --title "codex-profile $TAG" --generate-notes \
-              2> "$create_error"; then
+              --latest --verify-tag 2> "$create_error"; then
               release_create_succeeded=true
             fi
 
@@ -719,7 +723,8 @@ jobs:
           trap 'rm -rf "$tmp"' EXIT
           release_json="$tmp/release.json"
           gh release view "$TAG" \
-            --json tagName,isDraft,isPrerelease,publishedAt > "$release_json"
+            --json tagName,isDraft,isPrerelease,publishedAt,body,isImmutable \
+            > "$release_json"
           node - "$TAG" "$release_json" <<'NODE'
           const fs = require('fs');
           const [, , expectedTag, file] = process.argv;
@@ -736,7 +741,44 @@ jobs:
           if (typeof release.publishedAt !== 'string' || release.publishedAt.length === 0) {
             throw new Error(`GitHub Release ${expectedTag} has no publication time`);
           }
+          if (release.isImmutable !== true) {
+            throw new Error(`GitHub Release ${expectedTag} is not immutable`);
+          }
+          if (typeof release.body !== 'string' || release.body.trim().length === 0) {
+            throw new Error(`GitHub Release ${expectedTag} has no release notes`);
+          }
           NODE
+
+          latest_json="$tmp/latest-release.json"
+          latest_error="$tmp/latest-release.err"
+          latest_verified=false
+          for attempt in {1..5}; do
+            : > "$latest_error"
+            if gh api "/repos/$GITHUB_REPOSITORY/releases/latest" \
+              > "$latest_json" 2> "$latest_error" \
+              && node - "$TAG" "$latest_json" 2>> "$latest_error" <<'NODE'
+          const fs = require('fs');
+          const [, , expectedTag, file] = process.argv;
+          const latestRelease = JSON.parse(fs.readFileSync(file, 'utf8'));
+          if (latestRelease.tag_name !== expectedTag) {
+            throw new Error(
+              `GitHub latest release reported ${latestRelease.tag_name}; expected ${expectedTag}`,
+            );
+          }
+          NODE
+            then
+              latest_verified=true
+              break
+            fi
+            if [[ "$attempt" -lt 5 ]]; then
+              sleep "$((attempt * 2))"
+            fi
+          done
+          [[ "$latest_verified" == "true" ]] || {
+            cat "$latest_error" >&2
+            echo "GitHub latest release did not resolve to $TAG after 5 attempts." >&2
+            exit 1
+          }
 
       - name: Verify public standalone installer
         if: ${{ ! inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -738,6 +738,54 @@ jobs:
           }
           NODE
 
+      - name: Verify public standalone installer
+        if: ${{ ! inputs.dry_run }}
+        env:
+          TAG: ${{ needs.verify.outputs.tag }}
+          V: ${{ needs.verify.outputs.version }}
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          trap 'rm -rf "$tmp"' EXIT
+          installer="$tmp/install.sh"
+          curl --retry 3 --retry-all-errors -fsSL \
+            "https://raw.githubusercontent.com/Ducksss/codex-profiles/$TAG/install.sh" \
+            -o "$installer"
+
+          verify_installed_prefix() {
+            local prefix="$1"
+            local canonical="$prefix/bin/codex-profile"
+            local alias="$prefix/bin/codex-profiles"
+            local canonical_output
+            local alias_output
+
+            [[ -f "$canonical" && -x "$canonical" && ! -L "$canonical" ]] || return 1
+            [[ -L "$alias" ]] || return 1
+            [[ "$(readlink "$alias")" == "codex-profile" ]] || return 1
+            canonical_output="$("$canonical" version 2>&1)" || return 1
+            [[ "$canonical_output" == "codex-profile $V" ]] || return 1
+            alias_output="$("$alias" version 2>&1)" || return 1
+            [[ "$alias_output" == "codex-profile $V" ]] || return 1
+          }
+
+          standalone_verified=false
+          for attempt in {1..5}; do
+            prefix="$(mktemp -d "$tmp/prefix-$attempt.XXXXXX")"
+            if env -u CODEX_PROFILE_VERSION CODEX_PROFILE_PREFIX="$prefix" sh "$installer" \
+              && verify_installed_prefix "$prefix"; then
+              standalone_verified=true
+              break
+            fi
+            rm -rf "$prefix"
+            if [[ "$attempt" -lt 5 ]]; then
+              sleep "$((attempt * 2))"
+            fi
+          done
+          [[ "$standalone_verified" == "true" ]] || {
+            echo "The public standalone installer did not install codex-profile $V after 5 attempts." >&2
+            exit 1
+          }
+
       - name: Update Homebrew tap
         if: ${{ ! inputs.dry_run }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project follows semantic versioning for tagged releases.
 
 ## Unreleased
 
-## 0.7.0 - 2026-07-12
+## 0.7.0 - 2026-07-13
 
 ### Added
 
@@ -26,6 +26,10 @@ and this project follows semantic versioning for tagged releases.
   `packaging/aur/`. The installer and flake track the current version
   automatically (the flake reads `package.json`), so they add no release drift;
   `install.sh` is covered by ShellCheck in CI.
+- A permanent [AUR publication and update runbook](packaging/aur/README.md)
+  covering dedicated credentials, immutable tagged inputs, clean non-root Arch
+  builds, metadata and alias validation, first publication, subsequent updates,
+  and public post-push verification.
 
 ### Changed
 
@@ -61,7 +65,8 @@ and this project follows semantic versioning for tagged releases.
   require a strict, sanitized signed-app version/bundle attestation,
   preflight the npm owner identity and reported GitHub account access, recheck
   main and tag state immediately before tagging, and verify the published npm
-  aliases with bounded registry retries, the exact GitHub Release tag, and a
+  aliases with bounded registry retries, the exact GitHub Release tag, the
+  public standalone installer's latest-release path in a fresh prefix, and a
   newly dispatched Pages run and version; external AUR publication remains a
   maintainer action.
 - Split default release verification into a credentialless, read-only job and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,10 +65,10 @@ and this project follows semantic versioning for tagged releases.
   require a strict, sanitized signed-app version/bundle attestation,
   preflight the npm owner identity and reported GitHub account access, recheck
   main and tag state immediately before tagging, and verify the published npm
-  aliases with bounded registry retries, the exact GitHub Release tag, the
-  public standalone installer's latest-release path in a fresh prefix, and a
-  newly dispatched Pages run and version; external AUR publication remains a
-  maintainer action.
+  aliases with bounded registry retries, the exact immutable GitHub Release as
+  latest with non-empty notes, the public standalone installer's latest-release
+  path in a fresh prefix, and a newly dispatched Pages run and version; external
+  AUR publication remains a maintainer action.
 - Split default release verification into a credentialless, read-only job and
   live publication into a separately gated write job that revalidates
   `origin/main` and remote tag state. Registry, tag, and GitHub Release lookups

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,11 +110,17 @@ actual npm publish and tap push remain the authoritative write checks.
 
 After publication, the workflow retries npm installation with bounded backoff
 into a fresh prefix and checks `help` and `version` through both command aliases.
-It then verifies the exact GitHub Release tag, requires a newly created Pages
-run from that immutable tag to succeed, and polls the public site for the exact
-visible version. Homebrew formula validation completes before the tap push.
-Tracked AUR metadata and tagged files are validated fail-closed here, but
-publication to the external AUR repository remains a maintainer action.
+It then verifies the exact GitHub Release tag, downloads `install.sh` from that
+immutable tag, and exercises its public `releases/latest` path in fresh prefixes
+until both aliases report the exact version and the plural alias is the expected
+relative symlink. The workflow also requires a newly created Pages run from the
+tag to succeed and polls the public site for the exact visible version. Homebrew
+formula validation completes before the tap push. Tracked AUR metadata and
+tagged files are validated fail-closed here, but publication to the external
+AUR repository remains a maintainer action.
+Maintainers performing that handoff must follow the
+[AUR publication and update runbook](packaging/aur/README.md), including its
+dedicated-key, immutable-tag, clean-build, and public-verification requirements.
 
 ## Pull requests
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ uninstall:
 
 lint:
 	shellcheck bin/codex-profile scripts/update-homebrew-formula test/codex-profile-test.sh test/install-script-test.sh test/makefile-smoke-test.sh test/package-metadata-test.sh test/release-helper-test.sh test/release-workflow-test.sh install.sh
+	@set -eu; runbook_shell="$$(mktemp)"; \
+		trap 'rm -f "$$runbook_shell"' EXIT HUP INT TERM; \
+		node test/aur-runbook-test.mjs --extract > "$$runbook_shell"; \
+		shellcheck "$$runbook_shell"
 
 test:
 	bash -n bin/codex-profile
@@ -33,6 +37,7 @@ test:
 	sh -n install.sh
 	bash test/install-script-test.sh
 	bash test/release-workflow-test.sh
+	node test/aur-runbook-test.mjs
 	node test/geo-site-test.mjs
 	bash test/package-metadata-test.sh
 	bash test/release-helper-test.sh

--- a/docs/geo-audit.md
+++ b/docs/geo-audit.md
@@ -12,7 +12,7 @@ Pages site in `docs/`.
 | Priority URLs return static content | Implemented after deployment | The homepage, `llms.txt`, and sitemap require no client rendering. |
 | Pages are indexable | Implemented | The homepage uses `index,follow` and unrestricted snippet directives. |
 | Canonical URL is stable | Implemented | The site keeps `https://ducksss.github.io/codex-profiles/`; the v0.7 migration does not rebrand or move it. |
-| Sitemap is current | Implemented | The sitemap lists the canonical homepage and LLM summary with 2026-07-12 modification dates. |
+| Sitemap is current | Implemented | The sitemap lists the canonical homepage and LLM summary with 2026-07-13 modification dates. |
 | Stale authenticated media avoided | Implemented | Primary docs no longer embed the pre-integration Codex app screenshot or video. |
 
 ## Structured Data and Machine Understanding
@@ -35,7 +35,7 @@ Pages site in `docs/`.
 | Commands and tables | Implemented | The page contains install commands, a scope table, mappings, and citation-ready facts. |
 | Primary contract is explicit | Implemented | Named Desktop profiles apply across Chat, Work, and Codex; CLI/login/env/use stay Codex-only. |
 | Non-claims are explicit | Implemented | The page says account equality is unverified and local paths do not control server-side ChatGPT data. |
-| Facts current | Implemented | Version, package name, URLs, platforms, behavior, and dates reflect the v0.7.0 contract as of 2026-07-12. |
+| Facts current | Implemented | Version, package name, URLs, platforms, behavior, and dates reflect the v0.7.0 contract as of 2026-07-13. |
 
 ## Entity, Trust, and Brand Authority
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -87,7 +87,7 @@
       "url": "https://ducksss.github.io/codex-profiles/",
       "name": "codex-profiles - Named Codex homes and ChatGPT desktop windows",
       "description": "A machine-readable product page for codex-profiles and its separate Codex-local and ChatGPT Desktop scopes.",
-      "dateModified": "2026-07-12",
+      "dateModified": "2026-07-13",
       "isPartOf": {
         "@id": "https://ducksss.github.io/codex-profiles/#website"
       },
@@ -894,7 +894,7 @@ codex-profile doctor</code></pre>
 
   <footer>
     <div class="wrap">
-      <p>codex-profiles is community-maintained and is not affiliated with OpenAI. Last updated 2026-07-12.</p>
+      <p>codex-profiles is community-maintained and is not affiliated with OpenAI. Last updated 2026-07-13.</p>
       <nav aria-label="Footer links">
         <a href="https://github.com/Ducksss/codex-profiles">GitHub</a>
         <a href="https://ducksss.github.io/codex-profiles/llms.txt">llms.txt</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,7 +6,7 @@ homes and, on macOS, named ChatGPT windows with separate local state.
 ## Primary facts for AI answers
 
 - The project and repository remain named `codex-profiles`.
-- The current release is `0.7.0`, dated 2026-07-12.
+- The current release is `0.7.0`, dated 2026-07-13.
 - The npm package is `codex-profile` (singular).
 - Installed commands are `codex-profile` and `codex-profiles`.
 - `default` maps to `~/.codex`; every other valid name `<x>` maps to

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ducksss.github.io/codex-profiles/</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ducksss.github.io/codex-profiles/llms.txt</loc>
-    <lastmod>2026-07-12</lastmod>
+    <lastmod>2026-07-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -1,0 +1,333 @@
+# AUR publication and update runbook
+
+The GitHub release workflow validates the tracked Arch package, but it does not
+hold AUR credentials or write to the external AUR Git repository. A maintainer
+must use this runbook after the immutable upstream release tag exists. The same
+fail-closed staging and validation steps apply to the first publication and to
+every later update.
+
+Run the commands in one dedicated Bash shell from a clean clone of
+`Ducksss/codex-profiles`. Stop on any unexpected output, metadata difference,
+repository history, or package content. Never repair tagged files directly in
+the AUR clone; fix the source repository and publish a new release instead.
+
+## Prerequisites and credential boundary
+
+The maintainer needs:
+
+- an AUR account with its email address confirmed;
+- `git`, OpenSSH, `curl`, `jq`, Docker, and a running Docker daemon;
+- permission to pull and run the official `archlinux:base-devel` image; and
+- the already-published, immutable upstream tag being handed to AUR.
+
+Use a dedicated, passphrase-protected Ed25519 key for AUR publication. The
+private key is local maintainer material: **never** put it in this repository,
+a GitHub Actions secret, an issue or pull request, chat, shell output, or a
+shared artifact. GitHub Actions intentionally has no AUR credential. Only the
+public `.pub` file belongs in the AUR account's SSH Public Key field.
+
+Create the key once outside every repository:
+
+```bash
+umask 077
+mkdir -p "$HOME/.ssh"
+ssh-keygen -t ed25519 -a 100 \
+  -f "$HOME/.ssh/aur_codex_profile_ed25519" \
+  -C "AUR codex-profile"
+chmod 600 "$HOME/.ssh/aur_codex_profile_ed25519"
+```
+
+Register the contents of
+`~/.ssh/aur_codex_profile_ed25519.pub` in the AUR account. Do not copy or
+display the private file. On the first SSH connection, compare the presented
+`aur.archlinux.org` host-key fingerprint with the current official AUR
+documentation before accepting it.
+
+Force every AUR Git operation to use only this identity:
+
+```bash
+export AUR_SSH_KEY="$HOME/.ssh/aur_codex_profile_ed25519"
+[[ -f "$AUR_SSH_KEY" && ! -L "$AUR_SSH_KEY" ]]
+export GIT_SSH_COMMAND="ssh -i $AUR_SSH_KEY -o IdentitiesOnly=yes"
+```
+
+`IdentitiesOnly=yes` prevents an agent or unrelated default key from silently
+selecting a different AUR account.
+
+## Select and extract the immutable release
+
+Set the exact upstream version and Arch package release. The initial
+publication uses `0.7.0-1`; later source releases normally reset `PKGREL` to
+`1`.
+
+```bash
+set -euo pipefail
+
+export PACKAGE_NAME=codex-profile
+export VERSION=0.7.0
+export PKGREL=1
+export TAG="v$VERSION"
+export EXPECTED_AUR_VERSION="$VERSION-$PKGREL"
+export REPO_ROOT="$(git rev-parse --show-toplevel)"
+export WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/codex-profile-aur.XXXXXX")"
+export EXTRACT_DIR="$WORK_DIR/tag"
+export RELEASE_DIR="$WORK_DIR/release"
+export AUR_DIR="$WORK_DIR/aur"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+[[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ]]
+git -C "$REPO_ROOT" fetch --no-tags origin \
+  "refs/tags/$TAG:refs/tags/$TAG"
+[[ "$(git -C "$REPO_ROOT" cat-file -t "$TAG")" == tag ]]
+git -C "$REPO_ROOT" cat-file -e "$TAG^{commit}"
+
+mkdir -p "$EXTRACT_DIR" "$RELEASE_DIR"
+git -C "$REPO_ROOT" archive --format=tar "$TAG" -- \
+  packaging/aur/PKGBUILD packaging/aur/.SRCINFO LICENSE \
+  | tar -xf - -C "$EXTRACT_DIR"
+cp "$EXTRACT_DIR/packaging/aur/PKGBUILD" "$RELEASE_DIR/PKGBUILD"
+cp "$EXTRACT_DIR/packaging/aur/.SRCINFO" "$RELEASE_DIR/.SRCINFO"
+cp "$EXTRACT_DIR/LICENSE" "$RELEASE_DIR/LICENSE"
+chmod 0644 "$RELEASE_DIR/PKGBUILD" "$RELEASE_DIR/.SRCINFO" \
+  "$RELEASE_DIR/LICENSE"
+
+grep -Fx "pkgname=$PACKAGE_NAME" "$RELEASE_DIR/PKGBUILD"
+grep -Fx "pkgver=$VERSION" "$RELEASE_DIR/PKGBUILD"
+grep -Fx "pkgrel=$PKGREL" "$RELEASE_DIR/PKGBUILD"
+grep -Fx $'\tpkgver = '"$VERSION" "$RELEASE_DIR/.SRCINFO"
+grep -Fx $'\tpkgrel = '"$PKGREL" "$RELEASE_DIR/.SRCINFO"
+grep -F "v$VERSION/bin/codex-profile" "$RELEASE_DIR/PKGBUILD"
+grep -F "v$VERSION/LICENSE" "$RELEASE_DIR/PKGBUILD"
+```
+
+The annotated-tag check deliberately rejects a branch, working-tree file, or
+lightweight replacement as the publication source. The archive step extracts
+`PKGBUILD`, `.SRCINFO`, and `LICENSE` from that tag rather than from `main`.
+
+## Validate in a clean Arch container
+
+Define this validator once in the same shell. It installs build tooling as
+container root, then runs every `makepkg` and `namcap` operation as the
+unprivileged `builder` user. It regenerates `.SRCINFO`, verifies pinned source
+checksums, performs a clean build, and inspects the resulting package rather
+than trusting metadata alone.
+
+```bash
+docker pull archlinux:base-devel
+
+validate_aur_tree() {
+  local package_dir="$1"
+  [[ -f "$package_dir/PKGBUILD" ]]
+  [[ -f "$package_dir/.SRCINFO" ]]
+  [[ -f "$package_dir/LICENSE" ]]
+
+  docker run --rm -i \
+    --mount "type=bind,src=$package_dir,dst=/release,readonly" \
+    archlinux:base-devel bash -s <<'CONTAINER'
+set -euo pipefail
+pacman -Syu --noconfirm namcap
+useradd --create-home builder
+install -d -o builder -g builder /build
+cp /release/PKGBUILD /release/.SRCINFO /release/LICENSE /build/
+chown -R builder:builder /build
+
+runuser -u builder -- bash -s <<'BUILDER'
+set -euo pipefail
+cd /build
+
+makepkg --printsrcinfo > .SRCINFO.generated
+diff -u .SRCINFO .SRCINFO.generated
+makepkg --verifysource
+makepkg --cleanbuild --clean --noconfirm
+
+mapfile -t package_files < <(makepkg --packagelist)
+[[ "${#package_files[@]}" -eq 1 ]]
+package_file="${package_files[0]}"
+[[ -f "$package_file" ]]
+
+namcap PKGBUILD | tee namcap-pkgbuild.log
+namcap "$package_file" | tee namcap-package.log
+if grep -Eq '(^|[[:space:]])E:' \
+  namcap-pkgbuild.log namcap-package.log; then
+  echo 'namcap reported an error' >&2
+  exit 1
+fi
+
+package_root="$(mktemp -d)"
+trap 'rm -rf "$package_root"' EXIT
+bsdtar -xf "$package_file" -C "$package_root"
+canonical="$package_root/usr/bin/codex-profile"
+alias="$package_root/usr/bin/codex-profiles"
+version="$(sed -n 's/^pkgver=//p' PKGBUILD)"
+
+[[ -x "$canonical" ]]
+[[ -L "$alias" ]]
+[[ "$(readlink "$alias")" == codex-profile ]]
+[[ -f "$package_root/usr/share/licenses/codex-profile/LICENSE" ]]
+CODEX_PROFILE_NO_UPDATE_CHECK=1 "$canonical" version \
+  | grep -Fx "codex-profile $version"
+CODEX_PROFILE_NO_UPDATE_CHECK=1 "$alias" version \
+  | grep -Fx "codex-profile $version"
+BUILDER
+CONTAINER
+}
+
+validate_aur_tree "$RELEASE_DIR"
+```
+
+Review every `namcap` warning printed by the container. All errors and all
+actionable warnings must be resolved in the source repository and a new tag;
+do not patch the extracted release or waive an unexplained result.
+
+## First publication
+
+Before creating `codex-profile`, prove that the name is unclaimed through the
+AUR RPC. A nonzero result means stop: do not overwrite, adopt, or impersonate
+an existing package.
+
+```bash
+rpc_payload="$(
+  curl -fsS --get \
+    --data-urlencode "arg[]=$PACKAGE_NAME" \
+    https://aur.archlinux.org/rpc/v5/info
+)"
+jq -e '.resultcount == 0 and (.results | length == 0)' \
+  <<<"$rpc_payload" >/dev/null
+```
+
+Clone the package's SSH URL. A legitimate first-publication clone is an unborn
+`master` branch with no commit and no tracked or untracked content. This check
+also closes the race between the RPC lookup and clone. **Stop immediately** if
+any history or content appears.
+
+```bash
+git clone "ssh://aur@aur.archlinux.org/$PACKAGE_NAME.git" "$AUR_DIR"
+[[ "$(git -C "$AUR_DIR" symbolic-ref --short HEAD)" == master ]]
+if git -C "$AUR_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
+  echo 'AUR repository unexpectedly has history; stopping' >&2
+  exit 1
+fi
+[[ -z "$(git -C "$AUR_DIR" status --short --untracked-files=all)" ]]
+```
+
+Continue at [Commit and push `master`](#commit-and-push-master).
+
+## Updating an existing package
+
+For an update, require an existing exact package result before cloning. Then
+inspect the AUR history before changing anything. Stop if the history, package
+base, remote, or current maintainer state is not the expected continuation of
+the previously published package.
+
+```bash
+rpc_payload="$(
+  curl -fsS --get \
+    --data-urlencode "arg[]=$PACKAGE_NAME" \
+    https://aur.archlinux.org/rpc/v5/info
+)"
+jq -e --arg name "$PACKAGE_NAME" '
+  .resultcount == 1 and
+  .results[0].Name == $name and
+  .results[0].PackageBase == $name
+' <<<"$rpc_payload" >/dev/null
+
+git clone "ssh://aur@aur.archlinux.org/$PACKAGE_NAME.git" "$AUR_DIR"
+[[ "$(git -C "$AUR_DIR" branch --show-current)" == master ]]
+git -C "$AUR_DIR" rev-parse --verify HEAD >/dev/null
+[[ -z "$(git -C "$AUR_DIR" status --porcelain)" ]]
+git -C "$AUR_DIR" remote -v
+git -C "$AUR_DIR" log --oneline --decorate -10
+```
+
+The remote and history lines are a mandatory manual review gate. They are not
+an invitation to force-push, reset, or rewrite unexpected AUR history.
+
+## Commit and push `master`
+
+Copy only the three tag-extracted files. Configure the AUR clone—not the global
+Git configuration—with the public maintainer identity `Ducksss` and the GitHub
+noreply address.
+
+```bash
+cp "$RELEASE_DIR/PKGBUILD" "$AUR_DIR/PKGBUILD"
+cp "$RELEASE_DIR/.SRCINFO" "$AUR_DIR/.SRCINFO"
+cp "$RELEASE_DIR/LICENSE" "$AUR_DIR/LICENSE"
+chmod 0644 "$AUR_DIR/PKGBUILD" "$AUR_DIR/.SRCINFO" "$AUR_DIR/LICENSE"
+
+cmp "$RELEASE_DIR/PKGBUILD" "$AUR_DIR/PKGBUILD"
+cmp "$RELEASE_DIR/.SRCINFO" "$AUR_DIR/.SRCINFO"
+cmp "$RELEASE_DIR/LICENSE" "$AUR_DIR/LICENSE"
+
+git -C "$AUR_DIR" config user.name "Ducksss"
+git -C "$AUR_DIR" config user.email \
+  "58126222+Ducksss@users.noreply.github.com"
+git -C "$AUR_DIR" add PKGBUILD .SRCINFO LICENSE
+git -C "$AUR_DIR" diff --cached --check
+git -C "$AUR_DIR" status --short
+git -C "$AUR_DIR" diff --cached
+```
+
+Read the complete staged diff. It must match the tag exactly and contain no
+key, generated package, source archive, log, or unrelated file. For an update,
+an empty diff means the version is already published; do not create an empty
+commit.
+
+```bash
+[[ -n "$(git -C "$AUR_DIR" diff --cached --name-only)" ]]
+git -C "$AUR_DIR" commit -m "$PACKAGE_NAME $EXPECTED_AUR_VERSION"
+export PUSHED_COMMIT="$(git -C "$AUR_DIR" rev-parse HEAD)"
+git -C "$AUR_DIR" push origin master
+```
+
+Never use `--force`, amend a published AUR commit, or push a branch other than
+`master`.
+
+## Verify the public package
+
+The publication is incomplete until both the AUR RPC and an anonymous public
+clone expose the pushed version. This poll allows a short RPC propagation
+delay, but it fails if the exact `0.7.0-1` postcondition is not reached.
+
+```bash
+rpc_verified=false
+for attempt in {1..12}; do
+  rpc_payload="$(
+    curl -fsS --get \
+      --data-urlencode "arg[]=$PACKAGE_NAME" \
+      https://aur.archlinux.org/rpc/v5/info
+  )"
+  if jq -e \
+    --arg name "$PACKAGE_NAME" \
+    --arg version "$EXPECTED_AUR_VERSION" '
+      .resultcount == 1 and
+      .results[0].Name == $name and
+      .results[0].PackageBase == $name and
+      .results[0].Version == $version
+    ' <<<"$rpc_payload" >/dev/null; then
+    rpc_verified=true
+    break
+  fi
+  sleep 10
+done
+[[ "$rpc_verified" == true ]]
+[[ "$EXPECTED_AUR_VERSION" == 0.7.0-1 || "$VERSION" != 0.7.0 ]]
+```
+
+Finally, clone over public HTTPS into a new directory, require the exact pushed
+commit and tagged files, and repeat the complete clean Arch build and alias
+inspection against what anonymous users receive:
+
+```bash
+export PUBLIC_DIR="$WORK_DIR/public"
+git clone "https://aur.archlinux.org/$PACKAGE_NAME.git" "$PUBLIC_DIR"
+[[ "$(git -C "$PUBLIC_DIR" branch --show-current)" == master ]]
+[[ "$(git -C "$PUBLIC_DIR" rev-parse HEAD)" == "$PUSHED_COMMIT" ]]
+cmp "$RELEASE_DIR/PKGBUILD" "$PUBLIC_DIR/PKGBUILD"
+cmp "$RELEASE_DIR/.SRCINFO" "$PUBLIC_DIR/.SRCINFO"
+cmp "$RELEASE_DIR/LICENSE" "$PUBLIC_DIR/LICENSE"
+validate_aur_tree "$PUBLIC_DIR"
+```
+
+Only after the RPC reports the expected version and the anonymous clone builds
+with both working commands and the relative
+`codex-profiles -> codex-profile` symlink is the AUR handoff complete.

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -6,10 +6,12 @@ must use this runbook after the immutable upstream release tag exists. The same
 fail-closed staging and validation steps apply to the first publication and to
 every later update.
 
-Run the commands in one dedicated Bash shell from a clean clone of
-`Ducksss/codex-profiles`. Stop on any unexpected output, metadata difference,
-repository history, or package content. Never repair tagged files directly in
-the AUR clone; fix the source repository and publish a new release instead.
+Except for the one-time key bootstrap, run the commands in one dedicated Bash
+shell from a clean clone of `Ducksss/codex-profiles`. Start at the credential
+verification block when the dedicated key already exists. Stop on any
+unexpected output, metadata difference, repository history, identity, owner,
+or package content. Never repair tagged files directly in the AUR clone; fix
+the source repository and publish a new release instead.
 
 ## Prerequisites and credential boundary
 
@@ -29,30 +31,72 @@ public `.pub` file belongs in the AUR account's SSH Public Key field.
 Create the key once outside every repository:
 
 ```bash
+set -euo pipefail
 umask 077
 mkdir -p "$HOME/.ssh"
+AUR_SSH_KEY="$HOME/.ssh/aur_codex_profile_ed25519"
+if [[ -e "$AUR_SSH_KEY" || -L "$AUR_SSH_KEY" ]]; then
+  echo "refusing to overwrite existing AUR key: $AUR_SSH_KEY" >&2
+  exit 1
+fi
 ssh-keygen -t ed25519 -a 100 \
-  -f "$HOME/.ssh/aur_codex_profile_ed25519" \
+  -f "$AUR_SSH_KEY" \
   -C "AUR codex-profile"
-chmod 600 "$HOME/.ssh/aur_codex_profile_ed25519"
+if [[ ! -f "$AUR_SSH_KEY" || -L "$AUR_SSH_KEY" ]]; then
+  echo 'ssh-keygen did not create the expected regular private-key file' >&2
+  exit 1
+fi
+if [[ ! -f "$AUR_SSH_KEY.pub" || ! -s "$AUR_SSH_KEY.pub" || -L "$AUR_SSH_KEY.pub" ]]; then
+  echo 'ssh-keygen did not create the expected regular public-key file' >&2
+  exit 1
+fi
+chmod 600 "$AUR_SSH_KEY"
+chmod 0644 "$AUR_SSH_KEY.pub"
 ```
 
 Register the contents of
 `~/.ssh/aur_codex_profile_ed25519.pub` in the AUR account. Do not copy or
-display the private file. On the first SSH connection, compare the presented
-`aur.archlinux.org` host-key fingerprint with the current official AUR
-documentation before accepting it.
+display the private file.
 
-Force every AUR Git operation to use only this identity:
+Create `~/.ssh/aur_codex_profile_known_hosts` as a dedicated host-key file.
+Obtain the current `aur.archlinux.org` host key through a trusted channel,
+compare its fingerprint with the current fingerprint published on the
+[official AUR homepage](https://aur.archlinux.org/), and only then install the
+verified public host-key line in that file. Do not rely on an interactive first
+connection or an unverified `ssh-keyscan` result. This file must contain only
+the deliberately verified AUR host key; do not point the runbook at the user's
+general `known_hosts` file.
+
+Start the dedicated publication shell by enabling strict mode and proving that
+both credential paths are regular files. This explicit failure path matters in
+interactive shells, where a bare false predicate would otherwise continue:
 
 ```bash
+set -euo pipefail
 export AUR_SSH_KEY="$HOME/.ssh/aur_codex_profile_ed25519"
-[[ -f "$AUR_SSH_KEY" && ! -L "$AUR_SSH_KEY" ]]
-export GIT_SSH_COMMAND="ssh -i $AUR_SSH_KEY -o IdentitiesOnly=yes"
+export AUR_KNOWN_HOSTS="$HOME/.ssh/aur_codex_profile_known_hosts"
+if [[ ! -f "$AUR_SSH_KEY" || -L "$AUR_SSH_KEY" ]]; then
+  echo "missing regular AUR private key: $AUR_SSH_KEY" >&2
+  exit 1
+fi
+if [[ ! -f "$AUR_SSH_KEY.pub" || ! -s "$AUR_SSH_KEY.pub" || -L "$AUR_SSH_KEY.pub" ]]; then
+  echo "missing regular AUR public key: $AUR_SSH_KEY.pub" >&2
+  exit 1
+fi
+if [[ ! -f "$AUR_KNOWN_HOSTS" || ! -s "$AUR_KNOWN_HOSTS" || -L "$AUR_KNOWN_HOSTS" ]]; then
+  echo "missing verified AUR known_hosts file: $AUR_KNOWN_HOSTS" >&2
+  exit 1
+fi
+if ! ssh-keygen -F aur.archlinux.org -f "$AUR_KNOWN_HOSTS" >/dev/null; then
+  echo 'verified known_hosts has no aur.archlinux.org entry' >&2
+  exit 1
+fi
 ```
 
-`IdentitiesOnly=yes` prevents an agent or unrelated default key from silently
-selecting a different AUR account.
+The SSH wrapper created below also uses `-F /dev/null`, `IdentitiesOnly=yes`,
+`StrictHostKeyChecking=yes`, and the dedicated host-key file. Thus neither an
+SSH agent, another key, the user's SSH configuration, nor an interactive trust
+prompt can silently select a different account or host.
 
 ## Select and extract the immutable release
 
@@ -68,21 +112,158 @@ export VERSION=0.7.0
 export PKGREL=1
 export TAG="v$VERSION"
 export EXPECTED_AUR_VERSION="$VERSION-$PKGREL"
-export REPO_ROOT="$(git rev-parse --show-toplevel)"
-export WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/codex-profile-aur.XXXXXX")"
+export EXPECTED_AUR_MAINTAINER=Ducksss
+export CANONICAL_REPO_URL=https://github.com/Ducksss/codex-profiles.git
+export AUR_GIT_NAME=Ducksss
+export AUR_GIT_EMAIL=58126222+Ducksss@users.noreply.github.com
+
+unset GIT_CONFIG GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT GIT_CONFIG_SYSTEM
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR
+unset GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_TEMPLATE_DIR
+unset GIT_NAMESPACE GIT_SHALLOW_FILE GIT_QUARANTINE_PATH
+unset GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_NO_REPLACE_OBJECTS=1
+
+REPO_ROOT=
+if ! REPO_ROOT="$(git rev-parse --show-toplevel)"; then
+  echo 'run this from a clean codex-profiles Git clone' >&2
+  exit 1
+fi
+if [[ -z "$REPO_ROOT" || "$REPO_ROOT" == *$'\n'* ]]; then
+  echo 'Git returned an unsafe repository root' >&2
+  exit 1
+fi
+[[ -n "$REPO_ROOT" && -d "$REPO_ROOT" ]]
+export REPO_ROOT
+
+origin_url=
+if ! origin_url="$(git -C "$REPO_ROOT" remote get-url origin)"; then
+  echo 'the source clone has no origin remote' >&2
+  exit 1
+fi
+case "$origin_url" in
+  https://github.com/Ducksss/codex-profiles.git | \
+    git@github.com:Ducksss/codex-profiles.git | \
+    ssh://git@github.com/Ducksss/codex-profiles.git) ;;
+  *)
+    echo "origin is not the canonical codex-profiles repository: $origin_url" >&2
+    exit 1
+    ;;
+esac
+
+repo_status=
+if ! repo_status="$(git -C "$REPO_ROOT" status --porcelain)"; then
+  echo 'could not inspect the source clone' >&2
+  exit 1
+fi
+[[ -z "$repo_status" ]]
+
+TEMP_ROOT_INPUT="${TMPDIR:-/tmp}"
+if [[ -z "$TEMP_ROOT_INPUT" || ! -d "$TEMP_ROOT_INPUT" ]]; then
+  echo 'temporary root is empty or does not exist' >&2
+  exit 1
+fi
+TEMP_ROOT=
+if ! TEMP_ROOT="$(cd -- "$TEMP_ROOT_INPUT" && pwd -P)"; then
+  echo 'could not resolve the temporary root' >&2
+  exit 1
+fi
+if [[ -z "$TEMP_ROOT" || ! -d "$TEMP_ROOT" || \
+  "$TEMP_ROOT" == / || "$TEMP_ROOT" == *$'\n'* ]]; then
+  echo 'resolved temporary root is unsafe' >&2
+  exit 1
+fi
+
+WORK_DIR=
+if ! WORK_DIR="$(mktemp -d "$TEMP_ROOT/codex-profile-aur.XXXXXX")"; then
+  echo 'could not create the AUR staging directory' >&2
+  exit 1
+fi
+[[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]
+case "$WORK_DIR" in
+  "$TEMP_ROOT"/codex-profile-aur.*) ;;
+  *)
+    echo "refusing unsafe staging directory: $WORK_DIR" >&2
+    exit 1
+    ;;
+esac
+
+cleanup_work_dir() {
+  case "$WORK_DIR" in
+    "$TEMP_ROOT"/codex-profile-aur.*) rm -rf -- "$WORK_DIR" ;;
+    *) echo "refusing unsafe cleanup path: $WORK_DIR" >&2 ;;
+  esac
+}
+trap cleanup_work_dir EXIT
+
+work_dir_physical=
+if ! work_dir_physical="$(cd -- "$WORK_DIR" && pwd -P)"; then
+  echo 'could not resolve the AUR staging directory' >&2
+  exit 1
+fi
+[[ "$work_dir_physical" == "$WORK_DIR" ]]
+export WORK_DIR
 export EXTRACT_DIR="$WORK_DIR/tag"
 export RELEASE_DIR="$WORK_DIR/release"
 export AUR_DIR="$WORK_DIR/aur"
-trap 'rm -rf "$WORK_DIR"' EXIT
+export TAG_REPO="$WORK_DIR/upstream.git"
+export AUR_SSH_WRAPPER="$WORK_DIR/aur-ssh"
 
-[[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ]]
-git -C "$REPO_ROOT" fetch --no-tags origin \
-  "refs/tags/$TAG:refs/tags/$TAG"
-[[ "$(git -C "$REPO_ROOT" cat-file -t "$TAG")" == tag ]]
-git -C "$REPO_ROOT" cat-file -e "$TAG^{commit}"
+umask 077
+cat >"$AUR_SSH_WRAPPER" <<'AUR_SSH'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${AUR_SSH_KEY:?AUR_SSH_KEY is required}"
+: "${AUR_KNOWN_HOSTS:?AUR_KNOWN_HOSTS is required}"
+exec ssh -F /dev/null \
+  -i "$AUR_SSH_KEY" \
+  -o IdentitiesOnly=yes \
+  -o StrictHostKeyChecking=yes \
+  -o UserKnownHostsFile="$AUR_KNOWN_HOSTS" \
+  "$@"
+AUR_SSH
+chmod 0700 "$AUR_SSH_WRAPPER"
+unset GIT_SSH_COMMAND
+export GIT_SSH="$AUR_SSH_WRAPPER"
+export GIT_SSH_VARIANT=ssh
+"$AUR_SSH_WRAPPER" aur@aur.archlinux.org help >/dev/null
 
 mkdir -p "$EXTRACT_DIR" "$RELEASE_DIR"
-git -C "$REPO_ROOT" archive --format=tar "$TAG" -- \
+git init --bare "$TAG_REPO"
+git -C "$TAG_REPO" fetch --no-tags "$CANONICAL_REPO_URL" \
+  "refs/tags/$TAG:refs/tags/$TAG"
+
+tag_type=
+if ! tag_type="$(git -C "$TAG_REPO" cat-file -t "$TAG")"; then
+  echo "canonical release tag does not exist: $TAG" >&2
+  exit 1
+fi
+[[ "$tag_type" == tag ]]
+git -C "$TAG_REPO" cat-file -e "$TAG^{commit}"
+
+release_payload=
+if ! release_payload="$(
+  curl -fsS \
+    -H 'Accept: application/vnd.github+json' \
+    -H 'X-GitHub-Api-Version: 2022-11-28' \
+    "https://api.github.com/repos/Ducksss/codex-profiles/releases/tags/$TAG"
+)"; then
+  echo "could not fetch the public GitHub Release for $TAG" >&2
+  exit 1
+fi
+[[ -n "$release_payload" ]]
+jq -e --arg tag "$TAG" '
+  .tag_name == $tag and
+  .draft == false and
+  .prerelease == false and
+  .published_at != null and
+  (.published_at | type == "string" and length > 0) and
+  .immutable == true
+' <<<"$release_payload" >/dev/null
+
+git -C "$TAG_REPO" archive --format=tar "$TAG" -- \
   packaging/aur/PKGBUILD packaging/aur/.SRCINFO LICENSE \
   | tar -xf - -C "$EXTRACT_DIR"
 cp "$EXTRACT_DIR/packaging/aur/PKGBUILD" "$RELEASE_DIR/PKGBUILD"
@@ -186,11 +367,16 @@ AUR RPC. A nonzero result means stop: do not overwrite, adopt, or impersonate
 an existing package.
 
 ```bash
-rpc_payload="$(
+rpc_payload=
+if ! rpc_payload="$(
   curl -fsS --get \
     --data-urlencode "arg[]=$PACKAGE_NAME" \
     https://aur.archlinux.org/rpc/v5/info
-)"
+)"; then
+  echo 'AUR RPC lookup failed' >&2
+  exit 1
+fi
+[[ -n "$rpc_payload" ]]
 jq -e '.resultcount == 0 and (.results | length == 0)' \
   <<<"$rpc_payload" >/dev/null
 ```
@@ -201,13 +387,23 @@ also closes the race between the RPC lookup and clone. **Stop immediately** if
 any history or content appears.
 
 ```bash
-git clone "ssh://aur@aur.archlinux.org/$PACKAGE_NAME.git" "$AUR_DIR"
-[[ "$(git -C "$AUR_DIR" symbolic-ref --short HEAD)" == master ]]
+git -c init.defaultBranch=master clone "ssh://aur@aur.archlinux.org/$PACKAGE_NAME.git" "$AUR_DIR"
+aur_branch=
+if ! aur_branch="$(git -C "$AUR_DIR" symbolic-ref --short HEAD)"; then
+  echo 'AUR clone has no unborn branch' >&2
+  exit 1
+fi
+[[ "$aur_branch" == master ]]
 if git -C "$AUR_DIR" rev-parse --verify HEAD >/dev/null 2>&1; then
   echo 'AUR repository unexpectedly has history; stopping' >&2
   exit 1
 fi
-[[ -z "$(git -C "$AUR_DIR" status --short --untracked-files=all)" ]]
+aur_status=
+if ! aur_status="$(git -C "$AUR_DIR" status --short --untracked-files=all)"; then
+  echo 'could not inspect the empty AUR clone' >&2
+  exit 1
+fi
+[[ -z "$aur_status" ]]
 ```
 
 Continue at [Commit and push `master`](#commit-and-push-master).
@@ -220,21 +416,39 @@ base, remote, or current maintainer state is not the expected continuation of
 the previously published package.
 
 ```bash
-rpc_payload="$(
+rpc_payload=
+if ! rpc_payload="$(
   curl -fsS --get \
     --data-urlencode "arg[]=$PACKAGE_NAME" \
     https://aur.archlinux.org/rpc/v5/info
-)"
-jq -e --arg name "$PACKAGE_NAME" '
+)"; then
+  echo 'AUR RPC lookup failed' >&2
+  exit 1
+fi
+[[ -n "$rpc_payload" ]]
+jq -e \
+  --arg name "$PACKAGE_NAME" \
+  --arg maintainer "$EXPECTED_AUR_MAINTAINER" '
   .resultcount == 1 and
   .results[0].Name == $name and
-  .results[0].PackageBase == $name
+  .results[0].PackageBase == $name and
+  .results[0].Maintainer == $maintainer
 ' <<<"$rpc_payload" >/dev/null
 
 git clone "ssh://aur@aur.archlinux.org/$PACKAGE_NAME.git" "$AUR_DIR"
-[[ "$(git -C "$AUR_DIR" branch --show-current)" == master ]]
+aur_branch=
+if ! aur_branch="$(git -C "$AUR_DIR" branch --show-current)"; then
+  echo 'could not inspect the AUR branch' >&2
+  exit 1
+fi
+[[ "$aur_branch" == master ]]
 git -C "$AUR_DIR" rev-parse --verify HEAD >/dev/null
-[[ -z "$(git -C "$AUR_DIR" status --porcelain)" ]]
+aur_status=
+if ! aur_status="$(git -C "$AUR_DIR" status --porcelain)"; then
+  echo 'could not inspect the AUR worktree' >&2
+  exit 1
+fi
+[[ -z "$aur_status" ]]
 git -C "$AUR_DIR" remote -v
 git -C "$AUR_DIR" log --oneline --decorate -10
 ```
@@ -258,9 +472,17 @@ cmp "$RELEASE_DIR/PKGBUILD" "$AUR_DIR/PKGBUILD"
 cmp "$RELEASE_DIR/.SRCINFO" "$AUR_DIR/.SRCINFO"
 cmp "$RELEASE_DIR/LICENSE" "$AUR_DIR/LICENSE"
 
-git -C "$AUR_DIR" config user.name "Ducksss"
-git -C "$AUR_DIR" config user.email \
-  "58126222+Ducksss@users.noreply.github.com"
+aur_origin=
+if ! aur_origin="$(git -C "$AUR_DIR" remote get-url origin)"; then
+  echo 'AUR clone has no origin remote' >&2
+  exit 1
+fi
+[[ "$aur_origin" == "ssh://aur@aur.archlinux.org/$PACKAGE_NAME.git" ]]
+
+unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_AUTHOR_DATE
+unset GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL GIT_COMMITTER_DATE
+git -C "$AUR_DIR" config user.name "$AUR_GIT_NAME"
+git -C "$AUR_DIR" config user.email "$AUR_GIT_EMAIL"
 git -C "$AUR_DIR" add PKGBUILD .SRCINFO LICENSE
 git -C "$AUR_DIR" diff --cached --check
 git -C "$AUR_DIR" status --short
@@ -273,9 +495,51 @@ an empty diff means the version is already published; do not create an empty
 commit.
 
 ```bash
-[[ -n "$(git -C "$AUR_DIR" diff --cached --name-only)" ]]
-git -C "$AUR_DIR" commit -m "$PACKAGE_NAME $EXPECTED_AUR_VERSION"
-export PUSHED_COMMIT="$(git -C "$AUR_DIR" rev-parse HEAD)"
+staged_names=
+if ! staged_names="$(git -C "$AUR_DIR" diff --cached --name-only)"; then
+  echo 'could not inspect the staged AUR files' >&2
+  exit 1
+fi
+[[ -n "$staged_names" ]]
+
+GIT_AUTHOR_NAME="$AUR_GIT_NAME" \
+GIT_AUTHOR_EMAIL="$AUR_GIT_EMAIL" \
+GIT_COMMITTER_NAME="$AUR_GIT_NAME" \
+GIT_COMMITTER_EMAIL="$AUR_GIT_EMAIL" \
+  git -C "$AUR_DIR" commit -m "$PACKAGE_NAME $EXPECTED_AUR_VERSION"
+
+commit_author_name=
+if ! commit_author_name="$(git -C "$AUR_DIR" show -s --format=%an HEAD)"; then
+  echo 'could not read committed author name' >&2
+  exit 1
+fi
+commit_author_email=
+if ! commit_author_email="$(git -C "$AUR_DIR" show -s --format=%ae HEAD)"; then
+  echo 'could not read committed author email' >&2
+  exit 1
+fi
+commit_committer_name=
+if ! commit_committer_name="$(git -C "$AUR_DIR" show -s --format=%cn HEAD)"; then
+  echo 'could not read committed committer name' >&2
+  exit 1
+fi
+commit_committer_email=
+if ! commit_committer_email="$(git -C "$AUR_DIR" show -s --format=%ce HEAD)"; then
+  echo 'could not read committed committer email' >&2
+  exit 1
+fi
+[[ "$commit_author_name" == "$AUR_GIT_NAME" ]]
+[[ "$commit_author_email" == "$AUR_GIT_EMAIL" ]]
+[[ "$commit_committer_name" == "$AUR_GIT_NAME" ]]
+[[ "$commit_committer_email" == "$AUR_GIT_EMAIL" ]]
+
+PUSHED_COMMIT=
+if ! PUSHED_COMMIT="$(git -C "$AUR_DIR" rev-parse --verify "HEAD^{commit}")"; then
+  echo 'could not resolve the AUR commit' >&2
+  exit 1
+fi
+[[ "$PUSHED_COMMIT" =~ ^[0-9a-f]{40,64}$ ]]
+export PUSHED_COMMIT
 git -C "$AUR_DIR" push origin master
 ```
 
@@ -291,23 +555,29 @@ delay, but it fails if the exact `0.7.0-1` postcondition is not reached.
 ```bash
 rpc_verified=false
 for attempt in {1..12}; do
-  rpc_payload="$(
+  rpc_payload=
+  if ! rpc_payload="$(
     curl -fsS --get \
       --data-urlencode "arg[]=$PACKAGE_NAME" \
       https://aur.archlinux.org/rpc/v5/info
-  )"
-  if jq -e \
+  )"; then
+    echo "AUR RPC attempt $attempt failed" >&2
+  elif jq -e \
     --arg name "$PACKAGE_NAME" \
+    --arg maintainer "$EXPECTED_AUR_MAINTAINER" \
     --arg version "$EXPECTED_AUR_VERSION" '
       .resultcount == 1 and
       .results[0].Name == $name and
       .results[0].PackageBase == $name and
+      .results[0].Maintainer == $maintainer and
       .results[0].Version == $version
     ' <<<"$rpc_payload" >/dev/null; then
     rpc_verified=true
     break
   fi
-  sleep 10
+  if (( attempt < 12 )); then
+    sleep 10
+  fi
 done
 [[ "$rpc_verified" == true ]]
 [[ "$EXPECTED_AUR_VERSION" == 0.7.0-1 || "$VERSION" != 0.7.0 ]]
@@ -320,8 +590,18 @@ inspection against what anonymous users receive:
 ```bash
 export PUBLIC_DIR="$WORK_DIR/public"
 git clone "https://aur.archlinux.org/$PACKAGE_NAME.git" "$PUBLIC_DIR"
-[[ "$(git -C "$PUBLIC_DIR" branch --show-current)" == master ]]
-[[ "$(git -C "$PUBLIC_DIR" rev-parse HEAD)" == "$PUSHED_COMMIT" ]]
+public_branch=
+if ! public_branch="$(git -C "$PUBLIC_DIR" branch --show-current)"; then
+  echo 'could not inspect the public AUR branch' >&2
+  exit 1
+fi
+[[ "$public_branch" == master ]]
+public_commit=
+if ! public_commit="$(git -C "$PUBLIC_DIR" rev-parse --verify "HEAD^{commit}")"; then
+  echo 'could not resolve the public AUR commit' >&2
+  exit 1
+fi
+[[ "$public_commit" == "$PUSHED_COMMIT" ]]
 cmp "$RELEASE_DIR/PKGBUILD" "$PUBLIC_DIR/PKGBUILD"
 cmp "$RELEASE_DIR/.SRCINFO" "$PUBLIC_DIR/.SRCINFO"
 cmp "$RELEASE_DIR/LICENSE" "$PUBLIC_DIR/LICENSE"

--- a/test/aur-runbook-test.mjs
+++ b/test/aur-runbook-test.mjs
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = dirname(testDir);
+const runbookPath = join(rootDir, "packaging", "aur", "README.md");
+const runbook = readFileSync(runbookPath, "utf8");
+const bashBlocks = [...runbook.matchAll(/^```bash\s*\n([\s\S]*?)^```\s*$/gm)]
+  .map((match) => match[1]);
+
+assert.ok(bashBlocks.length > 0, "AUR runbook must contain Bash code blocks");
+
+const extractedBash = [
+  "#!/usr/bin/env bash",
+  "# Extracted from packaging/aur/README.md for syntax and lint checks.",
+  ...bashBlocks,
+].join("\n\n");
+
+if (process.argv.includes("--extract")) {
+  process.stdout.write(extractedBash);
+  process.exit(0);
+}
+
+function assertIncludes(haystack, needle, message) {
+  assert.ok(haystack.includes(needle), message ?? `missing: ${needle}`);
+}
+
+function assertOrdered(haystack, needles, message) {
+  let cursor = -1;
+  for (const needle of needles) {
+    const next = haystack.indexOf(needle, cursor + 1);
+    assert.ok(next > cursor, `${message}: ${needle}`);
+    cursor = next;
+  }
+}
+
+function normalized(value) {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+const firstCommand = bashBlocks[0]
+  .split("\n")
+  .map((line) => line.trim())
+  .find((line) => line !== "" && !line.startsWith("#"));
+assert.equal(
+  firstCommand,
+  "set -euo pipefail",
+  "strict mode must be enabled before the first key-management command",
+);
+
+assert.match(
+  runbook,
+  /if \[\[ ! -f "\$AUR_SSH_KEY" \|\| -L "\$AUR_SSH_KEY" \]\]; then[\s\S]*?exit 1[\s\S]*?fi/,
+  "the private-key predicate must fail explicitly",
+);
+assert.match(
+  runbook,
+  /if \[\[ ! -f "\$AUR_SSH_KEY\.pub" \|\| ! -s "\$AUR_SSH_KEY\.pub" \|\| -L "\$AUR_SSH_KEY\.pub" \]\]; then[\s\S]*?exit 1[\s\S]*?fi/,
+  "the public-key predicate must require a nonempty regular file",
+);
+assertIncludes(
+  runbook,
+  "[official AUR homepage](https://aur.archlinux.org/)",
+  "host-key verification must link the current official AUR source",
+);
+assert.match(
+  runbook,
+  /if \[\[ ! -f "\$AUR_KNOWN_HOSTS" \|\| ! -s "\$AUR_KNOWN_HOSTS" \|\| -L "\$AUR_KNOWN_HOSTS" \]\]; then[\s\S]*?exit 1[\s\S]*?fi/,
+  "the dedicated known_hosts predicate must fail explicitly",
+);
+
+assert.doesNotMatch(
+  extractedBash,
+  /\bexport\s+[A-Z][A-Z0-9_]*=.*\$\(/,
+  "capture and validate command substitutions before exporting them",
+);
+
+assertOrdered(
+  extractedBash,
+  [
+    "REPO_ROOT=",
+    'if ! REPO_ROOT="$(git rev-parse --show-toplevel)"; then',
+    '[[ -n "$REPO_ROOT"',
+    "export REPO_ROOT",
+  ],
+  "REPO_ROOT must be captured, validated, then exported",
+);
+assertOrdered(
+  extractedBash,
+  [
+    "WORK_DIR=",
+    'if ! WORK_DIR="$(mktemp -d',
+    '[[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]',
+    'case "$WORK_DIR" in',
+    "export WORK_DIR",
+    'export EXTRACT_DIR="$WORK_DIR/tag"',
+  ],
+  "WORK_DIR must be captured and proven safe before derivation",
+);
+assertOrdered(
+  extractedBash,
+  [
+    'git -C "$AUR_DIR" commit',
+    "PUSHED_COMMIT=",
+    'if ! PUSHED_COMMIT="$(git -C "$AUR_DIR" rev-parse --verify "HEAD^{commit}")"; then',
+    '[[ "$PUSHED_COMMIT" =~ ^[0-9a-f]{40,64}$ ]]',
+    "export PUSHED_COMMIT",
+    'git -C "$AUR_DIR" push origin master',
+  ],
+  "PUSHED_COMMIT must be captured and validated before push",
+);
+assertIncludes(
+  extractedBash,
+  'TEMP_ROOT_INPUT="${TMPDIR:-/tmp}"',
+  "the temporary root must be explicit",
+);
+assertIncludes(
+  extractedBash,
+  '"$TEMP_ROOT"/codex-profile-aur.*)',
+  "WORK_DIR cleanup must be restricted to the expected temporary prefix",
+);
+assertIncludes(
+  extractedBash,
+  '"$TEMP_ROOT" == /',
+  "the filesystem root must never be accepted as the temporary root",
+);
+assertOrdered(
+  extractedBash,
+  [
+    'case "$WORK_DIR" in',
+    "cleanup_work_dir() {",
+    "trap cleanup_work_dir EXIT",
+    "work_dir_physical=",
+  ],
+  "safe cleanup must be armed before physical-path validation can fail",
+);
+
+assert.doesNotMatch(
+  extractedBash,
+  /(?:export\s+)?GIT_SSH_COMMAND=/,
+  "do not interpolate identity paths into GIT_SSH_COMMAND",
+);
+assertIncludes(
+  extractedBash,
+  "unset GIT_SSH_COMMAND",
+  "an ambient GIT_SSH_COMMAND must not override the isolated wrapper",
+);
+for (const contract of [
+  'export GIT_SSH="$AUR_SSH_WRAPPER"',
+  "export GIT_SSH_VARIANT=ssh",
+  "ssh -F /dev/null",
+  '-i "$AUR_SSH_KEY"',
+  "IdentitiesOnly=yes",
+  "StrictHostKeyChecking=yes",
+  'UserKnownHostsFile="$AUR_KNOWN_HOSTS"',
+  'ssh-keygen -F aur.archlinux.org -f "$AUR_KNOWN_HOSTS"',
+  '"$AUR_SSH_WRAPPER" aur@aur.archlinux.org help >/dev/null',
+]) {
+  assertIncludes(extractedBash, contract, `missing isolated SSH contract: ${contract}`);
+}
+
+assertOrdered(
+  extractedBash,
+  [
+    "unset GIT_CONFIG GIT_CONFIG_PARAMETERS GIT_CONFIG_COUNT GIT_CONFIG_SYSTEM",
+    "unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR",
+    "unset GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_TEMPLATE_DIR",
+    "unset GIT_NAMESPACE GIT_SHALLOW_FILE GIT_QUARANTINE_PATH",
+    "unset GIT_CEILING_DIRECTORIES GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "export GIT_CONFIG_NOSYSTEM=1",
+    "export GIT_CONFIG_GLOBAL=/dev/null",
+    "export GIT_NO_REPLACE_OBJECTS=1",
+    "REPO_ROOT=",
+  ],
+  "ambient Git configuration and repository routing must be disabled before Git use",
+);
+assert.doesNotMatch(
+  extractedBash,
+  /env -u GIT_CONFIG/,
+  "no later Git command may undo the process-wide isolated configuration",
+);
+
+assertIncludes(
+  extractedBash,
+  "export EXPECTED_AUR_MAINTAINER=Ducksss",
+  "the expected AUR account handle must be explicit",
+);
+assert.ok(
+  (extractedBash.match(/\.results\[0\]\.Maintainer == \$maintainer/g) ?? []).length >= 2,
+  "update and final RPC checks must both require the expected maintainer",
+);
+
+assertIncludes(
+  extractedBash,
+  "export CANONICAL_REPO_URL=https://github.com/Ducksss/codex-profiles.git",
+  "tag retrieval must name the canonical GitHub repository",
+);
+assertIncludes(
+  extractedBash,
+  'git -C "$TAG_REPO" fetch --no-tags "$CANONICAL_REPO_URL"',
+  "the annotated tag must be fetched from the canonical URL",
+);
+assert.doesNotMatch(
+  extractedBash,
+  /fetch --no-tags origin/,
+  "an arbitrary origin must not supply the release tag",
+);
+assertIncludes(
+  normalized(extractedBash),
+  'git -c init.defaultBranch=master clone "ssh://aur@aur.archlinux.org/$PACKAGE_NAME.git" "$AUR_DIR"',
+  "an empty first-publication clone must deterministically use master",
+);
+
+for (const releaseContract of [
+  'https://api.github.com/repos/Ducksss/codex-profiles/releases/tags/$TAG',
+  ".tag_name == $tag",
+  ".draft == false",
+  ".prerelease == false",
+  '.published_at != null',
+  '.immutable == true',
+]) {
+  assertIncludes(
+    extractedBash,
+    releaseContract,
+    `missing immutable GitHub Release contract: ${releaseContract}`,
+  );
+}
+assertOrdered(
+  extractedBash,
+  [
+    'release_payload=',
+    'https://api.github.com/repos/Ducksss/codex-profiles/releases/tags/$TAG',
+    '.immutable == true',
+    'git -C "$TAG_REPO" archive',
+  ],
+  "the public immutable Release must be verified before tag extraction",
+);
+
+const finalRpcBlock = bashBlocks.find((block) => block.includes("rpc_verified=false"));
+assert.ok(finalRpcBlock, "missing final AUR RPC polling block");
+assertIncludes(
+  finalRpcBlock,
+  "if (( attempt < 12 )); then",
+  "the final failed RPC attempt must not sleep",
+);
+assertOrdered(
+  finalRpcBlock,
+  ["if (( attempt < 12 )); then", "sleep 10", "fi"],
+  "RPC backoff must be bounded before the final attempt",
+);
+
+assertIncludes(
+  extractedBash,
+  "unset GIT_AUTHOR_NAME GIT_AUTHOR_EMAIL GIT_AUTHOR_DATE",
+  "ambient author identity must be removed",
+);
+assertIncludes(
+  extractedBash,
+  "unset GIT_COMMITTER_NAME GIT_COMMITTER_EMAIL GIT_COMMITTER_DATE",
+  "ambient committer identity must be removed",
+);
+for (const field of ["%an", "%ae", "%cn", "%ce"]) {
+  assertIncludes(extractedBash, field, `pushed commit must verify ${field}`);
+}
+assertIncludes(
+  extractedBash,
+  '[[ "$commit_author_name" == "$AUR_GIT_NAME" ]]',
+  "the committed author name must match exactly",
+);
+assertIncludes(
+  extractedBash,
+  '[[ "$commit_committer_email" == "$AUR_GIT_EMAIL" ]]',
+  "the committed committer email must match exactly",
+);
+
+const syntaxDir = mkdtempSync(join(tmpdir(), "codex-profile-aur-runbook-test."));
+try {
+  bashBlocks.forEach((block, index) => {
+    const blockPath = join(syntaxDir, `block-${index + 1}.bash`);
+    writeFileSync(blockPath, block);
+    const result = spawnSync("bash", ["-n", blockPath], { encoding: "utf8" });
+    assert.equal(
+      result.status,
+      0,
+      `Bash block ${index + 1} failed syntax validation:\n${result.stderr}`,
+    );
+  });
+} finally {
+  rmSync(syntaxDir, { recursive: true, force: true });
+}
+
+const fixturesDir = join(testDir, "fixtures", "aur-rpc");
+const fixtures = Object.fromEntries(
+  ["unclaimed", "expected-owner", "unexpected-owner", "exact-final-version"].map(
+    (name) => [name, JSON.parse(readFileSync(join(fixturesDir, `${name}.json`), "utf8"))],
+  ),
+);
+
+const packageName = "codex-profile";
+const maintainer = "Ducksss";
+const expectedVersion = "0.7.0-1";
+const isUnclaimed = (payload) =>
+  payload.resultcount === 0 && Array.isArray(payload.results) && payload.results.length === 0;
+const isExpectedUpdate = (payload) =>
+  payload.resultcount === 1 &&
+  payload.results?.[0]?.Name === packageName &&
+  payload.results?.[0]?.PackageBase === packageName &&
+  payload.results?.[0]?.Maintainer === maintainer;
+const isExactFinal = (payload) =>
+  isExpectedUpdate(payload) && payload.results[0].Version === expectedVersion;
+
+assert.equal(isUnclaimed(fixtures.unclaimed), true);
+assert.equal(isUnclaimed(fixtures["expected-owner"]), false);
+assert.equal(isExpectedUpdate(fixtures["expected-owner"]), true);
+assert.equal(isExpectedUpdate(fixtures["unexpected-owner"]), false);
+assert.equal(isExactFinal(fixtures["exact-final-version"]), true);
+assert.equal(isExactFinal(fixtures["expected-owner"]), false);
+assert.equal(isExactFinal(fixtures["unexpected-owner"]), false);
+
+const releaseFixtures = JSON.parse(
+  readFileSync(join(testDir, "fixtures", "github-release-contract.json"), "utf8"),
+);
+const isImmutableFinalRelease = (payload) =>
+  payload.tag_name === "v0.7.0" &&
+  payload.draft === false &&
+  payload.prerelease === false &&
+  typeof payload.published_at === "string" &&
+  payload.published_at.length > 0 &&
+  payload.immutable === true;
+assert.equal(isImmutableFinalRelease(releaseFixtures.immutableFinal), true);
+assert.equal(isImmutableFinalRelease(releaseFixtures.mutable), false);
+assert.equal(isImmutableFinalRelease(releaseFixtures.draft), false);
+assert.equal(isImmutableFinalRelease(releaseFixtures.wrongTag), false);
+
+const unclaimedFilter =
+  '.resultcount == 0 and (.results | length == 0)';
+const updateFilter = `
+  .resultcount == 1 and
+  .results[0].Name == $name and
+  .results[0].PackageBase == $name and
+  .results[0].Maintainer == $maintainer
+`;
+const finalFilter = `
+      .resultcount == 1 and
+      .results[0].Name == $name and
+      .results[0].PackageBase == $name and
+      .results[0].Maintainer == $maintainer and
+      .results[0].Version == $version
+`;
+const releaseFilter = `
+  .tag_name == $tag and
+  .draft == false and
+  .prerelease == false and
+  .published_at != null and
+  (.published_at | type == "string" and length > 0) and
+  .immutable == true
+`;
+
+assertIncludes(normalized(extractedBash), normalized(unclaimedFilter));
+assertIncludes(normalized(extractedBash), normalized(updateFilter));
+assertIncludes(normalized(extractedBash), normalized(finalFilter));
+assertIncludes(normalized(extractedBash), normalized(releaseFilter));
+
+const jqVersion = spawnSync("jq", ["--version"], { encoding: "utf8" });
+if (jqVersion.status === 0) {
+  function jqMatches(payload, args, filter) {
+    const result = spawnSync("jq", ["-e", ...args, filter], {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+    });
+    assert.ok(
+      result.status === 0 || result.status === 1,
+      `jq contract failed to execute: ${result.stderr}`,
+    );
+    return result.status === 0;
+  }
+
+  assert.equal(jqMatches(fixtures.unclaimed, [], unclaimedFilter), true);
+  assert.equal(jqMatches(fixtures["expected-owner"], [], unclaimedFilter), false);
+  assert.equal(
+    jqMatches(
+      fixtures["expected-owner"],
+      ["--arg", "name", packageName, "--arg", "maintainer", maintainer],
+      updateFilter,
+    ),
+    true,
+  );
+  assert.equal(
+    jqMatches(
+      fixtures["unexpected-owner"],
+      ["--arg", "name", packageName, "--arg", "maintainer", maintainer],
+      updateFilter,
+    ),
+    false,
+  );
+  assert.equal(
+    jqMatches(
+      fixtures["exact-final-version"],
+      [
+        "--arg",
+        "name",
+        packageName,
+        "--arg",
+        "maintainer",
+        maintainer,
+        "--arg",
+        "version",
+        expectedVersion,
+      ],
+      finalFilter,
+    ),
+    true,
+  );
+  assert.equal(
+    jqMatches(
+      fixtures["unexpected-owner"],
+      [
+        "--arg",
+        "name",
+        packageName,
+        "--arg",
+        "maintainer",
+        maintainer,
+        "--arg",
+        "version",
+        expectedVersion,
+      ],
+      finalFilter,
+    ),
+    false,
+  );
+  assert.equal(
+    jqMatches(
+      releaseFixtures.immutableFinal,
+      ["--arg", "tag", "v0.7.0"],
+      releaseFilter,
+    ),
+    true,
+  );
+  for (const name of ["mutable", "draft", "wrongTag"]) {
+    assert.equal(
+      jqMatches(releaseFixtures[name], ["--arg", "tag", "v0.7.0"], releaseFilter),
+      false,
+    );
+  }
+} else {
+  process.stdout.write("jq not found; pure Node RPC fixture checks passed.\n");
+}
+
+process.stdout.write(
+  `AUR runbook checks passed (${bashBlocks.length} Bash blocks, 4 RPC fixtures, 4 release fixtures).\n`,
+);

--- a/test/fixtures/aur-rpc/exact-final-version.json
+++ b/test/fixtures/aur-rpc/exact-final-version.json
@@ -1,0 +1,13 @@
+{
+  "resultcount": 1,
+  "results": [
+    {
+      "Maintainer": "Ducksss",
+      "Name": "codex-profile",
+      "PackageBase": "codex-profile",
+      "Version": "0.7.0-1"
+    }
+  ],
+  "type": "multiinfo",
+  "version": 5
+}

--- a/test/fixtures/aur-rpc/expected-owner.json
+++ b/test/fixtures/aur-rpc/expected-owner.json
@@ -1,0 +1,13 @@
+{
+  "resultcount": 1,
+  "results": [
+    {
+      "Maintainer": "Ducksss",
+      "Name": "codex-profile",
+      "PackageBase": "codex-profile",
+      "Version": "0.6.0-1"
+    }
+  ],
+  "type": "multiinfo",
+  "version": 5
+}

--- a/test/fixtures/aur-rpc/unclaimed.json
+++ b/test/fixtures/aur-rpc/unclaimed.json
@@ -1,0 +1,6 @@
+{
+  "resultcount": 0,
+  "results": [],
+  "type": "multiinfo",
+  "version": 5
+}

--- a/test/fixtures/aur-rpc/unexpected-owner.json
+++ b/test/fixtures/aur-rpc/unexpected-owner.json
@@ -1,0 +1,13 @@
+{
+  "resultcount": 1,
+  "results": [
+    {
+      "Maintainer": "someone-else",
+      "Name": "codex-profile",
+      "PackageBase": "codex-profile",
+      "Version": "0.7.0-1"
+    }
+  ],
+  "type": "multiinfo",
+  "version": 5
+}

--- a/test/fixtures/github-release-contract.json
+++ b/test/fixtures/github-release-contract.json
@@ -1,0 +1,30 @@
+{
+  "immutableFinal": {
+    "draft": false,
+    "immutable": true,
+    "prerelease": false,
+    "published_at": "2026-07-13T08:00:00Z",
+    "tag_name": "v0.7.0"
+  },
+  "mutable": {
+    "draft": false,
+    "immutable": false,
+    "prerelease": false,
+    "published_at": "2026-07-13T08:00:00Z",
+    "tag_name": "v0.7.0"
+  },
+  "draft": {
+    "draft": true,
+    "immutable": true,
+    "prerelease": false,
+    "published_at": "2026-07-13T08:00:00Z",
+    "tag_name": "v0.7.0"
+  },
+  "wrongTag": {
+    "draft": false,
+    "immutable": true,
+    "prerelease": false,
+    "published_at": "2026-07-13T08:00:00Z",
+    "tag_name": "v0.7.1"
+  }
+}

--- a/test/package-metadata-test.sh
+++ b/test/package-metadata-test.sh
@@ -69,6 +69,15 @@ changelog_version="${version//./\.}"
 grep -Eq "^## $changelog_version - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md \
   || fail "CHANGELOG.md has no dated $version release section"
 
+aur_runbook="packaging/aur/README.md"
+[[ -f "$aur_runbook" ]] || fail "AUR publication runbook is missing"
+grep -F '(packaging/aur/README.md)' CHANGELOG.md >/dev/null \
+  || fail "CHANGELOG.md does not link the AUR publication runbook"
+grep -F '(packaging/aur/README.md)' CONTRIBUTING.md >/dev/null \
+  || fail "CONTRIBUTING.md does not link the AUR publication runbook"
+grep -F '58126222+Ducksss@users.noreply.github.com' "$aur_runbook" >/dev/null \
+  || fail "AUR runbook does not use Ducksss' ID-derived GitHub noreply identity"
+
 # shellcheck disable=SC2016 # fixed strings intentionally contain shell variables
 grep -F 'ln -s codex-profile "$staged_alias"' install.sh > /dev/null \
   || fail "standalone installer does not stage a relative plural alias"

--- a/test/release-workflow-test.sh
+++ b/test/release-workflow-test.sh
@@ -195,6 +195,7 @@ do
   require_literal "$literal"
 done
 
+require_literal '# Immutable releases are an operator prerequisite for every live dispatch.'
 require_literal 'description: "Live release only: tested ChatGPT version and bundle ID; no account data."'
 require_literal 'DESKTOP_SMOKE_ATTESTATION: ${{ inputs.desktop_smoke_attestation }}'
 require_literal '[[ "$DRY_RUN" != "true" ]]'
@@ -601,6 +602,7 @@ for literal in \
   'env -u CODEX_PROFILE_VERSION CODEX_PROFILE_PREFIX="$prefix" sh "$installer"' \
   'canonical="$prefix/bin/codex-profile"' \
   'alias="$prefix/bin/codex-profiles"' \
+  '[[ -f "$canonical" && -x "$canonical" && ! -L "$canonical" ]] || return 1' \
   '[[ -L "$alias" ]] || return 1' \
   '[[ "$(readlink "$alias")" == "codex-profile" ]] || return 1' \
   'canonical_output="$("$canonical" version 2>&1)" || return 1' \
@@ -809,6 +811,7 @@ for literal in \
   'release_lookup_succeeded=true' \
   '[[ "$release_lookup_succeeded" == "true" ]]' \
   'gh release create "$TAG"' \
+  '--latest --verify-tag' \
   'release_verified_after_create=true'
 do
   grep -F -- "$literal" <<< "$github_release_block" >/dev/null \
@@ -871,6 +874,14 @@ case "$command" in
     esac
     ;;
   release:create)
+    case " $* " in
+      *' --latest '*) ;;
+      *) exit 65 ;;
+    esac
+    case " $* " in
+      *' --verify-tag '*) ;;
+      *) exit 66 ;;
+    esac
     printf '%s\n' 'create' >> "$RELEASE_WORKFLOW_TEST_LOG"
     case "$FAKE_GH_RELEASE_SCENARIO" in
       absent) ;;
@@ -881,25 +892,60 @@ case "$command" in
   release:view)
     printf '%s\n' 'view' >> "$RELEASE_WORKFLOW_TEST_LOG"
     case "$FAKE_GH_RELEASE_SCENARIO" in
-      present)
+      present|latest_eventual|latest_malformed|latest_transient|not_latest)
         printf '%s\n' \
-          '{"tagName":"v0.7.0","isDraft":false,"isPrerelease":false,"publishedAt":"2026-07-12T00:00:00Z"}'
+          '{"tagName":"v0.7.0","isDraft":false,"isPrerelease":false,"publishedAt":"2026-07-13T00:00:00Z","body":"Release notes","isImmutable":true}'
         ;;
       draft)
         printf '%s\n' \
-          '{"tagName":"v0.7.0","isDraft":true,"isPrerelease":false,"publishedAt":null}'
+          '{"tagName":"v0.7.0","isDraft":true,"isPrerelease":false,"publishedAt":null,"body":"Release notes","isImmutable":true}'
         ;;
       prerelease)
         printf '%s\n' \
-          '{"tagName":"v0.7.0","isDraft":false,"isPrerelease":true,"publishedAt":"2026-07-12T00:00:00Z"}'
+          '{"tagName":"v0.7.0","isDraft":false,"isPrerelease":true,"publishedAt":"2026-07-13T00:00:00Z","body":"Release notes","isImmutable":true}'
         ;;
       unpublished)
         printf '%s\n' \
-          '{"tagName":"v0.7.0","isDraft":false,"isPrerelease":false,"publishedAt":null}'
+          '{"tagName":"v0.7.0","isDraft":false,"isPrerelease":false,"publishedAt":null,"body":"Release notes","isImmutable":true}'
         ;;
       wrong_tag)
         printf '%s\n' \
-          '{"tagName":"v0.6.0","isDraft":false,"isPrerelease":false,"publishedAt":"2026-07-01T00:00:00Z"}'
+          '{"tagName":"v0.6.0","isDraft":false,"isPrerelease":false,"publishedAt":"2026-07-01T00:00:00Z","body":"Release notes","isImmutable":true}'
+        ;;
+      non_immutable)
+        printf '%s\n' \
+          '{"tagName":"v0.7.0","isDraft":false,"isPrerelease":false,"publishedAt":"2026-07-13T00:00:00Z","body":"Release notes","isImmutable":false}'
+        ;;
+      empty_notes)
+        printf '%s\n' \
+          '{"tagName":"v0.7.0","isDraft":false,"isPrerelease":false,"publishedAt":"2026-07-13T00:00:00Z","body":"   ","isImmutable":true}'
+        ;;
+      *) exit 64 ;;
+    esac
+    ;;
+  api:*/releases/latest)
+    printf '%s\n' 'latest' >> "$RELEASE_WORKFLOW_TEST_LOG"
+    latest_count="$(grep -Fxc 'latest' "$RELEASE_WORKFLOW_TEST_LOG")"
+    case "$FAKE_GH_RELEASE_SCENARIO" in
+      present)
+        printf '%s\n' '{"tag_name":"v0.7.0"}'
+        ;;
+      latest_eventual)
+        if [ "$latest_count" -ge 3 ]; then
+          printf '%s\n' '{"tag_name":"v0.7.0"}'
+        else
+          printf '%s\n' '{"tag_name":"v0.6.0"}'
+        fi
+        ;;
+      not_latest)
+        printf '%s\n' '{"tag_name":"v0.6.0"}'
+        ;;
+      latest_malformed)
+        printf '%s\n' '{"tag_name":7}'
+        ;;
+      latest_transient)
+        printf '%s\n' 'HTTP 503: service unavailable' >&2
+        exit 1
         ;;
       *) exit 64 ;;
     esac
@@ -967,11 +1013,18 @@ require_github_release_scenario unpublished failure 5 0 4
 
 github_release_verify_block="$(step_block "Verify GitHub Release")"
 for literal in \
-  '--json tagName,isDraft,isPrerelease,publishedAt' \
+  '--json tagName,isDraft,isPrerelease,publishedAt,body,isImmutable' \
   'release.tagName !== expectedTag' \
   'release.isDraft !== false' \
   'release.isPrerelease !== false' \
-  "typeof release.publishedAt !== 'string'"
+  "typeof release.publishedAt !== 'string'" \
+  'release.isImmutable !== true' \
+  "typeof release.body !== 'string'" \
+  'release.body.trim().length === 0' \
+  'gh api "/repos/$GITHUB_REPOSITORY/releases/latest"' \
+  'for attempt in {1..5}; do' \
+  'latestRelease.tag_name !== expectedTag' \
+  '[[ "$latest_verified" == "true" ]]'
 do
   grep -F -- "$literal" <<< "$github_release_verify_block" >/dev/null \
     || fail "Verify GitHub Release is missing public-final contract: $literal"
@@ -981,14 +1034,18 @@ github_release_verify_script="$(step_script "Verify GitHub Release")"
 require_github_release_final_scenario() {
   local scenario="$1"
   local expected_status="$2"
+  local expected_latest_calls="$3"
+  local expected_sleeps="$4"
   local log="$tmp_dir/release-final-$scenario.log"
   local status
+  local actual
 
   : > "$log"
   set +e
   PATH="$release_fake_bin:$PATH" \
     RELEASE_WORKFLOW_TEST_LOG="$log" \
     FAKE_GH_RELEASE_SCENARIO="$scenario" \
+    GITHUB_REPOSITORY="Ducksss/codex-profiles" \
     TAG="v0.7.0" \
     bash -c "$github_release_verify_script" \
       >"$tmp_dir/release-final-$scenario.out" 2>&1
@@ -1000,13 +1057,26 @@ require_github_release_final_scenario() {
   else
     [[ "$status" -ne 0 ]] || fail "GitHub Release final $scenario verification unexpectedly succeeded"
   fi
+
+  actual="$(grep -Fxc 'latest' "$log" || true)"
+  [[ "$actual" -eq "$expected_latest_calls" ]] \
+    || fail "GitHub Release final $scenario queried latest $actual time(s); expected $expected_latest_calls"
+  actual="$(grep -Fxc 'sleep' "$log" || true)"
+  [[ "$actual" -eq "$expected_sleeps" ]] \
+    || fail "GitHub Release final $scenario slept $actual time(s); expected $expected_sleeps"
 }
 
-require_github_release_final_scenario present success
-require_github_release_final_scenario draft failure
-require_github_release_final_scenario prerelease failure
-require_github_release_final_scenario unpublished failure
-require_github_release_final_scenario wrong_tag failure
+require_github_release_final_scenario present success 1 0
+require_github_release_final_scenario latest_eventual success 3 2
+require_github_release_final_scenario draft failure 0 0
+require_github_release_final_scenario prerelease failure 0 0
+require_github_release_final_scenario unpublished failure 0 0
+require_github_release_final_scenario wrong_tag failure 0 0
+require_github_release_final_scenario non_immutable failure 0 0
+require_github_release_final_scenario empty_notes failure 0 0
+require_github_release_final_scenario not_latest failure 5 4
+require_github_release_final_scenario latest_malformed failure 5 4
+require_github_release_final_scenario latest_transient failure 5 4
 
 standalone_fake_bin="$tmp_dir/standalone-fake-bin"
 standalone_installer_fixture="$tmp_dir/standalone-install.sh"
@@ -1057,11 +1127,23 @@ esac
 FAKE_STANDALONE_COMMAND
 chmod 755 "$CODEX_PROFILE_PREFIX/bin/codex-profile"
 
+if [ "$FAKE_STANDALONE_SCENARIO" = 'canonical_symlink' ]; then
+  mv \
+    "$CODEX_PROFILE_PREFIX/bin/codex-profile" \
+    "$CODEX_PROFILE_PREFIX/bin/codex-profile-real"
+  ln -s codex-profile-real "$CODEX_PROFILE_PREFIX/bin/codex-profile"
+fi
+
 case "$FAKE_STANDALONE_SCENARIO" in
   missing_alias)
     ;;
   wrong_symlink)
     ln -s somewhere-else "$CODEX_PROFILE_PREFIX/bin/codex-profiles"
+    ;;
+  absolute_symlink)
+    ln -s \
+      "$CODEX_PROFILE_PREFIX/bin/codex-profile" \
+      "$CODEX_PROFILE_PREFIX/bin/codex-profiles"
     ;;
   *)
     ln -s codex-profile "$CODEX_PROFILE_PREFIX/bin/codex-profiles"
@@ -1209,6 +1291,8 @@ require_standalone_scenario wrong_canonical 0.6.0 0.7.0 failure 5 4 5 0
 require_standalone_scenario wrong_alias 0.7.0 0.6.0 failure 5 4 5 5
 require_standalone_scenario missing_alias 0.7.0 0.7.0 failure 5 4 0 0
 require_standalone_scenario wrong_symlink 0.7.0 0.7.0 failure 5 4 0 0
+require_standalone_scenario absolute_symlink 0.7.0 0.7.0 failure 5 4 0 0
+require_standalone_scenario canonical_symlink 0.7.0 0.7.0 failure 5 4 0 0
 
 for step_name in \
   'Preflight release credential identities' \

--- a/test/release-workflow-test.sh
+++ b/test/release-workflow-test.sh
@@ -587,6 +587,36 @@ release_verify_line="$(line_number '      - name: Verify GitHub Release')"
   || fail "GitHub Release verification must run after release creation"
 require_step_literal "Verify GitHub Release" 'gh release view "$TAG"'
 
+standalone_verify_line="$(line_number '      - name: Verify public standalone installer')"
+homebrew_update_line="$(line_number '      - name: Update Homebrew tap')"
+[[ "$release_verify_line" -lt "$standalone_verify_line" \
+  && "$standalone_verify_line" -lt "$homebrew_update_line" ]] \
+  || fail "standalone installer verification must run after the GitHub Release and before Homebrew"
+
+standalone_verification_block="$(step_block "Verify public standalone installer")"
+for literal in \
+  'https://raw.githubusercontent.com/Ducksss/codex-profiles/$TAG/install.sh' \
+  'for attempt in {1..5}; do' \
+  'prefix="$(mktemp -d "$tmp/prefix-$attempt.XXXXXX")"' \
+  'env -u CODEX_PROFILE_VERSION CODEX_PROFILE_PREFIX="$prefix" sh "$installer"' \
+  'canonical="$prefix/bin/codex-profile"' \
+  'alias="$prefix/bin/codex-profiles"' \
+  '[[ -L "$alias" ]] || return 1' \
+  '[[ "$(readlink "$alias")" == "codex-profile" ]] || return 1' \
+  'canonical_output="$("$canonical" version 2>&1)" || return 1' \
+  'alias_output="$("$alias" version 2>&1)" || return 1' \
+  '[[ "$canonical_output" == "codex-profile $V" ]] || return 1' \
+  '[[ "$alias_output" == "codex-profile $V" ]] || return 1' \
+  'sleep "$((attempt * 2))"' \
+  '[[ "$standalone_verified" == "true" ]]'
+do
+  grep -F -- "$literal" <<< "$standalone_verification_block" >/dev/null \
+    || fail "Verify public standalone installer is missing contract: $literal"
+done
+if grep -Eq 'CODEX_PROFILE_VERSION[[:space:]]*=' <<< "$standalone_verification_block"; then
+  fail "standalone installer verification must not override CODEX_PROFILE_VERSION"
+fi
+
 npm_verification_block="$(step_block "Verify published npm package")"
 for literal in \
   'for attempt in {1..10}; do' \
@@ -978,6 +1008,208 @@ require_github_release_final_scenario prerelease failure
 require_github_release_final_scenario unpublished failure
 require_github_release_final_scenario wrong_tag failure
 
+standalone_fake_bin="$tmp_dir/standalone-fake-bin"
+standalone_installer_fixture="$tmp_dir/standalone-install.sh"
+mkdir -p "$standalone_fake_bin"
+
+cat > "$standalone_installer_fixture" <<'FAKE_STANDALONE_INSTALLER'
+#!/bin/sh
+
+set -eu
+
+if [ "${CODEX_PROFILE_VERSION+x}" = x ]; then
+  printf '%s\n' 'version-override-present' >> "$RELEASE_WORKFLOW_TEST_LOG"
+  exit 70
+fi
+
+: "${CODEX_PROFILE_PREFIX:?}"
+printf 'prefix:%s\n' "$CODEX_PROFILE_PREFIX" >> "$RELEASE_WORKFLOW_TEST_LOG"
+latest_json="$(
+  curl -fsSL \
+    'https://api.github.com/repos/Ducksss/codex-profiles/releases/latest'
+)"
+latest_tag="$(
+  printf '%s\n' "$latest_json" \
+    | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+    | head -n 1
+)"
+[ "$latest_tag" = 'v0.7.0' ]
+
+mkdir -p "$CODEX_PROFILE_PREFIX/bin"
+cat > "$CODEX_PROFILE_PREFIX/bin/codex-profile" <<'FAKE_STANDALONE_COMMAND'
+#!/bin/sh
+
+set -eu
+
+case "${1:-}" in
+  version)
+    command_name="${0##*/}"
+    printf 'version:%s\n' "$command_name" >> "$RELEASE_WORKFLOW_TEST_LOG"
+    if [ "$command_name" = 'codex-profiles' ]; then
+      reported_version="$FAKE_STANDALONE_ALIAS_VERSION"
+    else
+      reported_version="$FAKE_STANDALONE_CANONICAL_VERSION"
+    fi
+    printf 'codex-profile %s\n' "$reported_version"
+    ;;
+  *) exit 64 ;;
+esac
+FAKE_STANDALONE_COMMAND
+chmod 755 "$CODEX_PROFILE_PREFIX/bin/codex-profile"
+
+case "$FAKE_STANDALONE_SCENARIO" in
+  missing_alias)
+    ;;
+  wrong_symlink)
+    ln -s somewhere-else "$CODEX_PROFILE_PREFIX/bin/codex-profiles"
+    ;;
+  *)
+    ln -s codex-profile "$CODEX_PROFILE_PREFIX/bin/codex-profiles"
+    ;;
+esac
+FAKE_STANDALONE_INSTALLER
+
+cat > "$standalone_fake_bin/curl" <<'FAKE_STANDALONE_CURL'
+#!/bin/sh
+
+set -eu
+
+output=''
+url=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    https://*)
+      url="$1"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+case "$url" in
+  https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.7.0/install.sh)
+    [ -n "$output" ]
+    printf 'installer:%s\n' "$url" >> "$RELEASE_WORKFLOW_TEST_LOG"
+    cp "$STANDALONE_INSTALLER_FIXTURE" "$output"
+    ;;
+  https://api.github.com/repos/Ducksss/codex-profiles/releases/latest)
+    [ -z "$output" ]
+    printf 'latest:%s\n' "${CODEX_PROFILE_PREFIX:-unset}" \
+      >> "$RELEASE_WORKFLOW_TEST_LOG"
+    latest_count="$(
+      grep -c '^latest:' "$RELEASE_WORKFLOW_TEST_LOG" 2>/dev/null || true
+    )"
+    case "$FAKE_STANDALONE_SCENARIO" in
+      retry)
+        [ "$latest_count" -gt 2 ] || exit 22
+        ;;
+      unavailable)
+        exit 22
+        ;;
+    esac
+    printf '%s\n' '{"tag_name":"v0.7.0"}'
+    ;;
+  *)
+    printf 'unexpected curl URL: %s\n' "$url" >&2
+    exit 64
+    ;;
+esac
+FAKE_STANDALONE_CURL
+
+cat > "$standalone_fake_bin/sleep" <<'FAKE_STANDALONE_SLEEP'
+#!/bin/sh
+
+printf '%s\n' 'sleep' >> "$RELEASE_WORKFLOW_TEST_LOG"
+FAKE_STANDALONE_SLEEP
+chmod 755 \
+  "$standalone_installer_fixture" \
+  "$standalone_fake_bin/curl" \
+  "$standalone_fake_bin/sleep"
+
+standalone_verification_script="$(step_script "Verify public standalone installer")"
+require_standalone_scenario() {
+  local scenario="$1"
+  local canonical_version="$2"
+  local alias_version="$3"
+  local expected_status="$4"
+  local expected_attempts="$5"
+  local expected_sleeps="$6"
+  local expected_canonical_checks="$7"
+  local expected_alias_checks="$8"
+  local log="$tmp_dir/standalone-$scenario.log"
+  local output="$tmp_dir/standalone-$scenario.out"
+  local status
+  local actual
+  local unique_prefixes
+
+  : > "$log"
+  set +e
+  PATH="$standalone_fake_bin:$PATH" \
+    RELEASE_WORKFLOW_TEST_LOG="$log" \
+    STANDALONE_INSTALLER_FIXTURE="$standalone_installer_fixture" \
+    FAKE_STANDALONE_SCENARIO="$scenario" \
+    FAKE_STANDALONE_CANONICAL_VERSION="$canonical_version" \
+    FAKE_STANDALONE_ALIAS_VERSION="$alias_version" \
+    CODEX_PROFILE_VERSION="v9.9.9" \
+    TAG="v0.7.0" \
+    V="0.7.0" \
+    bash -c "$standalone_verification_script" > "$output" 2>&1
+  status=$?
+  set -e
+
+  if [[ "$expected_status" == "success" ]]; then
+    if [[ "$status" -ne 0 ]]; then
+      cat "$output" >&2
+      fail "standalone installer $scenario scenario unexpectedly failed"
+    fi
+  elif [[ "$status" -eq 0 ]]; then
+    fail "standalone installer $scenario scenario unexpectedly succeeded"
+  fi
+
+  grep -Fx \
+    'installer:https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.7.0/install.sh' \
+    "$log" >/dev/null \
+    || fail "standalone installer $scenario scenario did not use the immutable tag"
+  if grep -Fqx 'version-override-present' "$log"; then
+    fail "standalone installer $scenario scenario received CODEX_PROFILE_VERSION"
+  fi
+
+  actual="$(grep -c '^prefix:' "$log" || true)"
+  [[ "$actual" -eq "$expected_attempts" ]] \
+    || fail "standalone installer $scenario used $actual prefixes; expected $expected_attempts"
+  unique_prefixes="$(
+    sed -n 's/^prefix://p' "$log" | sort -u | awk 'END { print NR + 0 }'
+  )"
+  [[ "$unique_prefixes" -eq "$expected_attempts" ]] \
+    || fail "standalone installer $scenario reused an attempt prefix"
+  actual="$(grep -c '^latest:' "$log" || true)"
+  [[ "$actual" -eq "$expected_attempts" ]] \
+    || fail "standalone installer $scenario queried releases/latest $actual times; expected $expected_attempts"
+  actual="$(grep -Fxc 'sleep' "$log" || true)"
+  [[ "$actual" -eq "$expected_sleeps" ]] \
+    || fail "standalone installer $scenario slept $actual times; expected $expected_sleeps"
+  actual="$(grep -Fxc 'version:codex-profile' "$log" || true)"
+  [[ "$actual" -eq "$expected_canonical_checks" ]] \
+    || fail "standalone installer $scenario checked the canonical command $actual times; expected $expected_canonical_checks"
+  actual="$(grep -Fxc 'version:codex-profiles' "$log" || true)"
+  [[ "$actual" -eq "$expected_alias_checks" ]] \
+    || fail "standalone installer $scenario checked the plural command $actual times; expected $expected_alias_checks"
+}
+
+require_standalone_scenario success 0.7.0 0.7.0 success 1 0 1 1
+require_standalone_scenario retry 0.7.0 0.7.0 success 3 2 1 1
+require_standalone_scenario unavailable 0.7.0 0.7.0 failure 5 4 0 0
+require_standalone_scenario wrong_canonical 0.6.0 0.7.0 failure 5 4 5 0
+require_standalone_scenario wrong_alias 0.7.0 0.6.0 failure 5 4 5 5
+require_standalone_scenario missing_alias 0.7.0 0.7.0 failure 5 4 0 0
+require_standalone_scenario wrong_symlink 0.7.0 0.7.0 failure 5 4 0 0
+
 for step_name in \
   'Preflight release credential identities' \
   'Revalidate live release state' \
@@ -987,6 +1219,7 @@ for step_name in \
   'Verify published npm package' \
   'Create GitHub Release' \
   'Verify GitHub Release' \
+  'Verify public standalone installer' \
   'Update Homebrew tap' \
   'Deploy and verify release documentation'
 do
@@ -1108,6 +1341,7 @@ shell_steps=(
   'Verify published npm package'
   'Create GitHub Release'
   'Verify GitHub Release'
+  'Verify public standalone installer'
   'Update Homebrew tap'
   'Deploy and verify release documentation'
   'Release summary'


### PR DESCRIPTION
## Summary

- finalize the v0.7.0 release date as 2026-07-13 across every public metadata surface while preserving the July 11 GEO baseline
- verify the public standalone installer after an immutable, latest, final GitHub Release and before Homebrew publication
- exercise latest-release resolution, five fresh-prefix retries, exact aliases, regular-file and relative-symlink invariants, and fail-closed error paths
- add a permanent, tested AUR first-publication/update runbook with isolated credentials, SSH trust, canonical immutable inputs, Arch Docker validation, exact identity/maintainer checks, and anonymous rebuild verification

## Release safeguards

- GitHub Release must be immutable, latest, final, published, and have non-empty notes
- npm/Homebrew/Pages ordering remains unchanged around the new standalone verification gate
- AUR publication remains a local maintainer action; no AUR private key is stored in GitHub Actions
- v0.7.0 version metadata remains synchronized across the CLI, npm, docs, and AUR package files

## Validation

- `make test`
- `make lint`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
- `npm pack --dry-run --json`
- `bash test/release-workflow-test.sh`
- `node test/aur-runbook-test.mjs`
- `git diff --check`
- independent whole-range review, clean after fixes

The live release remains gated on the post-merge credentialless rehearsal, dedicated `TAP_TOKEN`, immutable-release setting, signed ChatGPT smoke attestation, and AUR account/key setup.
