### PR TITLE
cli(feat): add workspace-aware profile routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project follows semantic versioning for tagged releases.
 - Added `init <profile> --share-with <source-profile>` for linked profiles that
   share only an explicit configuration allowlist while keeping authentication,
   sessions, logs, Desktop data, caches, and connector/app state separate.
-- Private workspace-to-profile bindings with nearest-ancestor resolution,
+- Added private workspace-to-profile bindings with nearest-ancestor resolution,
   `run`/`run --app` automatic routing, warn/strict/off mismatch guards,
   machine-readable inspection, profile-removal cleanup, doctor diagnostics,
   and Bash/Zsh/Fish completion support. Bindings contain only canonical paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project follows semantic versioning for tagged releases.
 - Added `init <profile> --share-with <source-profile>` for linked profiles that
   share only an explicit configuration allowlist while keeping authentication,
   sessions, logs, Desktop data, caches, and connector/app state separate.
+- Private workspace-to-profile bindings with nearest-ancestor resolution,
+  `run`/`run --app` automatic routing, warn/strict/off mismatch guards,
+  machine-readable inspection, profile-removal cleanup, doctor diagnostics,
+  and Bash/Zsh/Fish completion support. Bindings contain only canonical paths
+  and profile names; they never inspect or move authentication or cookies.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ codex-profile cli personal
 codex-profile cli work exec "run tests and summarize failures"
 ```
 
+Optionally bind a project once, then let the current directory select its
+profile for both CLI and Desktop launches:
+
+```sh
+codex-profile workspace bind ~/Dev/work-project work
+cd ~/Dev/work-project
+codex-profile run exec "run tests and summarize failures"
+codex-profile run --app
+```
+
 On macOS, open the stock ChatGPT session or a named window with separate local
 state:
 
@@ -196,7 +206,57 @@ codex-profile remove client-a --yes
 
 `list` and `status` are read-only. They do not create a directory for a typo.
 Removing a profile deletes its Codex home and, for a named Desktop profile, its
-local Electron data. Review the path and close the corresponding window first.
+local Electron data. It also removes bindings that target that profile, without
+deleting any project directory. Review the path and close the corresponding
+window first.
+
+### Bind projects to profiles
+
+```sh
+codex-profile workspace bind ~/Dev/client-a client-a
+codex-profile workspace bind ~/Dev/client-a/service client-a-service
+codex-profile workspace list
+codex-profile workspace status
+codex-profile workspace status --json ~/Dev/client-a/service
+```
+
+Bindings use physical canonical directory paths. The nearest bound ancestor
+wins, so a nested project can override a broader workspace. Similar string
+prefixes are not matches: binding `client-a` does not bind `client-app`.
+Bindings are private local metadata; they do not create or modify files in a
+project.
+
+From a bound directory, omit the profile name:
+
+```sh
+codex-profile run
+codex-profile run exec "review this repo"
+codex-profile run -- --app            # pass --app to the upstream CLI
+codex-profile run --app               # launch the bound ChatGPT window
+codex-profile run --app ~/Dev/client-a
+```
+
+Explicit `cli`, `env`/`use`, and `app` selections are checked against the
+current or supplied workspace. Mismatches warn on stderr by default, so stdout
+remains safe for `eval` and scripts. Choose stricter or disabled checks with:
+
+```sh
+codex-profile workspace guard strict
+codex-profile workspace guard off
+codex-profile workspace guard warn
+```
+
+Strict mode rejects a mismatch before launching Codex, ChatGPT, or emitting
+shell exports. This is a mistake-prevention guardrail, not a security boundary;
+it can be disabled or bypassed by invoking upstream Codex directly. The wrapper
+does not parse upstream arguments such as `codex -C <directory>`, so change to
+the intended directory before using `run` or an explicitly guarded `cli`.
+
+Binding state is stored with private permissions in
+`${XDG_CONFIG_HOME:-~/.config}/codex-profile/workspaces.tsv`; the guard setting
+is stored beside it. `CODEX_PROFILE_CONFIG_HOME` overrides that directory for
+automation. Bindings contain only canonical project paths and profile names,
+never authentication, cookies, sessions, or credentials.
 
 #### Share configuration, not identity or runtime state
 
@@ -367,6 +427,13 @@ codex-profile cli <profile> [codex-args...]
 codex-profile login <profile> [codex-login-args...]
 codex-profile init <profile> [--share-with <source-profile>]
 codex-profile remove <profile> [--yes]
+codex-profile workspace bind <path> <profile> [--force]
+codex-profile workspace unbind <path>
+codex-profile workspace list [--json]
+codex-profile workspace status [--json] [path]
+codex-profile workspace guard [off|warn|strict]
+codex-profile run [--] [codex-args...]
+codex-profile run --app [workspace]
 codex-profile status [profile]
 codex-profile status --json [profile]
 codex-profile path <profile>
@@ -404,6 +471,7 @@ launch or log mode.
 | `CODEX_APP_BIN` | Deprecated executable override; accepted only for an executable inside an app bundle. |
 | `CODEX_CLI` | Use a specific Codex CLI. An invalid explicit override fails instead of silently selecting another binary. |
 | `CODEX_BUNDLED_CLI` | Optional fallback Codex CLI checked after `PATH` and before the selected app's bundled CLI. |
+| `CODEX_PROFILE_CONFIG_HOME` | Override the private directory containing workspace bindings and guard mode. |
 | `CODEX_PROFILE_UPGRADE_REPO` | Override the source-upgrade repository. |
 | `CODEX_PROFILE_UPGRADE_REF` | Override the source-upgrade git ref. |
 | `CODEX_PROFILE_UPGRADE_CACHE` | Override the source-upgrade cache. |
@@ -447,7 +515,7 @@ contains no profile data; disable it with `CODEX_PROFILE_NO_UPDATE_CHECK=1` or
 CLI-oriented commands are tested on macOS and Ubuntu/Linux:
 
 ```text
