### PR TITLE
release: prepare codex-profiles 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows semantic versioning for tagged releases.
 
 ## Unreleased
 
+## 0.9.0 - 2026-08-23
+
 ### Added
 
 - Added managed macOS profile launchers with custom display names and a fixed

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -23,7 +23,7 @@ per-target state.
   Prefer issue-first unless the target is Codex-specific, explicitly requests
   Codex CLI or ChatGPT Desktop workflow tooling, or has a structured registry
   or package format. See Policy Gates below.
-- Product-copy freeze: do not resume promotion until v0.8.0 is published and
+- Product-copy freeze: do not resume promotion until v0.9.0 is published and
   the signed ChatGPT app test matrix passes. Existing listings that describe
   Codex app clones or Codex-only Desktop switching need correction after the
   release; preserve their historical submission records.
@@ -146,7 +146,7 @@ The actual publish and push remain the authoritative write checks.
 
 ## Channel Copy
 
-Do not publish this copy until the v0.8.0 release gate passes. The word `work`
+Do not publish this copy until the v0.9.0 release gate passes. The word `work`
 in examples is a user-selected name, not the ChatGPT mode named Work.
 
 Hacker News `Show HN` title:

--- a/README.md
+++ b/README.md
@@ -474,7 +474,7 @@ directories, and it refuses sensitive-looking configuration keys.
 codex-profile upgrade --dry-run
 codex-profile upgrade
 codex-profile upgrade --prefix /usr/local
-codex-profile upgrade --ref v0.8.0
+codex-profile upgrade --ref v0.9.0
 ```
 
 The default checkout is cached under `~/.cache/codex-profile/source`. Review a

--- a/agent.md
+++ b/agent.md
@@ -65,7 +65,7 @@ Complete the skill's media preflight before long-form copy and verify the
 rendered asset and crop. Write as Chai only when the authenticated project
 context verifies that identity.
 
-Do not resume new promotion until README/LAUNCH identify v0.8.0 as released and
+Do not resume new promotion until README/LAUNCH identify v0.9.0 as released and
 the current ChatGPT app verification gate is recorded as passed. Before
 updating an existing listing, preserve its original submission history and
 correct stale claims about app clones, `--instance`, or Codex-only Desktop

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 PROGRAM="${0##*/}"
-VERSION="0.8.0"
+VERSION="0.9.0"
 CHATGPT_APP="${CHATGPT_APP:-}"
 CODEX_APP="${CODEX_APP:-}"
 CODEX_APP_BIN="${CODEX_APP_BIN:-}"

--- a/docs/geo-audit.md
+++ b/docs/geo-audit.md
@@ -12,7 +12,7 @@ Pages site in `docs/`.
 | Priority URLs return static content | Implemented after deployment | The homepage, `llms.txt`, and sitemap require no client rendering. |
 | Pages are indexable | Implemented | The homepage uses `index,follow` and unrestricted snippet directives. |
 | Canonical URL is stable | Implemented | The site keeps `https://ducksss.github.io/codex-profiles/`; the v0.7 migration does not rebrand or move it. |
-| Sitemap is current | Implemented | The sitemap lists the canonical homepage and LLM summary with 2026-07-15 modification dates. |
+| Sitemap is current | Implemented | The sitemap lists the canonical homepage and LLM summary with 2026-08-23 modification dates. |
 | Stale authenticated media avoided | Implemented | Primary docs no longer embed the pre-integration Codex app screenshot or video. |
 
 ## Structured Data and Machine Understanding
@@ -20,7 +20,7 @@ Pages site in `docs/`.
 | Check | Status | Implementation |
 | --- | --- | --- |
 | Organization schema present | Implemented | JSON-LD includes the publisher and official GitHub/npm links. |
