### PR TITLE
PinZheng(docs): add platform outreach guardrails

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -47,6 +47,24 @@ to base `appcezSUhDxz7uaQW` and requires Node 18+.
 Do not duplicate prior submissions unless there is a clear reason, such as a
 closed PR that needs a replacement.
 
+## Dashboard and Platform Outreach
+
+Before any dashboard, directory form, launchpad, community, article site, or
+other non-GitHub platform work, invoke `$platform-outreach`. Follow its
+community-voice recipe, media preflight, draft-integrity, completion-state,
+ledger, and publication-gate requirements. Its stop-before-publication rules
+override the general submission authority in this file for these surfaces.
+
+For this project, use this verified visual hierarchy:
+
+- Product screenshot: `media/codex-profile-parallel-instances.png`
+- Cover, launch card, banner, or social preview:
+  `media/codex-profiles-saas-promo-frame.png`
+
+Complete the skill's media preflight before long-form copy and verify the
+rendered asset and crop. Write as Chai only when the authenticated project
+context verifies that identity.
+
 Do not resume new promotion until README/LAUNCH identify v0.8.0 as released and
 the current ChatGPT app verification gate is recorded as passed. Before
 updating an existing listing, preserve its original submission history and


### PR DESCRIPTION
## Summary

- Require `$platform-outreach` for non-GitHub dashboard and platform work.
- Record the project-specific screenshot and cover-art hierarchy.
- Keep the repository hook concise while delegating detailed workflow rules to the reusable skill.

## Why

This keeps outreach community-first, visually complete, and stopped before public consequences without duplicating the full skill inside `agent.md`.

## Impact

Future non-GitHub outreach runs receive the correct skill, media, identity, and publication-gate instructions.

## Validation

- `make test`
- `make lint`
- `quick_validate.py platform-outreach`
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for dashboard and platform outreach workflows.
  * Documented media preparation, screenshot verification, drafting, tracking, completion, and publication requirements.
  * Clarified approved project assets and restricted use of the Chai identity to authenticated project contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->