-cli login init remove status path env use logs clone-config list doctor completions shell-init upgrade version help
+cli login init remove workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help
 ```
 
 `app` is macOS-only. It detects the installed integrated `ChatGPT.app` and

--- a/README.md
+++ b/README.md
@@ -249,8 +249,10 @@ codex-profile workspace guard warn
 Strict mode rejects a mismatch before launching Codex, ChatGPT, or emitting
 shell exports. This is a mistake-prevention guardrail, not a security boundary;
 it can be disabled or bypassed by invoking upstream Codex directly. The wrapper
-does not parse upstream arguments such as `codex -C <directory>`, so change to
-the intended directory before using `run` or an explicitly guarded `cli`.
+requires `--` before upstream options that start with a dash, for example
+`codex-profile run -- -C <directory>`. Those arguments are passed through and
+are not parsed for guard resolution, so change to the intended directory before
+using `run` or an explicitly guarded `cli`.
 
 Binding state is stored with private permissions in
 `${XDG_CONFIG_HOME:-~/.config}/codex-profile/workspaces.tsv`; the guard setting

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -11,6 +11,9 @@ CODEX_BUNDLED_CLI="${CODEX_BUNDLED_CLI:-}"
 CODEX_PROFILE_APP_INSTANCE_ROOT="${CODEX_PROFILE_APP_INSTANCE_ROOT:-$HOME/Library/Application Support/codex-profile/app-instances}"
 CODEX_PROFILE_UPGRADE_REPO="${CODEX_PROFILE_UPGRADE_REPO:-https://github.com/Ducksss/codex-profiles.git}"
 CODEX_PROFILE_UPGRADE_REF="${CODEX_PROFILE_UPGRADE_REF:-main}"
+CODEX_PROFILE_CONFIG_HOME="${CODEX_PROFILE_CONFIG_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/codex-profile}"
+WORKSPACE_REGISTRY="$CODEX_PROFILE_CONFIG_HOME/workspaces.tsv"
+WORKSPACE_GUARD_FILE="$CODEX_PROFILE_CONFIG_HOME/guard-mode"
 
 usage() {
   cat <<EOF
@@ -217,6 +220,215 @@ initialize_shared_profile() {
 
   note "Initialized $target_profile ($target_home)"
   note "Sharing configuration with $source_profile ($source_home)"
+}
+
+profile_is_initialized() {
+  local codex_home
+
+  codex_home="$(codex_home_for_profile "$1")"
+  [[ -d "$codex_home" && ! -L "$codex_home" ]]
+}
+
+workspace_path_has_control_characters() {
+  local path="$1"
+
+  [[ "$path" == *$'\t'* || "$path" == *$'\r'* || "$path" == *$'\n'* ]]
+}
+
+canonical_directory() {
+  local path="$1" canonical
+
+  workspace_path_has_control_characters "$path" && \
+    die "Workspace paths cannot contain tab, carriage-return, or newline control characters."
+  [[ -d "$path" ]] || die "Workspace directory does not exist: $path"
+  canonical="$(cd -- "$path" 2> /dev/null && pwd -P)" || \
+    die "Cannot resolve workspace directory: $path"
+  workspace_path_has_control_characters "$canonical" && \
+    die "Workspace paths cannot contain tab, carriage-return, or newline control characters."
+  printf '%s\n' "$canonical"
+}
+
+workspace_path_for_unbind() {
+  local path="$1"
+
+  workspace_path_has_control_characters "$path" && \
+    die "Workspace paths cannot contain tab, carriage-return, or newline control characters."
+
+  if [[ -d "$path" ]]; then
+    canonical_directory "$path"
+    return 0
+  fi
+
+  [[ "$path" == /* ]] || die "Missing workspace paths must be supplied as absolute paths: $path"
+  while [[ "$path" != "/" && "$path" == */ ]]; do
+    path="${path%/}"
+  done
+  printf '%s\n' "$path"
+}
+
+workspace_assert_state_paths_safe() {
+  [[ ! -L "$CODEX_PROFILE_CONFIG_HOME" ]] || \
+    die "Refusing symlinked workspace config directory: $CODEX_PROFILE_CONFIG_HOME"
+  [[ ! -L "$WORKSPACE_REGISTRY" ]] || \
+    die "Refusing symlinked workspace registry: $WORKSPACE_REGISTRY"
+  [[ ! -L "$WORKSPACE_GUARD_FILE" ]] || \
+    die "Refusing symlinked workspace guard file: $WORKSPACE_GUARD_FILE"
+
+  if [[ -e "$WORKSPACE_REGISTRY" && ! -f "$WORKSPACE_REGISTRY" ]]; then
+    die "Workspace registry is not a regular file: $WORKSPACE_REGISTRY"
+  fi
+  if [[ -e "$WORKSPACE_GUARD_FILE" && ! -f "$WORKSPACE_GUARD_FILE" ]]; then
+    die "Workspace guard state is not a regular file: $WORKSPACE_GUARD_FILE"
+  fi
+}
+
+ensure_workspace_config_home() {
+  workspace_assert_state_paths_safe
+  mkdir -p "$CODEX_PROFILE_CONFIG_HOME" || \
+    die "Cannot create workspace config directory: $CODEX_PROFILE_CONFIG_HOME"
+  [[ -d "$CODEX_PROFILE_CONFIG_HOME" ]] || \
+    die "Workspace config path is not a directory: $CODEX_PROFILE_CONFIG_HOME"
+  chmod 700 "$CODEX_PROFILE_CONFIG_HOME" || \
+    die "Cannot set private permissions on: $CODEX_PROFILE_CONFIG_HOME"
+}
+
+workspace_parse_registry_line() {
+  local line="$1" line_number="$2" tab=$'\t' path profile
+
+  [[ -n "$line" ]] || return 1
+  if [[ "$line" != *"$tab"* ]]; then
+    die "Malformed workspace registry line $line_number: expected <path><tab><profile>."
+  fi
+
+  path="${line%%$'\t'*}"
+  profile="${line#*$'\t'}"
+  if [[ -z "$path" || -z "$profile" || "$profile" == *"$tab"* || \
+        "$path" != /* ]] || workspace_path_has_control_characters "$path" || \
+        ! is_valid_profile_name "$profile"; then
+    die "Malformed workspace registry line $line_number: invalid path or profile."
+  fi
+
+  WORKSPACE_ROW_PATH="$path"
+  WORKSPACE_ROW_PROFILE="$profile"
+  return 0
+}
+
+workspace_registry_validate() {
+  local line line_number=0
+
+  workspace_assert_state_paths_safe
+  [[ -f "$WORKSPACE_REGISTRY" ]] || return 0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    workspace_parse_registry_line "$line" "$line_number" || true
+  done < "$WORKSPACE_REGISTRY"
+}
+
+workspace_guard_mode() {
+  local mode
+
+  workspace_assert_state_paths_safe
+  if [[ ! -f "$WORKSPACE_GUARD_FILE" ]]; then
+    printf 'warn\n'
+    return 0
+  fi
+
+  mode="$(< "$WORKSPACE_GUARD_FILE")"
+  case "$mode" in
+    off | warn | strict)
+      printf '%s\n' "$mode"
+      ;;
+    *)
+      die "Invalid workspace guard state in $WORKSPACE_GUARD_FILE. Use off, warn, or strict."
+      ;;
+  esac
+}
+
+workspace_exact_profile() {
+  local requested_path="$1" line line_number=0
+
+  WORKSPACE_EXACT_PROFILE=""
+  workspace_registry_validate
+  [[ -f "$WORKSPACE_REGISTRY" ]] || return 1
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    workspace_parse_registry_line "$line" "$line_number" || continue
+    if [[ "$WORKSPACE_ROW_PATH" == "$requested_path" ]]; then
+      WORKSPACE_EXACT_PROFILE="$WORKSPACE_ROW_PROFILE"
+      return 0
+    fi
+  done < "$WORKSPACE_REGISTRY"
+  return 1
+}
+
+workspace_registry_rewrite() {
+  local skipped_path="$1" appended_profile="${2:-}"
+  local line line_number=0 temp
+
+  workspace_registry_validate
+  ensure_workspace_config_home
+  temp="$(mktemp "$CODEX_PROFILE_CONFIG_HOME/.workspaces.tmp.XXXXXX")" || \
+    die "Cannot create a temporary workspace registry."
+  chmod 600 "$temp" || {
+    rm -f "$temp"
+    die "Cannot set private permissions on temporary workspace registry."
+  }
+
+  if [[ -f "$WORKSPACE_REGISTRY" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      line_number=$((line_number + 1))
+      if ! workspace_parse_registry_line "$line" "$line_number"; then
+        continue
+      fi
+      if [[ "$WORKSPACE_ROW_PATH" != "$skipped_path" ]]; then
+        printf '%s\t%s\n' "$WORKSPACE_ROW_PATH" "$WORKSPACE_ROW_PROFILE" >> "$temp" || {
+          rm -f "$temp"
+          die "Cannot write temporary workspace registry."
+        }
+      fi
+    done < "$WORKSPACE_REGISTRY"
+  fi
+
+  if [[ -n "$appended_profile" ]]; then
+    printf '%s\t%s\n' "$skipped_path" "$appended_profile" >> "$temp" || {
+      rm -f "$temp"
+      die "Cannot write temporary workspace registry."
+    }
+  fi
+
+  mv -f "$temp" "$WORKSPACE_REGISTRY" || {
+    rm -f "$temp"
+    die "Cannot replace workspace registry: $WORKSPACE_REGISTRY"
+  }
+}
+
+workspace_resolve() {
+  local requested_path="$1" line line_number=0 binding profile
+
+  WORKSPACE_RESOLVED_PATH="$(canonical_directory "$requested_path")"
+  WORKSPACE_RESOLVED_BINDING=""
+  WORKSPACE_RESOLVED_PROFILE=""
+  workspace_registry_validate
+  [[ -f "$WORKSPACE_REGISTRY" ]] || return 1
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    workspace_parse_registry_line "$line" "$line_number" || continue
+    binding="$WORKSPACE_ROW_PATH"
+    profile="$WORKSPACE_ROW_PROFILE"
+
+    if [[ "$WORKSPACE_RESOLVED_PATH" == "$binding" || "$binding" == "/" || \
+          "$WORKSPACE_RESOLVED_PATH" == "$binding/"* ]]; then
+      if [[ ${#binding} -gt ${#WORKSPACE_RESOLVED_BINDING} ]]; then
+        WORKSPACE_RESOLVED_BINDING="$binding"
+        WORKSPACE_RESOLVED_PROFILE="$profile"
+      fi
+    fi
+  done < "$WORKSPACE_REGISTRY"
+
+  [[ -n "$WORKSPACE_RESOLVED_PROFILE" ]]
 }
 
 desktop_plist_value() {
@@ -921,6 +1133,214 @@ command_status() {
 
 command_list() {
   discover_profiles yes
+}
+
+command_workspace_bind() {
+  local usage="Usage: $PROGRAM workspace bind <path> <profile> [--force]"
+  local path="${1:-}" profile="${2:-}" force=no canonical existing
+
+  [[ -n "$path" && -n "$profile" ]] || die "$usage"
+  shift 2 || true
+  if [[ "${1:-}" == "--force" ]]; then
+    force=yes
+    shift
+  fi
+  [[ "$#" -eq 0 ]] || die "$usage"
+
+  validate_profile "$profile"
+  profile_is_initialized "$profile" || \
+    die "Profile '$profile' is not initialized; run '$PROGRAM init $profile' first."
+  canonical="$(canonical_directory "$path")"
+
+  if workspace_exact_profile "$canonical"; then
+    existing="$WORKSPACE_EXACT_PROFILE"
+    if [[ "$existing" == "$profile" ]]; then
+      note "Already bound $canonical to profile $profile"
+      return 0
+    fi
+    [[ "$force" == "yes" ]] || \
+      die "Workspace $canonical is already bound to profile $existing; use --force to replace it."
+    workspace_registry_rewrite "$canonical" "$profile"
+    note "Rebound $canonical from profile $existing to $profile"
+    return 0
+  fi
+
+  workspace_registry_rewrite "$canonical" "$profile"
+  note "Bound $canonical to profile $profile"
+}
+
+command_workspace_unbind() {
+  local usage="Usage: $PROGRAM workspace unbind <path>"
+  local path="${1:-}" canonical
+
+  [[ -n "$path" ]] || die "$usage"
+  shift || true
+  [[ "$#" -eq 0 ]] || die "$usage"
+  canonical="$(workspace_path_for_unbind "$path")"
+
+  workspace_exact_profile "$canonical" || \
+    die "No exact workspace binding exists for $canonical."
+  workspace_registry_rewrite "$canonical"
+  note "Unbound $canonical"
+}
+
+command_workspace_list() {
+  local json=no line line_number=0 mode first=yes
+  local path profile path_exists profile_exists state
+
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --json | -j) json=yes ;;
+      *) die "Usage: $PROGRAM workspace list [--json]" ;;
+    esac
+    shift
+  done
+
+  workspace_registry_validate
+  mode="$(workspace_guard_mode)"
+
+  if [[ "$json" == "yes" ]]; then
+    printf '{"guard_mode":'
+    json_string "$mode"
+    printf ',"bindings":['
+  else
+    note "Workspace guard mode: $mode"
+  fi
+
+  if [[ -f "$WORKSPACE_REGISTRY" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      line_number=$((line_number + 1))
+      workspace_parse_registry_line "$line" "$line_number" || continue
+      path="$WORKSPACE_ROW_PATH"
+      profile="$WORKSPACE_ROW_PROFILE"
+      if [[ -d "$path" ]]; then path_exists=true; else path_exists=false; fi
+      if profile_is_initialized "$profile"; then profile_exists=true; else profile_exists=false; fi
+
+      if [[ "$json" == "yes" ]]; then
+        if [[ "$first" == "yes" ]]; then first=no; else printf ','; fi
+        printf '{"path":'
+        json_string "$path"
+        printf ',"profile":'
+        json_string "$profile"
+        printf ',"path_exists":%s,"profile_exists":%s}' "$path_exists" "$profile_exists"
+      else
+        state=""
+        [[ "$path_exists" == "true" ]] || state="${state} missing-path"
+        [[ "$profile_exists" == "true" ]] || state="${state} missing-profile"
+        if [[ -n "$state" ]]; then
+          printf '%s -> %s [%s]\n' "$path" "$profile" "${state# }"
+        else
+          printf '%s -> %s\n' "$path" "$profile"
+        fi
+      fi
+    done < "$WORKSPACE_REGISTRY"
+  fi
+
+  if [[ "$json" == "yes" ]]; then
+    printf ']}\n'
+  elif [[ "$first" == "yes" && ! -s "$WORKSPACE_REGISTRY" ]]; then
+    note "No workspace bindings."
+  fi
+}
+
+command_workspace_status() {
+  local usage="Usage: $PROGRAM workspace status [--json] [path]"
+  local json=no path="" mode matched=no
+
+  while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+      --json | -j)
+        json=yes
+        ;;
+      -*)
+        die "$usage"
+        ;;
+      *)
+        [[ -z "$path" ]] || die "$usage"
+        path="$1"
+        ;;
+    esac
+    shift
+  done
+  [[ -n "$path" ]] || path="$PWD"
+
+  mode="$(workspace_guard_mode)"
+  if workspace_resolve "$path"; then
+    matched=yes
+  fi
+
+  if [[ "$json" == "yes" ]]; then
+    printf '{"path":'
+    json_string "$WORKSPACE_RESOLVED_PATH"
+    printf ',"binding_path":'
+    if [[ "$matched" == "yes" ]]; then json_string "$WORKSPACE_RESOLVED_BINDING"; else printf 'null'; fi
+    printf ',"profile":'
+    if [[ "$matched" == "yes" ]]; then json_string "$WORKSPACE_RESOLVED_PROFILE"; else printf 'null'; fi
+    printf ',"guard_mode":'
+    json_string "$mode"
+    printf '}\n'
+    return 0
+  fi
+
+  note "Workspace: $WORKSPACE_RESOLVED_PATH"
+  if [[ "$matched" == "yes" ]]; then
+    note "Binding: $WORKSPACE_RESOLVED_BINDING"
+    note "Profile: $WORKSPACE_RESOLVED_PROFILE"
+  else
+    note "Binding: none"
+    note "Profile: none"
+  fi
+  note "Guard mode: $mode"
+}
+
+command_workspace_guard() {
+  local usage="Usage: $PROGRAM workspace guard [off|warn|strict]"
+  local mode="${1:-}" temp
+
+  if [[ -z "$mode" ]]; then
+    workspace_guard_mode
+    return 0
+  fi
+  shift
+  [[ "$#" -eq 0 ]] || die "$usage"
+  case "$mode" in
+    off | warn | strict) ;;
+    *) die "Invalid workspace guard mode '$mode'. Use off, warn, or strict." ;;
+  esac
+
+  workspace_registry_validate
+  ensure_workspace_config_home
+  temp="$(mktemp "$CODEX_PROFILE_CONFIG_HOME/.guard-mode.tmp.XXXXXX")" || \
+    die "Cannot create temporary workspace guard state."
+  printf '%s\n' "$mode" > "$temp" || {
+    rm -f "$temp"
+    die "Cannot write temporary workspace guard state."
+  }
+  chmod 600 "$temp" || {
+    rm -f "$temp"
+    die "Cannot set private permissions on temporary workspace guard state."
+  }
+  mv -f "$temp" "$WORKSPACE_GUARD_FILE" || {
+    rm -f "$temp"
+    die "Cannot replace workspace guard state: $WORKSPACE_GUARD_FILE"
+  }
+  note "Workspace guard mode: $mode"
+}
+
+command_workspace() {
+  local subcommand="${1:-}"
+
+  [[ -n "$subcommand" ]] || \
+    die "Usage: $PROGRAM workspace <bind|unbind|list|status|guard> ..."
+  shift || true
+  case "$subcommand" in
+    bind) command_workspace_bind "$@" ;;
+    unbind) command_workspace_unbind "$@" ;;
+    list) command_workspace_list "$@" ;;
+    status) command_workspace_status "$@" ;;
+    guard) command_workspace_guard "$@" ;;
+    *) die "Unknown workspace command '$subcommand'. Use bind, unbind, list, status, or guard." ;;
+  esac
 }
 
 command_path() {
@@ -1731,7 +2151,7 @@ main() {
   shift || true
 
   case "$command" in
-    status | doctor)
+    status | doctor | workspace)
       for arg in "$@"; do
         if [[ "$arg" == "--json" || "$arg" == "-j" ]]; then
           json_command=yes
@@ -1763,6 +2183,9 @@ main() {
       ;;
     remove)
       command_remove "$@"
+      ;;
+    workspace)
+      command_workspace "$@"
       ;;
     status)
       command_status "$@"

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -25,6 +25,13 @@ Usage:
   $PROGRAM login <profile> [codex-login-args...]
   $PROGRAM init <profile> [--share-with <source-profile>]
   $PROGRAM remove <profile> [--yes]
+  $PROGRAM workspace bind <path> <profile> [--force]
+  $PROGRAM workspace unbind <path>
+  $PROGRAM workspace list [--json]
+  $PROGRAM workspace status [--json] [path]
+  $PROGRAM workspace guard [off|warn|strict]
+  $PROGRAM run [--] [codex-args...]
+  $PROGRAM run --app [workspace]
   $PROGRAM status [profile]
   $PROGRAM status --json [profile]
   $PROGRAM path <profile>
@@ -47,6 +54,9 @@ Examples:
   $PROGRAM app personal ~/Dev/my-project
   $PROGRAM app work ~/Dev/client-project
   $PROGRAM cli personal exec "review this repo"
+  $PROGRAM workspace bind ~/Dev/client-project work
+  $PROGRAM run exec "review this repo"
+  $PROGRAM run --app
   $PROGRAM status
   eval "\$($PROGRAM env work)"     # set CODEX_HOME for this shell
   $PROGRAM use work               # same, via the shell-init wrapper
@@ -75,6 +85,7 @@ Environment:
   CODEX_APP_BIN   Locate a desktop .app from its executable (deprecated).
   CODEX_CLI       Override Codex CLI binary path.
   CODEX_BUNDLED_CLI  Override the bundled Codex CLI fallback path.
+  CODEX_PROFILE_CONFIG_HOME  Override private workspace binding storage.
   CODEX_PROFILE_APP_INSTANCE_ROOT  Legacy clone root (doctor only; never written).
   CODEX_PROFILE_UPGRADE_REPO    Override upgrade repository.
   CODEX_PROFILE_UPGRADE_REF     Override upgrade git ref.
@@ -2024,14 +2035,15 @@ command_completions() {
       cat <<'EOF'
 _codex_profile()
 {
-  local cur command prev profiles
+  local cur command prev profiles workspace_commands
   COMPREPLY=()
   cur="${COMP_WORDS[COMP_CWORD]}"
   command="${COMP_WORDS[1]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
+  workspace_commands="bind unbind list status guard"
 
   if [[ "$COMP_CWORD" -eq 1 ]]; then
-    COMPREPLY=( $(compgen -W "app app-instance cli login init remove status path env use logs clone-config list doctor completions shell-init upgrade version help" -- "$cur") )
+    COMPREPLY=( $(compgen -W "app app-instance cli login init remove workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help" -- "$cur") )
     return 0
   fi
 
@@ -2064,6 +2076,23 @@ _codex_profile()
         COMPREPLY=( $(compgen -W "default personal work $profiles" -- "$cur") )
       fi
       ;;
+    workspace)
+      if [[ "$COMP_CWORD" -eq 2 ]]; then
+        COMPREPLY=( $(compgen -W "$workspace_commands" -- "$cur") )
+      elif [[ "${COMP_WORDS[2]}" == "bind" && "$COMP_CWORD" -eq 4 ]]; then
+        profiles="$(codex-profile list 2>/dev/null)"
+        COMPREPLY=( $(compgen -W "default personal work $profiles" -- "$cur") )
+      elif [[ "${COMP_WORDS[2]}" == "guard" && "$COMP_CWORD" -eq 3 ]]; then
+        COMPREPLY=( $(compgen -W "off warn strict" -- "$cur") )
+      elif [[ ( "${COMP_WORDS[2]}" == "list" || "${COMP_WORDS[2]}" == "status" ) && "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "--json" -- "$cur") )
+      fi
+      ;;
+    run)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "--app" -- "$cur") )
+      fi
+      ;;
     completions|shell-init)
       if [[ "$COMP_CWORD" -eq 2 ]]; then
         COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
@@ -2079,14 +2108,16 @@ EOF
 #compdef codex-profile codex-profiles
 
 _codex_profile() {
-  local -a commands profiles shells app_flags init_flags
+  local -a commands profiles shells app_flags init_flags workspace_commands run_flags
   commands=(
-    app app-instance cli login init remove status path env use logs clone-config list doctor completions shell-init upgrade version help
+    app app-instance cli login init remove workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help
   )
   profiles=(${(f)"$(codex-profile list 2>/dev/null)"} default personal work)
   shells=(bash zsh fish)
   app_flags=(--instance --rebuild)
   init_flags=(--share-with)
+  workspace_commands=(bind unbind list status guard)
+  run_flags=(--app)
 
   if (( CURRENT == 2 )); then
     _describe 'command' commands
@@ -2118,6 +2149,20 @@ _codex_profile() {
         _describe 'profile' profiles
       fi
       ;;
+    workspace)
+      if (( CURRENT == 3 )); then
+        _describe 'workspace command' workspace_commands
+      elif [[ "$words[3]" == "bind" ]] && (( CURRENT == 5 )); then
+        _describe 'profile' profiles
+      elif [[ "$words[3]" == "guard" ]] && (( CURRENT == 4 )); then
+        _values 'guard mode' off warn strict
+      fi
+      ;;
+    run)
+      if [[ "$words[CURRENT]" == -* ]]; then
+        _describe 'flag' run_flags
+      fi
+      ;;
     completions|shell-init)
       if (( CURRENT == 3 )); then
         _describe 'shell' shells
@@ -2133,12 +2178,20 @@ EOF
       cat <<'EOF'
 for codex_profile_command in codex-profile codex-profiles
     complete -c $codex_profile_command -f
-    complete -c $codex_profile_command -n '__fish_is_first_arg' -a 'app app-instance cli login init remove status path env use logs clone-config list doctor completions shell-init upgrade version help'
+    complete -c $codex_profile_command -n '__fish_is_first_arg' -a 'app app-instance cli login init remove workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from app app-instance cli login init remove status path env use logs' -a '(codex-profile list 2>/dev/null) default personal work'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from app' -l instance -d 'Compatibility flag; named ChatGPT windows already use separate local state'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from app' -l rebuild -d 'Compatibility no-op; the signed app is never cloned'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from init' -l share-with -r -a '(codex-profile list 2>/dev/null) default personal work' -d 'Link the configuration allowlist from another profile'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from clone-config' -a '(codex-profile list 2>/dev/null) default personal work'
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from workspace; and test (count (commandline -opc)) -eq 2' -a 'bind unbind list status guard'
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from workspace; and __fish_seen_subcommand_from bind; and test (count (commandline -opc)) -eq 3' -F
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from workspace; and __fish_seen_subcommand_from bind; and test (count (commandline -opc)) -eq 4' -a '(codex-profile list 2>/dev/null) default personal work'
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from workspace; and __fish_seen_subcommand_from unbind; and test (count (commandline -opc)) -eq 3' -F
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from workspace; and __fish_seen_subcommand_from status; and test (count (commandline -opc)) -eq 3' -F
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from workspace; and __fish_seen_subcommand_from guard; and test (count (commandline -opc)) -eq 3' -a 'off warn strict'
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from workspace; and __fish_seen_subcommand_from list status' -l json -d 'Emit JSON'
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from run' -l app -d 'Launch the bound ChatGPT window'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from completions shell-init' -a 'bash zsh fish'
 end
 EOF

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -431,6 +431,23 @@ workspace_resolve() {
   [[ -n "$WORKSPACE_RESOLVED_PROFILE" ]]
 }
 
+workspace_guard_profile() {
+  local selected_profile="$1" path="$2" mode
+
+  mode="$(workspace_guard_mode)"
+  [[ "$mode" != "off" ]] || return 0
+  if ! workspace_resolve "$path"; then
+    return 0
+  fi
+  [[ "$selected_profile" != "$WORKSPACE_RESOLVED_PROFILE" ]] || return 0
+
+  if [[ "$mode" == "strict" ]]; then
+    die "Workspace '$WORKSPACE_RESOLVED_BINDING' is bound to profile '$WORKSPACE_RESOLVED_PROFILE'; refusing selected profile '$selected_profile'."
+  fi
+  printf "Warning: workspace '%s' is bound to profile '%s'; selected profile is '%s'.\n" \
+    "$WORKSPACE_RESOLVED_BINDING" "$WORKSPACE_RESOLVED_PROFILE" "$selected_profile" >&2
+}
+
 desktop_plist_value() {
   local app="$1"
   local key="$2"
@@ -713,6 +730,8 @@ command_app() {
 
   [[ "$profile_set" == yes ]] || die "$usage"
   [[ "$workspace_set" == yes ]] || workspace="$PWD"
+  validate_profile "$profile"
+  workspace_guard_profile "$profile" "$workspace"
 
   if [[ "$instance" == yes ]]; then
     note "Compatibility: --instance is no longer needed; named ChatGPT windows already use separate local state."
@@ -790,6 +809,8 @@ command_cli() {
   shift || true
 
   local codex_home codex_cli
+  validate_profile "$profile"
+  workspace_guard_profile "$profile" "$PWD"
   codex_home="$(codex_home_for_profile "$profile")"
   ensure_home "$codex_home"
   codex_cli="$(find_codex_cli)"
@@ -1343,6 +1364,35 @@ command_workspace() {
   esac
 }
 
+command_run() {
+  local usage="Usage: $PROGRAM run [--] [codex-args...]\n       $PROGRAM run --app [workspace]"
+  local workspace profile
+
+  if [[ "${1:-}" == "--app" ]]; then
+    shift
+    workspace="${1:-$PWD}"
+    if [[ "$#" -gt 0 ]]; then
+      shift
+    fi
+    [[ "$#" -eq 0 ]] || die "$usage"
+    if ! workspace_resolve "$workspace"; then
+      die "No workspace profile is bound to '$WORKSPACE_RESOLVED_PATH'. Run '$PROGRAM workspace bind $WORKSPACE_RESOLVED_PATH <profile>' first."
+    fi
+    profile="$WORKSPACE_RESOLVED_PROFILE"
+    command_app "$profile" "$WORKSPACE_RESOLVED_PATH"
+    return 0
+  fi
+
+  if [[ "${1:-}" == "--" ]]; then
+    shift
+  fi
+  if ! workspace_resolve "$PWD"; then
+    die "No workspace profile is bound to '$WORKSPACE_RESOLVED_PATH'. Run '$PROGRAM workspace bind $WORKSPACE_RESOLVED_PATH <profile>' first."
+  fi
+  profile="$WORKSPACE_RESOLVED_PROFILE"
+  command_cli "$profile" "$@"
+}
+
 command_path() {
   local profile="${1:-}"
   [[ -n "$profile" ]] || die "Usage: $PROGRAM path <profile>"
@@ -1389,6 +1439,7 @@ command_env() {
 
   local codex_home
   codex_home="$(codex_home_for_profile "$profile")"
+  workspace_guard_profile "$profile" "$PWD"
 
   if [[ ! -d "$codex_home" ]]; then
     printf "%s: profile '%s' is not initialized (%s); run '%s init %s' or '%s login %s'.\n" \
@@ -2186,6 +2237,9 @@ main() {
       ;;
     workspace)
       command_workspace "$@"
+      ;;
+    run)
+      command_run "$@"
       ;;
     status)
       command_status "$@"

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -295,7 +295,7 @@ workspace_assert_state_paths_safe() {
 
 ensure_workspace_config_home() {
   workspace_assert_state_paths_safe
-  mkdir -p "$CODEX_PROFILE_CONFIG_HOME" || \
+  (umask 077 && mkdir -p "$CODEX_PROFILE_CONFIG_HOME") || \
     die "Cannot create workspace config directory: $CODEX_PROFILE_CONFIG_HOME"
   [[ -d "$CODEX_PROFILE_CONFIG_HOME" ]] || \
     die "Workspace config path is not a directory: $CODEX_PROFILE_CONFIG_HOME"
@@ -421,9 +421,12 @@ workspace_registry_rewrite() {
 workspace_resolve() {
   local requested_path="$1" line line_number=0 binding profile
 
-  WORKSPACE_RESOLVED_PATH="$(canonical_directory "$requested_path")"
+  WORKSPACE_RESOLVED_PATH=""
   WORKSPACE_RESOLVED_BINDING=""
   WORKSPACE_RESOLVED_PROFILE=""
+  if ! WORKSPACE_RESOLVED_PATH="$(canonical_directory "$requested_path")"; then
+    return 2
+  fi
   workspace_registry_validate
   [[ -f "$WORKSPACE_REGISTRY" ]] || return 1
 
@@ -537,11 +540,17 @@ workspace_registry_stats() {
 }
 
 workspace_guard_profile() {
-  local selected_profile="$1" path="$2" mode
+  local selected_profile="$1" path="$2" mode resolve_status
 
   mode="$(workspace_guard_mode)"
   [[ "$mode" != "off" ]] || return 0
-  if ! workspace_resolve "$path"; then
+  workspace_registry_validate
+  [[ -s "$WORKSPACE_REGISTRY" && -d "$path" ]] || return 0
+  if workspace_resolve "$path"; then
+    :
+  else
+    resolve_status=$?
+    [[ "$resolve_status" -eq 1 ]] || return 1
     return 0
   fi
   [[ "$selected_profile" != "$WORKSPACE_RESOLVED_PROFILE" ]] || return 0
@@ -1374,7 +1383,7 @@ command_workspace_list() {
 
 command_workspace_status() {
   local usage="Usage: $PROGRAM workspace status [--json] [path]"
-  local json=no path="" mode matched=no
+  local json=no path="" mode matched=no resolve_status
 
   while [[ "$#" -gt 0 ]]; do
     case "$1" in
@@ -1396,6 +1405,9 @@ command_workspace_status() {
   mode="$(workspace_guard_mode)"
   if workspace_resolve "$path"; then
     matched=yes
+  else
+    resolve_status=$?
+    [[ "$resolve_status" -eq 1 ]] || return 1
   fi
 
   if [[ "$json" == "yes" ]]; then
@@ -1474,7 +1486,7 @@ command_workspace() {
 
 command_run() {
   local usage="Usage: $PROGRAM run [--] [codex-args...]\n       $PROGRAM run --app [workspace]"
-  local workspace profile
+  local workspace profile resolve_status
 
   if [[ "${1:-}" == "--app" ]]; then
     shift
@@ -1483,7 +1495,11 @@ command_run() {
       shift
     fi
     [[ "$#" -eq 0 ]] || die "$usage"
-    if ! workspace_resolve "$workspace"; then
+    if workspace_resolve "$workspace"; then
+      :
+    else
+      resolve_status=$?
+      [[ "$resolve_status" -eq 1 ]] || return 1
       die "No workspace profile is bound to '$WORKSPACE_RESOLVED_PATH'. Run '$PROGRAM workspace bind $WORKSPACE_RESOLVED_PATH <profile>' first."
     fi
     profile="$WORKSPACE_RESOLVED_PROFILE"
@@ -1494,7 +1510,11 @@ command_run() {
   if [[ "${1:-}" == "--" ]]; then
     shift
   fi
-  if ! workspace_resolve "$PWD"; then
+  if workspace_resolve "$PWD"; then
+    :
+  else
+    resolve_status=$?
+    [[ "$resolve_status" -eq 1 ]] || return 1
     die "No workspace profile is bound to '$WORKSPACE_RESOLVED_PATH'. Run '$PROGRAM workspace bind $WORKSPACE_RESOLVED_PATH <profile>' first."
   fi
   profile="$WORKSPACE_RESOLVED_PROFILE"

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -280,6 +280,9 @@ workspace_path_for_unbind() {
 workspace_assert_state_paths_safe() {
   [[ ! -L "$CODEX_PROFILE_CONFIG_HOME" ]] || \
     die "Refusing symlinked workspace config directory: $CODEX_PROFILE_CONFIG_HOME"
+  if [[ -e "$CODEX_PROFILE_CONFIG_HOME" && ! -d "$CODEX_PROFILE_CONFIG_HOME" ]]; then
+    die "Workspace config path is not a directory: $CODEX_PROFILE_CONFIG_HOME"
+  fi
   [[ ! -L "$WORKSPACE_REGISTRY" ]] || \
     die "Refusing symlinked workspace registry: $WORKSPACE_REGISTRY"
   [[ ! -L "$WORKSPACE_GUARD_FILE" ]] || \
@@ -499,6 +502,11 @@ workspace_registry_stats() {
   WORKSPACE_STATS_MISSING_PATHS=0
   WORKSPACE_STATS_MISSING_PROFILES=0
 
+  if [[ -e "$CODEX_PROFILE_CONFIG_HOME" && ! -d "$CODEX_PROFILE_CONFIG_HOME" ]]; then
+    WORKSPACE_STATS_GUARD_MODE=""
+    WORKSPACE_STATS_REGISTRY_VALID=false
+    return 0
+  fi
   if [[ -L "$CODEX_PROFILE_CONFIG_HOME" || -L "$WORKSPACE_REGISTRY" || \
         -L "$WORKSPACE_GUARD_FILE" ]]; then
     WORKSPACE_STATS_GUARD_MODE=""
@@ -1485,7 +1493,8 @@ command_workspace() {
 }
 
 command_run() {
-  local usage="Usage: $PROGRAM run [--] [codex-args...]\n       $PROGRAM run --app [workspace]"
+  local usage="Usage: $PROGRAM run [--] [codex-args...]
+       $PROGRAM run --app [workspace]"
   local workspace profile resolve_status
 
   if [[ "${1:-}" == "--app" ]]; then
@@ -1507,9 +1516,10 @@ command_run() {
     return 0
   fi
 
-  if [[ "${1:-}" == "--" ]]; then
-    shift
-  fi
+  case "${1:-}" in
+    --) shift ;;
+    -*) die "$usage" ;;
+  esac
   if workspace_resolve "$PWD"; then
     :
   else
@@ -2128,7 +2138,7 @@ EOF
 #compdef codex-profile codex-profiles
 
 _codex_profile() {
-  local -a commands profiles shells app_flags init_flags workspace_commands run_flags
+  local -a commands profiles shells app_flags init_flags workspace_commands run_flags workspace_json_flags
   commands=(
     app app-instance cli login init remove workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help
   )
@@ -2138,6 +2148,7 @@ _codex_profile() {
   init_flags=(--share-with)
   workspace_commands=(bind unbind list status guard)
   run_flags=(--app)
+  workspace_json_flags=(--json)
 
   if (( CURRENT == 2 )); then
     _describe 'command' commands
@@ -2176,6 +2187,9 @@ _codex_profile() {
         _describe 'profile' profiles
       elif [[ "$words[3]" == "guard" ]] && (( CURRENT == 4 )); then
         _values 'guard mode' off warn strict
+      elif [[ "$words[3]" == "list" || "$words[3]" == "status" ]] && \
+           [[ "$words[CURRENT]" == -* ]]; then
+        _describe 'flag' workspace_json_flags
       fi
       ;;
     run)

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -292,25 +292,28 @@ ensure_workspace_config_home() {
     die "Cannot set private permissions on: $CODEX_PROFILE_CONFIG_HOME"
 }
 
-workspace_parse_registry_line() {
-  local line="$1" line_number="$2" tab=$'\t' path profile
+workspace_decode_registry_line() {
+  local line="$1" tab=$'\t' path profile
 
-  [[ -n "$line" ]] || return 1
-  if [[ "$line" != *"$tab"* ]]; then
-    die "Malformed workspace registry line $line_number: expected <path><tab><profile>."
-  fi
-
+  [[ -n "$line" && "$line" == *"$tab"* ]] || return 1
   path="${line%%$'\t'*}"
   profile="${line#*$'\t'}"
   if [[ -z "$path" || -z "$profile" || "$profile" == *"$tab"* || \
         "$path" != /* ]] || workspace_path_has_control_characters "$path" || \
         ! is_valid_profile_name "$profile"; then
-    die "Malformed workspace registry line $line_number: invalid path or profile."
+    return 1
   fi
 
   WORKSPACE_ROW_PATH="$path"
   WORKSPACE_ROW_PROFILE="$profile"
-  return 0
+}
+
+workspace_parse_registry_line() {
+  local line="$1" line_number="$2"
+
+  [[ -n "$line" ]] || return 1
+  workspace_decode_registry_line "$line" || \
+    die "Malformed workspace registry line $line_number: expected one absolute <path><tab><profile> row."
 }
 
 workspace_registry_validate() {
@@ -429,6 +432,97 @@ workspace_resolve() {
   done < "$WORKSPACE_REGISTRY"
 
   [[ -n "$WORKSPACE_RESOLVED_PROFILE" ]]
+}
+
+workspace_remove_profile_bindings() {
+  local target_profile="$1" line line_number=0 found=no temp
+
+  workspace_registry_validate
+  [[ -f "$WORKSPACE_REGISTRY" ]] || return 0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    workspace_parse_registry_line "$line" "$line_number" || continue
+    if [[ "$WORKSPACE_ROW_PROFILE" == "$target_profile" ]]; then
+      found=yes
+      break
+    fi
+  done < "$WORKSPACE_REGISTRY"
+  [[ "$found" == "yes" ]] || return 0
+
+  ensure_workspace_config_home
+  temp="$(mktemp "$CODEX_PROFILE_CONFIG_HOME/.workspaces.tmp.XXXXXX")" || \
+    die "Cannot create a temporary workspace registry."
+  chmod 600 "$temp" || {
+    rm -f "$temp"
+    die "Cannot set private permissions on temporary workspace registry."
+  }
+
+  line_number=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    workspace_parse_registry_line "$line" "$line_number" || continue
+    if [[ "$WORKSPACE_ROW_PROFILE" != "$target_profile" ]]; then
+      printf '%s\t%s\n' "$WORKSPACE_ROW_PATH" "$WORKSPACE_ROW_PROFILE" >> "$temp" || {
+        rm -f "$temp"
+        die "Cannot write temporary workspace registry."
+      }
+    fi
+  done < "$WORKSPACE_REGISTRY"
+
+  mv -f "$temp" "$WORKSPACE_REGISTRY" || {
+    rm -f "$temp"
+    die "Cannot replace workspace registry: $WORKSPACE_REGISTRY"
+  }
+}
+
+workspace_registry_stats() {
+  local line mode line_number=0
+
+  WORKSPACE_STATS_GUARD_MODE="warn"
+  WORKSPACE_STATS_REGISTRY_VALID=true
+  WORKSPACE_STATS_BINDING_COUNT=0
+  WORKSPACE_STATS_MISSING_PATHS=0
+  WORKSPACE_STATS_MISSING_PROFILES=0
+
+  if [[ -L "$CODEX_PROFILE_CONFIG_HOME" || -L "$WORKSPACE_REGISTRY" || \
+        -L "$WORKSPACE_GUARD_FILE" ]]; then
+    WORKSPACE_STATS_GUARD_MODE=""
+    WORKSPACE_STATS_REGISTRY_VALID=false
+    return 0
+  fi
+  if [[ -e "$WORKSPACE_REGISTRY" && ! -f "$WORKSPACE_REGISTRY" ]] || \
+     [[ -e "$WORKSPACE_GUARD_FILE" && ! -f "$WORKSPACE_GUARD_FILE" ]]; then
+    WORKSPACE_STATS_GUARD_MODE=""
+    WORKSPACE_STATS_REGISTRY_VALID=false
+    return 0
+  fi
+
+  if [[ -f "$WORKSPACE_GUARD_FILE" ]]; then
+    mode="$(< "$WORKSPACE_GUARD_FILE")"
+    case "$mode" in
+      off | warn | strict) WORKSPACE_STATS_GUARD_MODE="$mode" ;;
+      *)
+        WORKSPACE_STATS_GUARD_MODE=""
+        WORKSPACE_STATS_REGISTRY_VALID=false
+        ;;
+    esac
+  fi
+
+  [[ -f "$WORKSPACE_REGISTRY" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line_number=$((line_number + 1))
+    [[ -n "$line" ]] || continue
+    if ! workspace_decode_registry_line "$line"; then
+      WORKSPACE_STATS_REGISTRY_VALID=false
+      continue
+    fi
+    WORKSPACE_STATS_BINDING_COUNT=$((WORKSPACE_STATS_BINDING_COUNT + 1))
+    [[ -d "$WORKSPACE_ROW_PATH" ]] || \
+      WORKSPACE_STATS_MISSING_PATHS=$((WORKSPACE_STATS_MISSING_PATHS + 1))
+    profile_is_initialized "$WORKSPACE_ROW_PROFILE" || \
+      WORKSPACE_STATS_MISSING_PROFILES=$((WORKSPACE_STATS_MISSING_PROFILES + 1))
+  done < "$WORKSPACE_REGISTRY"
 }
 
 workspace_guard_profile() {
@@ -892,8 +986,10 @@ command_remove() {
 
   local codex_home confirmation
   codex_home="$(codex_home_for_profile "$profile")"
+  workspace_registry_validate
 
   if [[ ! -d "$codex_home" ]]; then
+    workspace_remove_profile_bindings "$profile"
     note "Not initialized $profile ($codex_home)"
     return 0
   fi
@@ -909,6 +1005,7 @@ command_remove() {
   fi
 
   rm -rf -- "$codex_home" || die "Cannot remove profile home: $codex_home"
+  workspace_remove_profile_bindings "$profile"
   note "Removed $profile ($codex_home)"
 }
 
@@ -2120,6 +2217,7 @@ command_doctor() {
     bundle_id="$(desktop_bundle_identifier "$app")"
   fi
   [[ -d "$CODEX_PROFILE_APP_INSTANCE_ROOT" ]] && legacy_clone_found=true
+  workspace_registry_stats
 
   if [[ "$json" == "yes" ]]; then
     local status_code=0
@@ -2136,6 +2234,20 @@ command_doctor() {
     printf ',"legacy_clone_root":{"found":%s,"path":' "$legacy_clone_found"
     json_string "$CODEX_PROFILE_APP_INSTANCE_ROOT"
     printf '}'
+    printf ',"workspaces":{"config_home":'
+    json_string "$CODEX_PROFILE_CONFIG_HOME"
+    printf ',"registry_path":'
+    json_string "$WORKSPACE_REGISTRY"
+    printf ',"guard_mode":'
+    if [[ -n "$WORKSPACE_STATS_GUARD_MODE" ]]; then
+      json_string "$WORKSPACE_STATS_GUARD_MODE"
+    else
+      printf 'null'
+    fi
+    printf ',"registry_valid":%s' "$WORKSPACE_STATS_REGISTRY_VALID"
+    printf ',"binding_count":%s' "$WORKSPACE_STATS_BINDING_COUNT"
+    printf ',"missing_paths":%s' "$WORKSPACE_STATS_MISSING_PATHS"
+    printf ',"missing_profiles":%s}' "$WORKSPACE_STATS_MISSING_PROFILES"
 
     if codex_cli="$(try_find_codex_cli)"; then
       cli_source="$(codex_cli_source "$codex_cli")"
@@ -2178,6 +2290,16 @@ command_doctor() {
   if [[ "$legacy_clone_found" == "true" ]]; then
     note "Legacy app clones: found at $CODEX_PROFILE_APP_INSTANCE_ROOT (safe to remove after closing old cloned apps)"
   fi
+  note "Workspace registry: $WORKSPACE_REGISTRY"
+  if [[ "$WORKSPACE_STATS_REGISTRY_VALID" == "true" ]]; then
+    note "Workspace guard mode: $WORKSPACE_STATS_GUARD_MODE"
+  else
+    note "Workspace guard mode: invalid"
+  fi
+  note "Workspace registry valid: $WORKSPACE_STATS_REGISTRY_VALID"
+  note "Workspace bindings: $WORKSPACE_STATS_BINDING_COUNT"
+  note "Missing workspace paths: $WORKSPACE_STATS_MISSING_PATHS"
+  note "Missing workspace profiles: $WORKSPACE_STATS_MISSING_PROFILES"
 
   if codex_cli="$(try_find_codex_cli)"; then
     cli_source="$(codex_cli_source "$codex_cli")"

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -91,7 +91,7 @@ not match.
 `env`/`use`, and `app` selections before side effects; `off` disables checks.
 This is a local mistake-prevention feature, not an account, OS, server-side, or
 security boundary. Upstream Codex directory flags such as `-C` are passed
-through and are not parsed for guard resolution.
+through after the `run --` separator and are not parsed for guard resolution.
 
 ## Deprecated compatibility spellings
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -23,6 +23,11 @@ homes and, on macOS, named ChatGPT windows with separate local state.
   patching, re-signing, quitting, or replacing it.
 - `status` reports Codex-local authentication. The project does not inspect or
   verify whether a CLI login and ChatGPT Desktop window use the same account.
+- `workspace bind <path> <profile>` stores a private local canonical-path
+  binding. The nearest bound ancestor wins; no file is added to the project.
+- `run` uses the current directory's binding for Codex CLI, while `run --app`
+  uses it for the signed ChatGPT app. Explicit mismatches warn by default and
+  can be rejected with `workspace guard strict`.
 - The project never reads, copies, prints, parses, uploads, compares, or
   migrates auth tokens or ChatGPT cookies.
 - `init <name> --share-with <source>` creates a real private profile directory
@@ -61,6 +66,9 @@ codex-profile init work
 codex-profile init personal-2 --share-with personal
 codex-profile login work
 codex-profile cli work exec "review this repo"
+codex-profile workspace bind ~/Dev/work-project work
+codex-profile run exec "review this repo"
+codex-profile run --app
 codex-profile app default ~/Dev/main-project
 codex-profile app personal ~/Dev/personal-project
 codex-profile app work ~/Dev/work-project
@@ -70,6 +78,20 @@ eval "$(codex-profile env work)"
 
 The word `work` in these examples is an arbitrary profile name. It must not be
 confused with the ChatGPT mode named Work.
+
+## Workspace routing
+
+Workspace bindings contain only a physical canonical path and profile name.
+They live under `${XDG_CONFIG_HOME:-~/.config}/codex-profile` by default, with
+private permissions, and can be relocated with `CODEX_PROFILE_CONFIG_HOME`.
+Nested bindings override broader ancestors; sibling paths with similar names do
+not match.
+
+`workspace guard` defaults to `warn`. `strict` rejects mismatched `cli`,
+`env`/`use`, and `app` selections before side effects; `off` disables checks.
+This is a local mistake-prevention feature, not an account, OS, server-side, or
+security boundary. Upstream Codex directory flags such as `-C` are passed
+through and are not parsed for guard resolution.
 
 ## Deprecated compatibility spellings
 

--- a/docs/superpowers/plans/2026-07-14-workspace-bindings.md
+++ b/docs/superpowers/plans/2026-07-14-workspace-bindings.md
@@ -1,0 +1,270 @@
+# Workspace Bindings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add private workspace-to-profile bindings, bound-profile launches, mismatch guards, lifecycle cleanup, diagnostics, completions, and documentation.
+
+**Architecture:** Keep runtime behavior in `bin/codex-profile`. Store canonical-path bindings in a private tab-separated registry, resolve the longest matching directory ancestor, and reuse that resolver for the new `workspace`/`run` commands and guards around explicit profile commands. Extend the existing Bash behavior suite before each implementation slice.
+
+**Tech Stack:** Bash 3.2-compatible shell, standard macOS/Linux tools, dependency-free Bash tests, ShellCheck, Markdown.
+
+## Global Constraints
+
+- Keep the CLI dependency-free: Bash plus standard POSIX/macOS tools only.
+- Never inspect or move authentication, cookies, sessions, MCP credentials, or tokens.
+- Launch only the original signed ChatGPT bundle; never clone, patch, sign, quit, or broadly kill apps.
+- Preserve every existing behavior when no binding matches.
+- Use modes `0700` for the config directory and `0600` for state, written through same-directory temporary files and atomic rename.
+- Stay compatible with macOS Bash 3.2: no associative arrays, `readarray`, GNU-only `realpath`, or new dependency.
+- Do not bump the release version; document the feature under `CHANGELOG.md` Unreleased.
+
+---
+
+### Task 1: Private Binding Registry and Inspection
+
+**Files:**
+- Modify: `test/codex-profile-test.sh`
+- Modify: `bin/codex-profile`
+
+**Interfaces:**
+- Produces `CODEX_PROFILE_CONFIG_HOME`, `WORKSPACE_REGISTRY`, and `WORKSPACE_GUARD_FILE`.
+- Produces `canonical_directory`, `workspace_registry_validate`, `workspace_registry_rewrite`, `workspace_resolve`, `workspace_guard_mode`, and `profile_is_initialized`.
+- `workspace_resolve <path>` sets `WORKSPACE_RESOLVED_PATH`, `WORKSPACE_RESOLVED_BINDING`, and `WORKSPACE_RESOLVED_PROFILE`; return 0 means matched and 1 means unbound.
+- Produces `command_workspace` with `bind`, `unbind`, `list`, `status`, and `guard`.
+
+- [ ] **Step 1: Write failing registry and resolution tests**
+
+Add isolated-HOME tests with this core contract:
+
+```bash
+run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$tmp/config" \
+  "$SCRIPT" workspace bind "$tmp/Dev/client" client
+assert_status 0
+assert_contains "Bound $tmp/Dev/client to profile client"
+[[ "$(mode_of "$tmp/config")" == "700" ]] || fail "workspace config directory is not private"
+[[ "$(mode_of "$tmp/config/workspaces.tsv")" == "600" ]] || fail "workspace registry is not private"
+
+run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$tmp/config" \
+  "$SCRIPT" workspace status --json "$tmp/Dev/client/service"
+assert_status 0
+assert_contains '"binding_path":"'"$tmp/Dev/client"'"'
+assert_contains '"profile":"client"'
+```
+
+Cover idempotent bind, replacement rejection/`--force`, exact unbind, nested precedence, sibling-prefix rejection, symlink canonicalization, spaces, missing paths, unknown profiles, control-character rejection, stale rows, list/status JSON validity/nulls, and guard default/set/read.
+
+- [ ] **Step 2: Verify RED**
+
+Run `bash test/codex-profile-test.sh` and expect `Unknown command 'workspace'`.
+
+- [ ] **Step 3: Implement registry and workspace commands**
+
+Add:
+
+```bash
+CODEX_PROFILE_CONFIG_HOME="${CODEX_PROFILE_CONFIG_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/codex-profile}"
+WORKSPACE_REGISTRY="$CODEX_PROFILE_CONFIG_HOME/workspaces.tsv"
+WORKSPACE_GUARD_FILE="$CODEX_PROFILE_CONFIG_HOME/guard-mode"
+```
+
+Canonicalize with `(cd -- "$path" && pwd -P)`. Reject non-directories and tab/CR/LF. Refuse symlinked config directories and files. Parse exactly one literal tab per non-empty row using parameter expansion; never `source` or `eval` state. Validate the whole existing registry before mutations, then write with `mktemp`, `chmod 600`, and `mv`.
+
+Resolve exact/ancestor directory boundaries and keep the longest binding:
+
+```bash
+if [[ "$candidate" == "$binding" ]] || [[ "$binding" == "/" ]] || \
+   [[ "$candidate" == "$binding/"* ]]; then
+  if [[ ${#binding} -gt ${#WORKSPACE_RESOLVED_BINDING} ]]; then
+    WORKSPACE_RESOLVED_BINDING="$binding"
+    WORKSPACE_RESOLVED_PROFILE="$profile"
+  fi
+fi
+```
+
+Emit the approved human/JSON shapes, JSON nulls when unbound, and valid failure output for corrupt state. Register `workspace` in `main` and suppress update notices for its JSON forms.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run `bash test/codex-profile-test.sh`; all tests must pass.
+
+- [ ] **Step 5: Commit**
+
+Commit `bin/codex-profile` and `test/codex-profile-test.sh` as `cli(feat): add private workspace bindings`, with summary, rationale, and test body sections.
+
+### Task 2: Bound Runs and Mismatch Guards
+
+**Files:**
+- Modify: `test/codex-profile-test.sh`
+- Modify: `bin/codex-profile`
+
+**Interfaces:**
+- Consumes Task 1's resolver and guard-mode reader.
+- Produces `workspace_guard_profile <selected-profile> <path>` and `command_run`.
+- `run [--] [codex-args...]` calls `command_cli`; `run --app [workspace]` calls `command_app` with a canonical workspace.
+
+- [ ] **Step 1: Write failing run and guard tests**
+
+Use the existing fake Codex and signed-app helpers. Verify CLI routing and forwarding:
+
+```bash
+run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$tmp/config" \
+  CODEX_CLI="$fake_codex" bash -c \
+  'cd "$1" && exec "$2" run -- exec "run tests"' _ "$tmp/Dev/client/service" "$SCRIPT"
+assert_status 0
+assert_contains "CODEX_HOME=$tmp/home/.codex-client"
+assert_contains "ARGS=exec run tests"
+```
+
+Test `run --app`, missing-binding errors, and warn/strict/off behavior for `cli`, `app`, and `env`. Prove warnings are stderr-only, strict mode runs no side effect or shell output, a matching profile is quiet, and unbound commands are unchanged.
+
+- [ ] **Step 2: Verify RED**
+
+Run `bash test/codex-profile-test.sh` and expect `Unknown command 'run'`.
+
+- [ ] **Step 3: Implement run and guards**
+
+Implement:
+
+```bash
+workspace_guard_profile() {
+  local selected_profile="$1" path="$2" mode
+  mode="$(workspace_guard_mode)"
+  [[ "$mode" != "off" ]] || return 0
+  workspace_resolve "$path" || return 0
+  [[ "$selected_profile" != "$WORKSPACE_RESOLVED_PROFILE" ]] || return 0
+  if [[ "$mode" == "strict" ]]; then
+    die "Workspace '$WORKSPACE_RESOLVED_BINDING' is bound to profile '$WORKSPACE_RESOLVED_PROFILE'; refusing selected profile '$selected_profile'."
+  fi
+  printf "Warning: workspace '%s' is bound to profile '%s'; selected profile is '%s'.\n" \
+    "$WORKSPACE_RESOLVED_BINDING" "$WORKSPACE_RESOLVED_PROFILE" "$selected_profile" >&2
+}
+```
+
+Call it before side effects in `command_cli`, `command_env`, and `command_app`. `app` checks its supplied workspace or `$PWD`; shell-wrapper `use` is covered through `env`. Implement the two approved `run` forms, rejecting other wrapper options and stripping only a leading `--` in CLI form. Register `run` in `main`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run `bash test/codex-profile-test.sh`; all tests must pass.
+
+- [ ] **Step 5: Commit**
+
+Commit the two files as `cli(feat): route bound workspaces safely`, with summary, rationale, and tests.
+
+### Task 3: Lifecycle Cleanup and Doctor Health
+
+**Files:**
+- Modify: `test/codex-profile-test.sh`
+- Modify: `bin/codex-profile`
+
+**Interfaces:**
+- Produces `workspace_remove_profile_bindings <profile>` and `workspace_registry_stats`.
+- Extends doctor JSON with top-level `workspaces` containing `config_home`, `registry_path`, `guard_mode`, `registry_valid`, `binding_count`, `missing_paths`, and `missing_profiles`.
+
+- [ ] **Step 1: Write failing lifecycle/doctor tests**
+
+Bind two workspaces to a removed profile and one to another profile; verify only unrelated rows survive and no project file is deleted. Cover cleanup for an already-missing profile. Assert human doctor fields and parse this JSON shape:
+
+```json
+"workspaces": {
+  "guard_mode": "strict",
+  "registry_valid": true,
+  "binding_count": 3,
+  "missing_paths": 1,
+  "missing_profiles": 1
+}
+```
+
+Verify corrupt rows/guard values are reported and `doctor --json` remains one valid document whether the Codex CLI exists or not.
+
+- [ ] **Step 2: Verify RED**
+
+Run `bash test/codex-profile-test.sh`; expect stale bindings or missing doctor fields.
+
+- [ ] **Step 3: Implement cleanup and health reporting**
+
+Validate registry mutability before removal. After confirmed profile deletion, atomically remove all rows for that profile; also clean stale bindings when the profile is already absent. Compute counts without reading Codex state. Human doctor always reports workspace health. JSON uses `guard_mode: null` and `registry_valid: false` for invalid state, without partial output.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run `bash test/codex-profile-test.sh`; all tests must pass.
+
+- [ ] **Step 5: Commit**
+
+Commit the two files as `cli(feat): diagnose and clean workspace bindings`, with summary, rationale, and tests.
+
+### Task 4: Help, Completions, and Documentation
+
+**Files:**
+- Modify: `bin/codex-profile`
+- Modify: `test/codex-profile-test.sh`
+- Modify: `README.md`
+- Modify: `docs/llms.txt`
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Adds `workspace` and `run` to usage and Bash/Zsh/Fish completions.
+- Documents `CODEX_PROFILE_CONFIG_HOME`, nearest-ancestor routing, guard semantics, persistence, cleanup, and safety limitations.
+
+- [ ] **Step 1: Write failing discovery assertions**
+
+Require every generated completion to contain `workspace` and `run`, workspace subcommands `bind unbind list status guard`, profile completion at the bind profile position, and `--app` for run. Require help to show every new command and environment override.
+
+- [ ] **Step 2: Verify RED**
+
+Run `bash test/codex-profile-test.sh`; expect help/completion assertions to fail.
+
+- [ ] **Step 3: Update command discovery and docs**
+
+Document this exact workflow in README and `docs/llms.txt`:
+
+```sh
+codex-profile workspace bind ~/Dev/client-a client-a
+cd ~/Dev/client-a
+codex-profile run
+codex-profile run exec "run tests"
+codex-profile run --app
+codex-profile workspace guard strict
+codex-profile workspace status --json
+```
+
+Explain precedence, private global state, default warn mode, strict/off, guarded commands, upstream `-C` non-parsing, cleanup, and non-security-boundary status. Add an Unreleased/Added changelog entry. Keep deprecated spellings in all completions.
+
+- [ ] **Step 4: Verify behavior and GEO docs**
+
+Run `bash test/codex-profile-test.sh` and `node test/geo-site-test.mjs`; both must pass.
+
+- [ ] **Step 5: Commit**
+
+Commit the five files as `docs(feat): document workspace-aware routing`, with summary, rationale, and tests.
+
+### Task 5: Full Verification and Draft PR
+
+**Files:**
+- Verify all branch changes and the design/plan documents.
+
+**Interfaces:**
+- Produces a pushed `PinZheng/workspace-bindings` branch and draft PR titled `PinZheng(cli): add workspace-aware profile routing`.
+
+- [ ] **Step 1: Run required checks**
+
+```bash
+make test
+make lint
+git diff --check origin/main...HEAD
+```
+
+Expected: all exit 0 with no ShellCheck or whitespace findings.
+
+- [ ] **Step 2: Review diff and invariants**
+
+```bash
+git status -sb
+git diff --stat origin/main...HEAD
+rg -n "auth\.json|cookie|token|killall|pkill|codesign|cp -R" bin/codex-profile
+```
+
+Confirm there is no credential access, app copying/signing, broad process control, unrelated artifact, or version bump.
+
+- [ ] **Step 3: Push and open the draft PR**
+
+Push with tracking, create a draft PR against the remote default branch using the explicit required title, include behavior/safety/docs/checks in the body, and verify title plus draft state with `gh pr view`.

--- a/docs/superpowers/specs/2026-07-14-workspace-bindings-design.md
+++ b/docs/superpowers/specs/2026-07-14-workspace-bindings-design.md
@@ -1,0 +1,202 @@
+# Workspace-Aware Profile Routing Design
+
+## Summary
+
+Add explicit workspace-to-profile bindings so `codex-profiles` can select the
+right profile from a project directory and detect explicit profile mistakes.
+Bindings remain local to the OS user, contain no credentials, and never modify
+the bound repository.
+
+The feature adds a `workspace` command family, a profile-resolving `run`
+command, and optional mismatch guards for existing commands. It preserves the
+project's single-file, dependency-free Bash architecture and does not turn
+local state separation into an account or security boundary.
+
+## Goals
+
+- Let a user bind an existing directory to an existing Codex profile.
+- Resolve the nearest binding for a directory, including nested workspaces.
+- Launch the bound CLI or ChatGPT window without repeating the profile name.
+- Warn about or reject an explicitly selected profile that conflicts with a
+  binding.
+- Provide human-readable and JSON inspection for scripts and diagnostics.
+- Keep binding state private, atomic, deterministic, and credential-free.
+
+## Non-goals
+
+- Do not inspect, compare, copy, import, or export authentication or cookies.
+- Do not modify repositories or introduce a checked-in `.codex-profile` file.
+- Do not infer whether CLI and Desktop sessions use the same account.
+- Do not parse upstream Codex arguments such as `-C` to infer another working
+  directory.
+- Do not automatically mutate the caller's shell. Existing `env` and `use`
+  behavior remains explicit.
+- Do not add cross-tool profiles, usage/quota monitoring, or configuration
+  sharing in this release.
+
+## Command Surface
+
+```text
+codex-profile workspace bind <path> <profile> [--force]
+codex-profile workspace unbind <path>
+codex-profile workspace list [--json]
+codex-profile workspace status [--json] [path]
+codex-profile workspace guard [off|warn|strict]
+codex-profile run [--] [codex-args...]
+codex-profile run --app [workspace]
+```
+
+`workspace bind` requires an existing directory and a discovered profile. It
+stores the directory's physical canonical path. Rebinding an exact path to a
+different profile fails unless `--force` is present; repeating the same binding
+is an idempotent success.
+
+`workspace unbind` removes only an exact canonical-path binding. It does not
+remove a profile or any workspace files.
+
+`workspace list` shows every binding, the global guard mode, and whether each
+path and profile still exist. `workspace status` resolves the supplied path or
+the current directory and reports the winning binding, selected profile, and
+guard mode. A missing binding is a successful inspection result, not an error.
+
+`workspace guard` prints the current mode when no value is supplied. The
+default is `warn`: once a binding exists, an explicit mismatch produces a
+concise stderr warning but still runs. `strict` rejects the mismatch before
+launch or shell output, and `off` disables mismatch checks. A directory with no
+matching binding behaves exactly as it does today in every mode.
+
+`run` resolves the current directory and passes all remaining arguments to
+`cli <resolved-profile>`. A leading `--` is removed so an upstream argument can
+be protected from wrapper parsing. `run --app` resolves its optional workspace
+or the current directory, then launches `app <resolved-profile>` with that
+canonical workspace. Both forms fail with a binding command example if no
+profile is bound.
+
+The usage text and Bash, Zsh, and Fish completions expose the new commands and
+their fixed options.
+
+## Persistence and Resolution
+
+Binding state lives under:
+
+```text
+${CODEX_PROFILE_CONFIG_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/codex-profile}/
+  workspaces.tsv
+  guard-mode
+```
+
+`CODEX_PROFILE_CONFIG_HOME` is the documented test/automation override. The
+directory is mode `0700`; state files are mode `0600`. Mutations write a
+same-directory temporary file, set its permissions, and rename it over the
+destination so readers never observe a partial registry.
+
+Each registry line is a physical canonical path, one tab, and a validated
+profile name. Bind rejects paths containing tab, carriage-return, or newline
+characters so the transparent format is unambiguous. Empty lines are ignored;
+any other malformed line makes mutating commands fail closed and makes
+inspection or `doctor` report the corrupt line without evaluating it as shell
+code.
+
+Resolution compares canonical directory boundaries, not string prefixes. An
+exact match wins; otherwise the longest ancestor binding wins, allowing a
+specific nested repository to override a broader workspace binding. Symlinked
+input paths resolve to the same physical binding. Selection is independent of
+registry order.
+
+Human output is stable and concise. Machine output uses these shapes:
+
+```json
+{
+  "guard_mode": "warn",
+  "bindings": [
+    {
+      "path": "/Users/example/Dev/client-a",
+      "profile": "client-a",
+      "path_exists": true,
+      "profile_exists": true
+    }
+  ]
+}
+```
+
+```json
+{
+  "path": "/Users/example/Dev/client-a/service",
+  "binding_path": "/Users/example/Dev/client-a",
+  "profile": "client-a",
+  "guard_mode": "warn"
+}
+```
+
+For an unbound status, `binding_path` and `profile` are JSON `null`.
+
+## Guard and Lifecycle Integration
+
+Mismatch guards apply to the commands that select a profile for work in a
+directory:
+
+- `cli`, `env`, and `use` check the physical current directory.
+- `app` checks its workspace argument when present, otherwise the physical
+  current directory.
+- `run` already selects the resolved profile and never mismatches.
+
+Warnings go only to stderr. `status --json`, `doctor --json`, completion
+generation, update checks, and other machine-readable paths remain clean.
+`login`, `logs`, `path`, `clone-config`, and other non-workspace operations do
+not apply guards.
+
+Removing a named profile also removes all registry entries that target that
+profile, after the existing confirmation succeeds and the profile directory is
+removed. This prevents successful profile removal from leaving broken
+bindings. Removing a workspace binding never deletes profile or project data.
+
+`doctor` reports the registry path, guard mode, malformed rows, missing bound
+directories, and missing bound profiles. JSON diagnostics gain corresponding
+workspace fields without changing existing field meanings.
+
+## Error Handling and Safety
+
+- Missing/non-directory bind targets, unknown profiles, invalid modes, invalid
+  options, and control characters fail with actionable errors.
+- A corrupt registry is never sourced or evaluated. Mutations refuse to
+  overwrite it until the user repairs or removes the bad row.
+- `strict` is a guardrail, not a security boundary; users can disable it or
+  invoke upstream Codex directly.
+- The registry contains only local paths and profile names. It never reads or
+  stores `auth.json`, cookies, sessions, MCP credentials, logs, or tokens.
+- No command performs network access for binding resolution or guarding.
+- The implementation remains compatible with macOS Bash 3.2 and Ubuntu Bash;
+  it must not require associative arrays, `readarray`, GNU-only `realpath`, or
+  a new runtime dependency.
+
+## Testing and Documentation
+
+Behavior tests use isolated `HOME` and `XDG_CONFIG_HOME` directories and real
+CLI/app stubs. Tests cover bind/idempotence/forced replacement, exact unbind,
+nested resolution, path-boundary correctness, symlink canonicalization,
+spaces, rejected control characters, stale and corrupt registry rows, file
+permissions, JSON escaping and nulls, all guard modes, CLI/app `run`, argument
+forwarding, missing bindings, profile removal cleanup, doctor output, and quiet
+machine-readable commands.
+
+The full `make test` and `make lint` suites must pass on the supported shell
+surface. User-facing documentation is updated under `CHANGELOG.md` Unreleased,
+the README workflows and command reference, `docs/llms.txt`, environment
+overrides, safety language, and every completion generator. The feature does
+not bump the release version in this pull request.
+
+## Acceptance Criteria
+
+- A user can bind `~/Dev/client-a` to `client-a`, enter any descendant, and run
+  `codex-profile run` to launch the Codex CLI with that profile's `CODEX_HOME`.
+- `codex-profile run --app` opens the original signed ChatGPT bundle with the
+  resolved profile and canonical workspace.
+- An explicit mismatch warns by default, blocks in strict mode, and is ignored
+  in off mode without contaminating stdout.
+- Nested bindings select the nearest ancestor and never match sibling paths
+  that merely share a string prefix.
+- Registry writes are private and atomic; corrupt state is reported and never
+  executed or silently discarded.
+- Removing a profile cleans its bindings while preserving all unrelated
+  bindings and workspace files.
+- Existing commands retain their behavior when no binding matches.

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -8,7 +8,7 @@ pkgbase = codex-profile
 	depends = bash
 	source = codex-profile-0.7.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.7.0/bin/codex-profile
 	source = LICENSE-0.7.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.7.0/LICENSE
-	sha256sums = 5333d2fed3bbd9e9c4fe53db259a89815ec93f8c5a81e1bdaa3650a54c757f2c
+	sha256sums = db059709d65cb13d4081fddee39d03b89bcc48c589d83869e2b00622d952f444
 	sha256sums = 9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364
 
 pkgname = codex-profile

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -12,7 +12,7 @@ source=(
   "LICENSE-$pkgver::https://raw.githubusercontent.com/Ducksss/codex-profiles/v$pkgver/LICENSE"
 )
 sha256sums=(
-  '5333d2fed3bbd9e9c4fe53db259a89815ec93f8c5a81e1bdaa3650a54c757f2c'
+  'db059709d65cb13d4081fddee39d03b89bcc48c589d83869e2b00622d952f444'
   '9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364'
 )
 

--- a/test/codex-profile-test.sh
+++ b/test/codex-profile-test.sh
@@ -1287,6 +1287,20 @@ test_workspace_bind_rejects_unsafe_state_and_reports_stale_bindings() {
   assert_contains "Refusing symlinked workspace registry"
   [[ "$(cat "$outside")" == "outside" ]] || fail "workspace registry followed a symlink"
 
+  rm -rf "$config"
+  printf 'not a directory\n' > "$config"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace list --json
+  assert_status 1
+  assert_contains "Workspace config path is not a directory: $config"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI=/no/such/codex "$SCRIPT" doctor --json
+  assert_status 0
+  assert_contains '"guard_mode":null'
+  assert_contains '"registry_valid":false'
+  JSON_PAYLOAD="$output" node -e 'JSON.parse(process.env.JSON_PAYLOAD)'
+
   rm -rf "$tmp"
 }
 
@@ -1384,6 +1398,23 @@ FAKE_CODEX
 
   assert_status 0
   assert_contains "ARGS=--app"
+
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI="$fake_codex" bash -c \
+    'cd "$1" && exec "$2" run --typo' _ "$service" "$SCRIPT"
+
+  assert_status 1
+  assert_contains "Usage: codex-profile run"
+  assert_not_contains "ARGS=--typo"
+
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI="$fake_codex" bash -c \
+    'cd "$1" && exec "$2" run -- --typo' _ "$service" "$SCRIPT"
+
+  assert_status 0
+  assert_contains "ARGS=--typo"
 
   run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
     PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" CHATGPT_APP="$chatgpt_app" \
@@ -1845,6 +1876,7 @@ test_completions_generate_shell_scripts() {
   assert_contains "app app-instance cli login init remove workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help"
   assert_contains "workspace_commands=(bind unbind list status guard)"
   assert_contains "run_flags=(--app)"
+  assert_contains "workspace_json_flags=(--json)"
   assert_contains "logs"
   assert_contains "upgrade"
   assert_contains "--instance"

--- a/test/codex-profile-test.sh
+++ b/test/codex-profile-test.sh
@@ -1520,6 +1520,125 @@ FAKE_CODEX
   rm -rf "$tmp"
 }
 
+test_remove_cleans_workspace_bindings_without_touching_projects() {
+  local tmp config personal_one personal_two work_space ghost_space marker
+  tmp="$(mktemp -d)"
+  tmp="$(cd "$tmp" && pwd -P)"
+  config="$tmp/config"
+  personal_one="$tmp/projects/personal-one"
+  personal_two="$tmp/projects/personal-two"
+  work_space="$tmp/projects/work"
+  ghost_space="$tmp/projects/ghost"
+  marker="$personal_one/keep.txt"
+  mkdir -p "$tmp/home/.codex-personal" "$tmp/home/.codex-work" \
+    "$tmp/home/.codex-ghost" "$personal_one" "$personal_two" "$work_space" "$ghost_space"
+  printf 'keep project data\n' > "$marker"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$personal_one" personal
+  assert_status 0
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$personal_two" personal
+  assert_status 0
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$work_space" work
+  assert_status 0
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$ghost_space" ghost
+  assert_status 0
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" remove personal --yes
+
+  assert_status 0
+  assert_contains "Removed personal"
+  [[ -f "$marker" ]] || fail "profile removal deleted bound project data"
+  [[ -d "$personal_two" ]] || fail "profile removal deleted a bound workspace"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace list --json
+  assert_status 0
+  assert_not_contains '"profile":"personal"'
+  assert_contains '"profile":"work"'
+  assert_contains '"profile":"ghost"'
+
+  rm -rf "$tmp/home/.codex-ghost"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" remove ghost --yes
+  assert_status 0
+  assert_contains "Not initialized ghost"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace list --json
+  assert_status 0
+  assert_not_contains '"profile":"ghost"'
+  assert_contains '"profile":"work"'
+
+  printf 'malformed registry\n' > "$config/workspaces.tsv"
+  mkdir -p "$tmp/home/.codex-client"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" remove client --yes
+  assert_status 1
+  assert_contains "Malformed workspace registry line 1"
+  [[ -d "$tmp/home/.codex-client" ]] || fail "remove deleted a profile before validating binding cleanup"
+
+  rm -rf "$tmp"
+}
+
+test_doctor_reports_workspace_binding_health_in_human_and_json_output() {
+  local tmp config existing_one existing_two missing
+  tmp="$(mktemp -d)"
+  tmp="$(cd "$tmp" && pwd -P)"
+  config="$tmp/config"
+  existing_one="$tmp/projects/one"
+  existing_two="$tmp/projects/two"
+  missing="$tmp/projects/missing"
+  mkdir -p "$tmp/home/.codex-work" "$existing_one" "$existing_two" "$config"
+  chmod 700 "$config"
+  printf '%s\t%s\n' "$existing_one" work > "$config/workspaces.tsv"
+  printf '%s\t%s\n' "$missing" work >> "$config/workspaces.tsv"
+  printf '%s\t%s\n' "$existing_two" ghost >> "$config/workspaces.tsv"
+  chmod 600 "$config/workspaces.tsv"
+  printf 'strict\n' > "$config/guard-mode"
+  chmod 600 "$config/guard-mode"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI=/no/such/codex "$SCRIPT" doctor
+
+  assert_status 0
+  assert_contains "Workspace registry: $config/workspaces.tsv"
+  assert_contains "Workspace guard mode: strict"
+  assert_contains "Workspace bindings: 3"
+  assert_contains "Missing workspace paths: 1"
+  assert_contains "Missing workspace profiles: 1"
+  assert_contains "CLI: missing"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI=/no/such/codex "$SCRIPT" doctor --json
+
+  assert_status 0
+  assert_contains '"workspaces":{'
+  assert_contains '"guard_mode":"strict"'
+  assert_contains '"registry_valid":true'
+  assert_contains '"binding_count":3'
+  assert_contains '"missing_paths":1'
+  assert_contains '"missing_profiles":1'
+  JSON_PAYLOAD="$output" node -e 'JSON.parse(process.env.JSON_PAYLOAD)'
+
+  printf 'malformed registry\n' > "$config/workspaces.tsv"
+  printf 'dangerous\n' > "$config/guard-mode"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI=/no/such/codex "$SCRIPT" doctor --json
+
+  assert_status 0
+  assert_contains '"guard_mode":null'
+  assert_contains '"registry_valid":false'
+  assert_contains '"binding_count":0'
+  JSON_PAYLOAD="$output" node -e 'JSON.parse(process.env.JSON_PAYLOAD)'
+
+  rm -rf "$tmp"
+}
+
 test_logs_prints_path_and_contents() {
   local tmp log_file
   tmp="$(mktemp -d)"
@@ -2386,6 +2505,8 @@ test_workspace_bind_rejects_unsafe_state_and_reports_stale_bindings
 test_workspace_uses_xdg_config_and_manages_guard_mode
 test_workspace_run_routes_cli_and_signed_app
 test_workspace_guards_explicit_profile_commands
+test_remove_cleans_workspace_bindings_without_touching_projects
+test_doctor_reports_workspace_binding_health_in_human_and_json_output
 test_env_prints_posix_exports_for_profile
 test_env_emits_fish_syntax
 test_env_warns_to_stderr_without_polluting_stdout_when_uninitialized

--- a/test/codex-profile-test.sh
+++ b/test/codex-profile-test.sh
@@ -1341,6 +1341,185 @@ test_workspace_uses_xdg_config_and_manages_guard_mode() {
   rm -rf "$tmp"
 }
 
+test_workspace_run_routes_cli_and_signed_app() {
+  local tmp config workspace service fake_codex chatgpt_app fake_bin tool_log
+  tmp="$(mktemp -d)"
+  tmp="$(cd "$tmp" && pwd -P)"
+  config="$tmp/config"
+  workspace="$tmp/client"
+  service="$workspace/service"
+  fake_codex="$tmp/codex"
+  chatgpt_app="$tmp/ChatGPT.app"
+  fake_bin="$tmp/bin"
+  tool_log="$tmp/tool.log"
+  mkdir -p "$tmp/home/.codex-client" "$service"
+  cat > "$fake_codex" <<'FAKE_CODEX'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'fake-codex 1.0\n'
+  exit 0
+fi
+printf 'CODEX_HOME=%s\n' "$CODEX_HOME"
+printf 'ARGS=%s\n' "$*"
+FAKE_CODEX
+  chmod 755 "$fake_codex"
+  write_fake_chatgpt_app_bundle "$chatgpt_app" "bound ChatGPT launch"
+  write_fake_chatgpt_open_tools "$fake_bin"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$workspace" client
+  assert_status 0
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI="$fake_codex" bash -c \
+    'cd "$1" && exec "$2" run -- exec "run tests"' _ "$service" "$SCRIPT"
+
+  assert_status 0
+  assert_contains "CODEX_HOME=$tmp/home/.codex-client"
+  assert_contains "ARGS=exec run tests"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI="$fake_codex" bash -c \
+    'cd "$1" && exec "$2" run -- --app' _ "$service" "$SCRIPT"
+
+  assert_status 0
+  assert_contains "ARGS=--app"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" CHATGPT_APP="$chatgpt_app" \
+    "$SCRIPT" run --app "$service"
+
+  assert_status 0
+  assert_contains "Launching ChatGPT for profile client"
+  grep -Fqx "open -a $chatgpt_app files=$service args=--user-data-dir=$tmp/home/.codex-client/electron-user-data" "$tool_log" || \
+    fail "run --app did not launch the signed app with the bound profile"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI="$fake_codex" bash -c \
+    'cd "$1" && exec "$2" run' _ "$tmp" "$SCRIPT"
+
+  assert_status 1
+  assert_contains "No workspace profile is bound"
+  assert_contains "workspace bind"
+
+  rm -rf "$tmp"
+}
+
+test_workspace_guards_explicit_profile_commands() {
+  local tmp config workspace service unbound fake_codex marker out err chatgpt_app fake_bin tool_log
+  tmp="$(mktemp -d)"
+  tmp="$(cd "$tmp" && pwd -P)"
+  config="$tmp/config"
+  workspace="$tmp/client"
+  service="$workspace/service"
+  unbound="$tmp/unbound"
+  fake_codex="$tmp/codex"
+  marker="$tmp/codex-runs"
+  out="$tmp/out"
+  err="$tmp/err"
+  chatgpt_app="$tmp/ChatGPT.app"
+  fake_bin="$tmp/bin"
+  tool_log="$tmp/tool.log"
+  mkdir -p "$tmp/home/.codex-client" "$tmp/home/.codex-personal" "$service" "$unbound"
+  cat > "$fake_codex" <<'FAKE_CODEX'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'fake-codex 1.0\n'
+  exit 0
+fi
+printf 'ran %s\n' "$*" >> "${FAKE_CODEX_MARKER:?}"
+printf 'CODEX_HOME=%s\n' "$CODEX_HOME"
+printf 'ARGS=%s\n' "$*"
+FAKE_CODEX
+  chmod 755 "$fake_codex"
+  write_fake_chatgpt_app_bundle "$chatgpt_app" "guarded ChatGPT launch"
+  write_fake_chatgpt_open_tools "$fake_bin"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$workspace" client
+  assert_status 0
+
+  set +e
+  env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" CODEX_CLI="$fake_codex" \
+    FAKE_CODEX_MARKER="$marker" bash -c \
+    'cd "$1" && exec "$2" cli personal exec check' _ "$service" "$SCRIPT" \
+    > "$out" 2> "$err"
+  status=$?
+  set -e
+  [[ "$status" -eq 0 ]] || fail "warn-mode CLI mismatch should run"
+  [[ "$(cat "$out")" == *"CODEX_HOME=$tmp/home/.codex-personal"* ]] || \
+    fail "warn-mode CLI did not use the explicit profile"
+  [[ "$(cat "$out")" != *"Warning:"* ]] || fail "workspace warning polluted stdout"
+  [[ "$(cat "$err")" == *"bound to profile 'client'"* ]] || fail "warn mode omitted expected profile"
+  [[ "$(cat "$err")" == *"selected profile is 'personal'"* ]] || fail "warn mode omitted selected profile"
+
+  : > "$err"
+  set +e
+  env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" CODEX_CLI="$fake_codex" \
+    FAKE_CODEX_MARKER="$marker" bash -c \
+    'cd "$1" && exec "$2" cli client exec check' _ "$service" "$SCRIPT" \
+    > "$out" 2> "$err"
+  status=$?
+  set -e
+  [[ "$status" -eq 0 ]] || fail "matching CLI profile should run"
+  [[ ! -s "$err" ]] || fail "matching CLI profile emitted a warning"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace guard strict
+  assert_status 0
+  : > "$marker"
+
+  set +e
+  env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" CODEX_CLI="$fake_codex" \
+    FAKE_CODEX_MARKER="$marker" bash -c \
+    'cd "$1" && exec "$2" cli personal exec blocked' _ "$service" "$SCRIPT" \
+    > "$out" 2> "$err"
+  status=$?
+  set -e
+  [[ "$status" -eq 1 ]] || fail "strict-mode CLI mismatch was not rejected"
+  [[ ! -s "$marker" ]] || fail "strict-mode CLI mismatch invoked Codex"
+  [[ "$(cat "$err")" == *"refusing selected profile 'personal'"* ]] || fail "strict CLI error is not actionable"
+
+  set +e
+  env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    bash -c 'cd "$1" && exec "$2" env personal' _ "$service" "$SCRIPT" \
+    > "$out" 2> "$err"
+  status=$?
+  set -e
+  [[ "$status" -eq 1 ]] || fail "strict-mode env mismatch was not rejected"
+  [[ ! -s "$out" ]] || fail "strict-mode env mismatch emitted eval-able stdout"
+
+  rm -f "$tool_log"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" CHATGPT_APP="$chatgpt_app" \
+    "$SCRIPT" app personal "$service"
+  assert_status 1
+  assert_contains "refusing selected profile 'personal'"
+  [[ ! -e "$tool_log" ]] || fail "strict-mode app mismatch invoked macOS open"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace guard off
+  assert_status 0
+  : > "$err"
+  set +e
+  env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" CODEX_CLI="$fake_codex" \
+    FAKE_CODEX_MARKER="$marker" bash -c \
+    'cd "$1" && exec "$2" cli personal exec allowed' _ "$service" "$SCRIPT" \
+    > "$out" 2> "$err"
+  status=$?
+  set -e
+  [[ "$status" -eq 0 ]] || fail "off-mode CLI mismatch should run"
+  [[ ! -s "$err" ]] || fail "off-mode CLI mismatch emitted a warning"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" CODEX_CLI="$fake_codex" \
+    FAKE_CODEX_MARKER="$marker" bash -c \
+    'cd "$1" && exec "$2" cli personal exec unbound' _ "$unbound" "$SCRIPT"
+  assert_status 0
+  assert_not_contains "Warning:"
+
+  rm -rf "$tmp"
+}
+
 test_logs_prints_path_and_contents() {
   local tmp log_file
   tmp="$(mktemp -d)"
@@ -2205,6 +2384,8 @@ test_remove_yes_deletes_profiles_named_like_common_aliases
 test_workspace_bind_list_status_and_nested_resolution
 test_workspace_bind_rejects_unsafe_state_and_reports_stale_bindings
 test_workspace_uses_xdg_config_and_manages_guard_mode
+test_workspace_run_routes_cli_and_signed_app
+test_workspace_guards_explicit_profile_commands
 test_env_prints_posix_exports_for_profile
 test_env_emits_fish_syntax
 test_env_warns_to_stderr_without_polluting_stdout_when_uninitialized

--- a/test/codex-profile-test.sh
+++ b/test/codex-profile-test.sh
@@ -1790,12 +1790,20 @@ test_completions_generate_shell_scripts() {
   assert_status 0
   assert_contains "--instance"
   assert_contains "--share-with"
+  assert_contains "workspace bind <path> <profile> [--force]"
+  assert_contains "workspace guard [off|warn|strict]"
+  assert_contains "run [--] [codex-args...]"
+  assert_contains "run --app [workspace]"
+  assert_contains "CODEX_PROFILE_CONFIG_HOME"
 
   run_cmd "$SCRIPT" completions bash
 
   assert_status 0
   assert_contains "complete -F _codex_profile codex-profile codex-profiles"
-  assert_contains 'compgen -W "app app-instance cli login init remove status path env use logs clone-config list doctor completions shell-init upgrade version help"'
+  assert_contains 'compgen -W "app app-instance cli login init remove workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help"'
+  assert_contains 'workspace_commands="bind unbind list status guard"'
+  assert_contains 'compgen -W "$workspace_commands"'
+  assert_contains 'compgen -W "--app"'
   assert_contains "clone-config"
   assert_contains "upgrade"
   assert_contains "--instance"
@@ -1809,7 +1817,9 @@ test_completions_generate_shell_scripts() {
 
   assert_status 0
   assert_contains "#compdef codex-profile codex-profiles"
-  assert_contains "app app-instance cli login init remove status path env use logs clone-config list doctor completions shell-init upgrade version help"
+  assert_contains "app app-instance cli login init remove workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help"
+  assert_contains "workspace_commands=(bind unbind list status guard)"
+  assert_contains "run_flags=(--app)"
   assert_contains "logs"
   assert_contains "upgrade"
   assert_contains "--instance"
@@ -1822,7 +1832,12 @@ test_completions_generate_shell_scripts() {
   assert_status 0
   assert_contains "for codex_profile_command in codex-profile codex-profiles"
   assert_contains "complete -c \$codex_profile_command"
-  assert_contains "-a 'app app-instance cli login init remove status path env use logs clone-config list doctor completions shell-init upgrade version help'"
+  assert_contains "-a 'app app-instance cli login init remove workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help'"
+  assert_contains "-a 'bind unbind list status guard'"
+  assert_contains "-l app"
+  assert_contains "test (count (commandline -opc)) -eq 2"
+  assert_contains "__fish_seen_subcommand_from bind; and test (count (commandline -opc)) -eq 4"
+  assert_contains "-F"
   assert_contains "remove"
   assert_contains "upgrade"
   assert_contains "-l instance"

--- a/test/codex-profile-test.sh
+++ b/test/codex-profile-test.sh
@@ -1384,6 +1384,7 @@ FAKE_CODEX
     "$SCRIPT" workspace bind "$workspace" client
   assert_status 0
 
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
   run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
     CODEX_CLI="$fake_codex" bash -c \
     'cd "$1" && exec "$2" run -- exec "run tests"' _ "$service" "$SCRIPT"
@@ -1392,6 +1393,7 @@ FAKE_CODEX
   assert_contains "CODEX_HOME=$tmp/home/.codex-client"
   assert_contains "ARGS=exec run tests"
 
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
   run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
     CODEX_CLI="$fake_codex" bash -c \
     'cd "$1" && exec "$2" run -- --app' _ "$service" "$SCRIPT"
@@ -1425,6 +1427,7 @@ FAKE_CODEX
   grep -Fqx "open -a $chatgpt_app files=$service args=--user-data-dir=$tmp/home/.codex-client/electron-user-data" "$tool_log" || \
     fail "run --app did not launch the signed app with the bound profile"
 
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
   run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
     CODEX_CLI="$fake_codex" bash -c \
     'cd "$1" && exec "$2" run' _ "$tmp" "$SCRIPT"
@@ -1496,6 +1499,7 @@ FAKE_CODEX
   assert_status 0
 
   set +e
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
   env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" CODEX_CLI="$fake_codex" \
     FAKE_CODEX_MARKER="$marker" bash -c \
     'cd "$1" && exec "$2" cli personal exec check' _ "$service" "$SCRIPT" \
@@ -1511,6 +1515,7 @@ FAKE_CODEX
 
   : > "$err"
   set +e
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
   env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" CODEX_CLI="$fake_codex" \
     FAKE_CODEX_MARKER="$marker" bash -c \
     'cd "$1" && exec "$2" cli client exec check' _ "$service" "$SCRIPT" \
@@ -1526,6 +1531,7 @@ FAKE_CODEX
   : > "$marker"
 
   set +e
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
   env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" CODEX_CLI="$fake_codex" \
     FAKE_CODEX_MARKER="$marker" bash -c \
     'cd "$1" && exec "$2" cli personal exec blocked' _ "$service" "$SCRIPT" \
@@ -1537,6 +1543,7 @@ FAKE_CODEX
   [[ "$(cat "$err")" == *"refusing selected profile 'personal'"* ]] || fail "strict CLI error is not actionable"
 
   set +e
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
   env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
     bash -c 'cd "$1" && exec "$2" env personal' _ "$service" "$SCRIPT" \
     > "$out" 2> "$err"
@@ -1558,6 +1565,7 @@ FAKE_CODEX
   assert_status 0
   : > "$err"
   set +e
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
   env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" CODEX_CLI="$fake_codex" \
     FAKE_CODEX_MARKER="$marker" bash -c \
     'cd "$1" && exec "$2" cli personal exec allowed' _ "$service" "$SCRIPT" \
@@ -1567,6 +1575,7 @@ FAKE_CODEX
   [[ "$status" -eq 0 ]] || fail "off-mode CLI mismatch should run"
   [[ ! -s "$err" ]] || fail "off-mode CLI mismatch emitted a warning"
 
+  # shellcheck disable=SC2016 # the child bash expands positional parameters
   run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" CODEX_CLI="$fake_codex" \
     FAKE_CODEX_MARKER="$marker" bash -c \
     'cd "$1" && exec "$2" cli personal exec unbound' _ "$unbound" "$SCRIPT"
@@ -1858,6 +1867,7 @@ test_completions_generate_shell_scripts() {
   assert_contains "complete -F _codex_profile codex-profile codex-profiles"
   assert_contains 'compgen -W "app app-instance cli login init remove workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help"'
   assert_contains 'workspace_commands="bind unbind list status guard"'
+  # shellcheck disable=SC2016 # matching literal generated completion text
   assert_contains 'compgen -W "$workspace_commands"'
   assert_contains 'compgen -W "--app"'
   assert_contains "clone-config"

--- a/test/codex-profile-test.sh
+++ b/test/codex-profile-test.sh
@@ -1405,6 +1405,31 @@ FAKE_CODEX
   rm -rf "$tmp"
 }
 
+test_workspace_resolution_errors_are_not_treated_as_unbound() {
+  local tmp config missing
+  tmp="$(mktemp -d)"
+  tmp="$(cd "$tmp" && pwd -P)"
+  config="$tmp/config"
+  missing="$tmp/missing"
+  mkdir -p "$tmp/home"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace status --json "$missing"
+
+  assert_status 1
+  assert_contains "Workspace directory does not exist: $missing"
+  assert_not_contains '"binding_path"'
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" run --app "$missing"
+
+  assert_status 1
+  assert_contains "Workspace directory does not exist: $missing"
+  assert_not_contains "No workspace profile is bound to ''"
+
+  rm -rf "$tmp"
+}
+
 test_workspace_guards_explicit_profile_commands() {
   local tmp config workspace service unbound fake_codex marker out err chatgpt_app fake_bin tool_log
   tmp="$(mktemp -d)"
@@ -2519,6 +2544,7 @@ test_workspace_bind_list_status_and_nested_resolution
 test_workspace_bind_rejects_unsafe_state_and_reports_stale_bindings
 test_workspace_uses_xdg_config_and_manages_guard_mode
 test_workspace_run_routes_cli_and_signed_app
+test_workspace_resolution_errors_are_not_treated_as_unbound
 test_workspace_guards_explicit_profile_commands
 test_remove_cleans_workspace_bindings_without_touching_projects
 test_doctor_reports_workspace_binding_health_in_human_and_json_output

--- a/test/codex-profile-test.sh
+++ b/test/codex-profile-test.sh
@@ -1114,6 +1114,233 @@ test_remove_yes_deletes_profiles_named_like_common_aliases() {
   rm -rf "$tmp"
 }
 
+test_workspace_bind_list_status_and_nested_resolution() {
+  local tmp config dev client service sibling link
+  tmp="$(mktemp -d)"
+  tmp="$(cd "$tmp" && pwd -P)"
+  config="$tmp/config"
+  dev="$tmp/Dev"
+  client="$dev/client one"
+  service="$client/service"
+  sibling="$dev/client one-more"
+  link="$tmp/client-link"
+  mkdir -p "$tmp/home/.codex-work" "$tmp/home/.codex-client" \
+    "$dev" "$service" "$sibling"
+  ln -s "$client" "$link"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$dev" work
+
+  assert_status 0
+  assert_contains "Bound $dev to profile work"
+  [[ "$(mode_of "$config")" == "700" ]] || fail "workspace config directory is not private"
+  [[ "$(mode_of "$config/workspaces.tsv")" == "600" ]] || fail "workspace registry is not private"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$dev" work
+
+  assert_status 0
+  assert_contains "Already bound $dev to profile work"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$client" client
+
+  assert_status 0
+  assert_contains "Bound $client to profile client"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace status --json "$service"
+
+  assert_status 0
+  assert_contains '"path":"'"$service"'"'
+  assert_contains '"binding_path":"'"$client"'"'
+  assert_contains '"profile":"client"'
+  assert_contains '"guard_mode":"warn"'
+  JSON_PAYLOAD="$output" node -e 'JSON.parse(process.env.JSON_PAYLOAD)'
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace status --json "$link/service"
+
+  assert_status 0
+  assert_contains '"path":"'"$service"'"'
+  assert_contains '"binding_path":"'"$client"'"'
+  assert_contains '"profile":"client"'
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace status --json "$sibling"
+
+  assert_status 0
+  assert_contains '"binding_path":"'"$dev"'"'
+  assert_contains '"profile":"work"'
+  assert_not_contains '"profile":"client"'
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace list --json
+
+  assert_status 0
+  assert_contains '"guard_mode":"warn"'
+  assert_contains '"path":"'"$client"'"'
+  assert_contains '"profile":"client"'
+  assert_contains '"path_exists":true'
+  assert_contains '"profile_exists":true'
+  JSON_PAYLOAD="$output" node -e 'JSON.parse(process.env.JSON_PAYLOAD)'
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace unbind "$client"
+
+  assert_status 0
+  assert_contains "Unbound $client"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace status --json "$service"
+
+  assert_status 0
+  assert_contains '"binding_path":"'"$dev"'"'
+  assert_contains '"profile":"work"'
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace status --json "$tmp"
+
+  assert_status 0
+  assert_contains '"binding_path":null'
+  assert_contains '"profile":null'
+
+  rm -rf "$tmp"
+}
+
+test_workspace_bind_rejects_unsafe_state_and_reports_stale_bindings() {
+  local tmp config workspace quoted outside
+  tmp="$(mktemp -d)"
+  tmp="$(cd "$tmp" && pwd -P)"
+  config="$tmp/config"
+  workspace="$tmp/workspace"
+  quoted="$tmp/quoted \"workspace\""
+  outside="$tmp/outside-registry"
+  mkdir -p "$tmp/home/.codex-work" "$tmp/home/.codex-client" \
+    "$workspace" "$quoted"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$workspace" work
+  assert_status 0
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$workspace" client
+  assert_status 1
+  assert_contains "already bound to profile work"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$workspace" client --force
+  assert_status 0
+  assert_contains "Rebound $workspace from profile work to client"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$quoted" work
+  assert_status 0
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace list --json
+  assert_status 0
+  JSON_PAYLOAD="$output" node -e 'JSON.parse(process.env.JSON_PAYLOAD)'
+  assert_contains '\"workspace\"'
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$tmp/missing" work
+  assert_status 1
+  assert_contains "Workspace directory does not exist"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$workspace" ghost --force
+  assert_status 1
+  assert_contains "Profile 'ghost' is not initialized"
+
+  mkdir -p "$tmp/tab"$'\t'"workspace" "$tmp/newline"$'\n'"workspace"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$tmp/tab"$'\t'"workspace" work
+  assert_status 1
+  assert_contains "control characters"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace bind "$tmp/newline"$'\n'"workspace" work
+  assert_status 1
+  assert_contains "control characters"
+
+  printf '%s\t%s\n' "$tmp/stale-path" work >> "$config/workspaces.tsv"
+  printf '%s\t%s\n' "$workspace" ghost >> "$config/workspaces.tsv"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace list --json
+  assert_status 0
+  assert_contains '"path_exists":false'
+  assert_contains '"profile_exists":false'
+
+  printf 'malformed row\n' > "$config/workspaces.tsv"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace list
+  assert_status 1
+  assert_contains "Malformed workspace registry line 1"
+
+  printf 'outside\n' > "$outside"
+  rm -f "$config/workspaces.tsv"
+  ln -s "$outside" "$config/workspaces.tsv"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace list
+  assert_status 1
+  assert_contains "Refusing symlinked workspace registry"
+  [[ "$(cat "$outside")" == "outside" ]] || fail "workspace registry followed a symlink"
+
+  rm -rf "$tmp"
+}
+
+test_workspace_uses_xdg_config_and_manages_guard_mode() {
+  local tmp config workspace
+  tmp="$(mktemp -d)"
+  tmp="$(cd "$tmp" && pwd -P)"
+  config="$tmp/xdg/codex-profile"
+  workspace="$tmp/workspace"
+  mkdir -p "$tmp/home/.codex-work" "$workspace"
+
+  run_cmd env HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/xdg" \
+    "$SCRIPT" workspace bind "$workspace" work
+  assert_status 0
+  [[ -f "$config/workspaces.tsv" ]] || fail "workspace binding ignored XDG_CONFIG_HOME"
+
+  run_cmd env HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/xdg" \
+    "$SCRIPT" workspace guard
+  assert_status 0
+  assert_equals "warn"
+
+  run_cmd env HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/xdg" \
+    "$SCRIPT" workspace guard strict
+  assert_status 0
+  assert_contains "Workspace guard mode: strict"
+  [[ "$(mode_of "$config/guard-mode")" == "600" ]] || fail "workspace guard state is not private"
+
+  run_cmd env HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/xdg" \
+    "$SCRIPT" workspace guard
+  assert_status 0
+  assert_equals "strict"
+
+  run_cmd env HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/xdg" \
+    "$SCRIPT" workspace guard off
+  assert_status 0
+  assert_contains "Workspace guard mode: off"
+
+  run_cmd env HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/xdg" \
+    "$SCRIPT" workspace guard invalid
+  assert_status 1
+  assert_contains "Use off, warn, or strict"
+
+  run_cmd env HOME="$tmp/home" XDG_CONFIG_HOME="$tmp/xdg" \
+    "$SCRIPT" workspace unbind "$tmp/missing"
+  assert_status 1
+  assert_contains "No exact workspace binding"
+
+  if find "$config" -maxdepth 1 -name '*.tmp.*' | grep -q .; then
+    fail "workspace mutation left temporary files behind"
+  fi
+
+  rm -rf "$tmp"
+}
+
 test_logs_prints_path_and_contents() {
   local tmp log_file
   tmp="$(mktemp -d)"
@@ -1975,6 +2202,9 @@ test_init_share_with_cleans_up_after_link_failure
 test_remove_aborts_when_confirmation_does_not_match
 test_remove_yes_deletes_profile_home
 test_remove_yes_deletes_profiles_named_like_common_aliases
+test_workspace_bind_list_status_and_nested_resolution
+test_workspace_bind_rejects_unsafe_state_and_reports_stale_bindings
+test_workspace_uses_xdg_config_and_manages_guard_mode
 test_env_prints_posix_exports_for_profile
 test_env_emits_fish_syntax
 test_env_warns_to_stderr_without_polluting_stdout_when_uninitialized


### PR DESCRIPTION
## Summary

- Add private canonical workspace-to-profile bindings with nearest-ancestor resolution.
- Add `run` and `run --app` for automatic Codex CLI and signed ChatGPT Desktop routing.
- Add warn/strict/off mismatch guards for explicit `cli`, `env`/`use`, and `app` selections.
- Clean bindings during profile removal and expose binding health through `doctor`.
- Synchronize help, Bash/Zsh/Fish completions, README, AI-readable docs, changelog, design, and tests.

## Safety and compatibility

- Bindings contain only canonical project paths and profile names and are stored with private permissions through same-directory atomic replacement.
- Project directories, auth tokens, ChatGPT cookies, and other credentials are never read, copied, moved, or deleted.
- Desktop routing continues to launch the original signed app bundle.
- Deprecated `--instance`, `--rebuild`, and `app-instance` spellings remain supported.
- The merged `init --share-with` linked-profile behavior and completions remain intact.

## Review revisions

- Rebased onto current `main`, including the merged guide and linked-profile PRs.
- Addressed CodeRabbit's two findings: workspace routing remains under `Unreleased`, and the premature 0.8.0 release/version/date changes were removed.
- Regenerated the AUR CLI integrity hash without changing the published 0.7.0 metadata.
- Audited registry parsing/writes, canonical matching, guards, cleanup, diagnostics, argument boundaries, and signed-app routing with no remaining blocking findings.

## Validation

- `make test`
- `make lint`
- `bin/codex-profile completions zsh | zsh -n`
- `git diff --check`