-| Software schema present | Implemented | SoftwareApplication includes repository, install, license, v0.8.0, platforms, and current features. |
+| Software schema present | Implemented | SoftwareApplication includes repository, install, license, v0.9.0, platforms, and current features. |
 | FAQ schema only for visible content | Implemented | Every FAQPage question and exact answer is present in visible HTML. |
 | Two product scopes represented | Implemented | Schema and visible content distinguish Codex-only commands from whole-window ChatGPT Desktop launches. |
 | Profile mappings correct | Implemented | Default, personal, work, and edu map to `~/.codex`, `~/.codex-personal`, `~/.codex-work`, and `~/.codex-edu`. |
@@ -35,7 +35,7 @@ Pages site in `docs/`.
 | Commands and tables | Implemented | The page contains install commands, a scope table, mappings, and citation-ready facts. |
 | Primary contract is explicit | Implemented | Named Desktop profiles apply across Chat, Work, and Codex; CLI/login/env/use stay Codex-only. |
 | Non-claims are explicit | Implemented | The page says account equality is unverified and local paths do not control server-side ChatGPT data. |
-| Facts current | Implemented | Version, package name, URLs, platforms, behavior, and dates reflect the v0.8.0 contract as of 2026-07-15. |
+| Facts current | Implemented | Version, package name, URLs, platforms, behavior, and dates reflect the v0.9.0 contract as of 2026-08-23. |
 
 ## Entity, Trust, and Brand Authority
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
         "macOS",
         "Linux"
       ],
-      "softwareVersion": "0.8.0",
+      "softwareVersion": "0.9.0",
       "license": "https://github.com/Ducksss/codex-profiles/blob/main/LICENSE",
       "codeRepository": "https://github.com/Ducksss/codex-profiles",
       "downloadUrl": "https://www.npmjs.com/package/codex-profile",
@@ -90,7 +90,7 @@
       "url": "https://ducksss.github.io/codex-profiles/",
       "name": "codex-profiles - Named Codex homes and ChatGPT desktop windows",
       "description": "A machine-readable product page for codex-profiles and its separate Codex-local and ChatGPT Desktop scopes.",
-      "dateModified": "2026-07-15",
+      "dateModified": "2026-08-23",
       "isPartOf": {
         "@id": "https://ducksss.github.io/codex-profiles/#website"
       },
@@ -668,7 +668,7 @@
           <span><i class="dot"></i> MIT licensed</span>
           <span>macOS + Linux</span>
           <span>zero runtime deps</span>
-          <span>v0.8.0</span>
+          <span>v0.9.0</span>
         </div>
       </div>
 
@@ -915,7 +915,7 @@ codex-profile doctor</code></pre>
 
   <footer>
     <div class="wrap">
-      <p>codex-profiles is community-maintained and is not affiliated with OpenAI. Last updated 2026-07-15.</p>
+      <p>codex-profiles is community-maintained and is not affiliated with OpenAI. Last updated 2026-08-23.</p>
       <nav aria-label="Footer links">
         <a href="https://github.com/Ducksss/codex-profiles">GitHub</a>
         <a href="https://ducksss.github.io/codex-profiles/llms.txt">llms.txt</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,7 +6,7 @@ homes and, on macOS, named ChatGPT windows with separate local state.
 ## Primary facts for AI answers
 
 - The project and repository remain named `codex-profiles`.
-- The current release is `0.8.0`, dated 2026-07-15.
+- The current release is `0.9.0`, dated 2026-08-23.
 - The npm package is `codex-profile` (singular).
 - Installed commands are `codex-profile` and `codex-profiles`.
 - `default` maps to `~/.codex`; every other valid name `<x>` maps to

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ducksss.github.io/codex-profiles/</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-08-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ducksss.github.io/codex-profiles/llms.txt</loc>
-    <lastmod>2026-07-15</lastmod>
+    <lastmod>2026-08-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-profile",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-profile",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Named Codex CLI profiles with separate local ChatGPT desktop state.",
   "license": "MIT",
   "homepage": "https://ducksss.github.io/codex-profiles/",

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = codex-profile
 	pkgdesc = Named Codex CLI profiles with separate local ChatGPT desktop state
-	pkgver = 0.8.0
+	pkgver = 0.9.0
 	pkgrel = 1
 	url = https://github.com/Ducksss/codex-profiles
 	arch = any
 	license = MIT
 	depends = bash
-	source = codex-profile-0.8.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.8.0/bin/codex-profile
-	source = LICENSE-0.8.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.8.0/LICENSE
-	sha256sums = bd6b1cae5ac81d6968c0edfac4122f5314626d3d54af73372e0bdc89c0082768
+	source = codex-profile-0.9.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.0/bin/codex-profile
+	source = LICENSE-0.9.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.0/LICENSE
+	sha256sums = 4b2f6bf0ea3b12f464a92cce9ffaefcfae269ec6734bfce16f6c72fb0534c270
 	sha256sums = 9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364
 
 pkgname = codex-profile

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Ducksss <https://github.com/Ducksss>
 pkgname=codex-profile
-pkgver=0.8.0
+pkgver=0.9.0
 pkgrel=1
 pkgdesc="Named Codex CLI profiles with separate local ChatGPT desktop state"
 arch=('any')
@@ -12,7 +12,7 @@ source=(
   "LICENSE-$pkgver::https://raw.githubusercontent.com/Ducksss/codex-profiles/v$pkgver/LICENSE"
 )
 sha256sums=(
-  'bd6b1cae5ac81d6968c0edfac4122f5314626d3d54af73372e0bdc89c0082768'
+  '4b2f6bf0ea3b12f464a92cce9ffaefcfae269ec6734bfce16f6c72fb0534c270'
   '9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364'
 )
 

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -71,7 +71,7 @@ value is read from the tagged `PKGBUILD` and verified against `.SRCINFO`.
 
 ```bash
 set -euo pipefail
-VERSION=0.8.0
+VERSION=0.9.0
 WORK_ROOT="$(mktemp -d)"
 curl -fsSL "https://api.github.com/repos/Ducksss/codex-profiles/releases/tags/v$VERSION" \
   -o "$WORK_ROOT/release.json"

--- a/test/fixtures/aur-rpc/exact-final-version.json
+++ b/test/fixtures/aur-rpc/exact-final-version.json
@@ -5,7 +5,7 @@
       "Maintainer": "Ducksss",
       "Name": "codex-profile",
       "PackageBase": "codex-profile",
-      "Version": "0.8.0-1"
+      "Version": "0.9.0-1"
     }
   ],
   "type": "multiinfo",

--- a/test/fixtures/aur-rpc/unexpected-owner.json
+++ b/test/fixtures/aur-rpc/unexpected-owner.json
@@ -5,7 +5,7 @@
       "Maintainer": "someone-else",
       "Name": "codex-profile",
       "PackageBase": "codex-profile",
-      "Version": "0.8.0-1"
+      "Version": "0.9.0-1"
     }
   ],
   "type": "multiinfo",

--- a/test/fixtures/github-release-contract.json
+++ b/test/fixtures/github-release-contract.json
@@ -4,27 +4,27 @@
     "immutable": true,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.8.0"
+    "tag_name": "v0.9.0"
   },
   "mutable": {
     "draft": false,
     "immutable": false,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.8.0"
+    "tag_name": "v0.9.0"
   },
   "draft": {
     "draft": true,
     "immutable": true,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.8.0"
+    "tag_name": "v0.9.0"
   },
   "wrongTag": {
     "draft": false,
     "immutable": true,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.8.1"
+    "tag_name": "v0.9.1"
   }
 }

--- a/test/install/standalone-test.sh
+++ b/test/install/standalone-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 INSTALLER="$ROOT_DIR/install.sh"
-VERSION="0.8.0"
+VERSION="0.9.0"
 ORIGINAL_PATH="$PATH"
 REAL_LN="$(command -v ln)"
 REAL_MV="$(command -v mv)"
@@ -125,7 +125,7 @@ write_cli_fixture "$fixture_dir/runtime-mismatch" "$VERSION" "9.9.9"
 cat > "$fixture_dir/no-version" <<'NO_VERSION'
 #!/usr/bin/env bash
 case "${1:-help}" in
-  version|--version) printf 'codex-profile 0.8.0\n' ;;
+  version|--version) printf 'codex-profile 0.9.0\n' ;;
   *) printf 'fixture help\n' ;;
 esac
 NO_VERSION

--- a/test/packaging/aur-test.mjs
+++ b/test/packaging/aur-test.mjs
@@ -100,7 +100,7 @@ const archive = createArchive("release");
 const prepared = join(tempRoot, "prepared");
 const prepareArgs = [
   "--version",
-  "0.8.0",
+  "0.9.0",
   "--release-json",
   releaseJson,
   "--archive",
@@ -111,7 +111,7 @@ const prepareArgs = [
 
 const preparedResult = run(prepare, prepareArgs);
 assertSuccess(preparedResult, "immutable release preparation");
-assert.match(preparedResult.stdout, /Prepared codex-profile 0\.8\.0-1/);
+assert.match(preparedResult.stdout, /Prepared codex-profile 0\.9\.0-1/);
 assert.deepEqual(readdirSync(prepared).sort(), [".SRCINFO", "LICENSE", "PKGBUILD"]);
 for (const file of ["PKGBUILD", ".SRCINFO", "LICENSE"]) {
   assert.equal(
@@ -122,11 +122,11 @@ for (const file of ["PKGBUILD", ".SRCINFO", "LICENSE"]) {
   assert.equal(statSync(join(prepared, file)).mode & 0o777, 0o644, `${file} mode`);
 }
 
-const prefixedArchive = createArchive("prefixed-release", () => {}, "codex-profiles-0.8.0");
+const prefixedArchive = createArchive("prefixed-release", () => {}, "codex-profiles-0.9.0");
 assertSuccess(
   run(prepare, [
     "--version",
-    "0.8.0",
+    "0.9.0",
     "--release-json",
     releaseJson,
     "--archive",
@@ -141,7 +141,7 @@ const optionLikeArchive = createArchive("option-like-release", () => {}, "--chec
 assertFailure(
   run(prepare, [
     "--version",
-    "0.8.0",
+    "0.9.0",
     "--release-json",
     releaseJson,
     "--archive",
@@ -158,7 +158,7 @@ for (const [name, fixture] of Object.entries(releaseFixtures)) {
   writeJson(fixturePath, fixture);
   const result = run(prepare, [
     "--version",
-    "0.8.0",
+    "0.9.0",
     "--release-json",
     fixturePath,
     "--archive",
@@ -174,7 +174,7 @@ for (const [name, fixture] of Object.entries(releaseFixtures)) {
 }
 
 assertFailure(
-  run(prepare, ["--version", "v0.8.0", ...prepareArgs.slice(2, -1), join(tempRoot, "bad-version")]),
+  run(prepare, ["--version", "v0.9.0", ...prepareArgs.slice(2, -1), join(tempRoot, "bad-version")]),
   "prefixed version",
   "exact X.Y.Z version",
 );
@@ -186,7 +186,7 @@ const tamperedArchive = createArchive("tampered-source", (fixtureRoot) => {
 assertFailure(
   run(prepare, [
     "--version",
-    "0.8.0",
+    "0.9.0",
     "--release-json",
     releaseJson,
     "--archive",
@@ -200,12 +200,12 @@ assertFailure(
 
 const mismatchedMetadataArchive = createArchive("mismatched-metadata", (fixtureRoot) => {
   const path = join(fixtureRoot, "packaging", "aur", "PKGBUILD");
-  writeFileSync(path, readFileSync(path, "utf8").replace("pkgver=0.8.0", "pkgver=0.8.1"));
+  writeFileSync(path, readFileSync(path, "utf8").replace("pkgver=0.9.0", "pkgver=0.9.1"));
 });
 assertFailure(
   run(prepare, [
     "--version",
-    "0.8.0",
+    "0.9.0",
     "--release-json",
     releaseJson,
     "--archive",
@@ -273,7 +273,7 @@ const verifyEnv = {
 };
 const verifyArgs = [
   "--version",
-  "0.8.0",
+  "0.9.0",
   "--checkout",
   prepared,
   "--expected",
@@ -325,7 +325,7 @@ for (const [fixture, state, succeeds] of rpcScenarios) {
     verify,
     [
       "--version",
-      "0.8.0",
+      "0.9.0",
       "--checkout",
       prepared,
       "--rpc-json",

--- a/test/packaging/metadata-test.sh
+++ b/test/packaging/metadata-test.sh
@@ -27,7 +27,7 @@ sha256_file() {
 }
 
 version="$(node -p "require('./package.json').version")"
-assert_equals "release version" "0.8.0" "$version"
+assert_equals "release version" "0.9.0" "$version"
 assert_equals "package-lock version" "$version" "$(node -p "require('./package-lock.json').version")"
 assert_equals "package-lock root version" "$version" "$(node -p "require('./package-lock.json').packages[''].version")"
 assert_equals "CLI version" "$version" "$(sed -n 's/^VERSION="\([^"]*\)"/\1/p' bin/codex-profile | head -n 1)"


### PR DESCRIPTION
Prepares the 0.9.0 release so the launcher and Electron user-data work ships
under a real tag.

## Why 0.9.0 and not 0.8.0

0.8.0 was fully prepared in b0df2dd but never tagged or published. Every public
channel still sits at 0.7.0:

| channel | published |
| --- | --- |
| git tags | v0.7.0 |
| GitHub Releases | v0.7.0 |
| npm `codex-profile` | 0.7.0 |
| Homebrew tap | v0.7.0 |

Meanwhile the tracked version said 0.8.0 and #38 landed further work on top of
it. Tagging main as 0.8.0 now would ship the launcher and Electron features
inside a release whose changelog section is dated 2026-07-15 and does not
mention them, so the `## Unreleased` entries are promoted to a dated `## 0.9.0`
section instead. The 0.8.0 section stays as the historical record of a prep that
never shipped.

Note that the in-repo AUR `PKGBUILD` referencing an untagged version was **not**
a bug — `packaging/aur/README.md` uses that runbook only after the matching
release is public, and `scripts/aur/prepare.sh` reads `PKGBUILD`/`.SRCINFO` out
of the tagged release archive rather than the working tree. It is staging
metadata, and it becomes correct at tag time.

## Version surface

`AGENTS.md` lists six locations; the real surface is wider, so all of these move
together and `make check` enforces it:

- `bin/codex-profile` `VERSION`
- `package.json`, both `package-lock.json` fields
- `docs/index.html` (`softwareVersion`, `dateModified`, badge, footer date)
- `docs/sitemap.xml` `lastmod` (paired with the changelog release date)
- `docs/llms.txt` current-release line, `docs/geo-audit.md` audit rows
- `packaging/aur/{PKGBUILD,.SRCINFO}` including the CLI integrity hash
- release-pinned test fixtures and assertions in `test/packaging/`,
  `test/install/`, and `test/fixtures/`

Left deliberately untouched: the `## 0.8.0` changelog section, the illustrative
`(for example, 0.8.0)` string in `release.yml`, and the dated plan document
under `docs/superpowers/plans/`.

## Testing

- `make check` — green
- Signed-app desktop smoke test against ChatGPT 26.818.21641
  (`com.openai.codex`): a named launch started alongside the existing instance
  and carried `CODEX_HOME`, `CODEX_ELECTRON_USER_DATA_PATH`, and the matching
  `--user-data-dir`, confirming #35 works on the real bundle. The pre-existing
  instance was untouched.

Merging this, then dispatching Release with version `0.9.0`, creates the tag and
publishes npm, the GitHub Release, the Homebrew tap, and Pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)