### PR TITLE
build: preflight publish credentials during release dry runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,13 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: Preflight publish credentials
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+        run: |
+          scripts/release/preflight.sh
+
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
 
@@ -90,7 +97,7 @@ jobs:
           TAG: ${{ steps.release.outputs.tag }}
         run: |
           if [[ "$DRY_RUN" == "true" ]]; then
-            echo "Validated $TAG. Dry run made no release changes." | tee -a "$GITHUB_STEP_SUMMARY"
+            echo "Validated $TAG and publish credentials. Dry run made no release changes." | tee -a "$GITHUB_STEP_SUMMARY"
           else
             echo "Validated $TAG for live publication." | tee -a "$GITHUB_STEP_SUMMARY"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project follows semantic versioning for tagged releases.
 
 ## Unreleased
 
+### Changed
+
+- Release dry runs now preflight the npm and Homebrew tap credentials, so a
+  missing or unauthorized publish secret fails before a live run reaches the
+  tag and publish steps. The secrets stay scoped to that step rather than the
+  whole verification job.
+
 ## 0.9.0 - 2026-08-23
 
 ### Added

--- a/test/release/workflow-contract-test.mjs
+++ b/test/release/workflow-contract-test.mjs
@@ -60,6 +60,36 @@ for (const permission of ["contents: write", "id-token: write", "actions: write"
   assert.ok(publishJob.includes(`      ${permission}`), `publish job should grant ${permission}`);
 }
 
+// A dry run must prove a live run could authenticate, so the always-running
+// verify job preflights the publish credentials too.
+const credentialPreflight = stepBlock("Preflight publish credentials");
+assert.ok(
+  verifyJob.includes("      - name: Preflight publish credentials"),
+  "verify job should preflight publish credentials so dry runs catch missing secrets",
+);
+for (const literal of ["NPM_TOKEN: ${{ secrets.NPM_TOKEN }}", "TAP_TOKEN: ${{ secrets.TAP_TOKEN }}"]) {
+  assert.ok(credentialPreflight.includes(literal), `credential preflight should read ${literal}`);
+}
+assert.ok(
+  !credentialPreflight.includes("if: ${{ ! inputs.dry_run }}"),
+  "credential preflight must also run for dry runs",
+);
+// Job-level secrets would be readable by `make check`, which runs the whole
+// test suite. Keep them scoped to the preflight step.
+const verifyJobConfig = verifyJob.slice(0, verifyJob.indexOf("    steps:"));
+for (const secret of ["NPM_TOKEN", "TAP_TOKEN"]) {
+  assert.ok(
+    !verifyJobConfig.includes(secret),
+    `verify job must not expose ${secret} to every step; scope it to the preflight step`,
+  );
+}
+for (const secret of ["NPM_TOKEN", "TAP_TOKEN"]) {
+  assert.ok(
+    !stepBlock("Run full verification").includes(secret),
+    `full verification must not receive ${secret}`,
+  );
+}
+
 const publishSteps = [
   "Validate live release source",
   "Preflight release credential identities",
@@ -122,7 +152,9 @@ for (const script of [
   "deploy-pages.sh",
 ]) {
   const matches = workflow.match(new RegExp(`scripts/release/${script.replace(".", "\\.")}`, "g")) ?? [];
-  const expected = ["verify-distribution.sh", "publish-npm.sh", "publish-github.sh"].includes(script) ? 2 : 1;
+  const expected = ["verify-distribution.sh", "publish-npm.sh", "publish-github.sh", "preflight.sh"].includes(script)
+    ? 2
+    : 1;
   assert.equal(matches.length, expected, `${script} should be wired ${expected} time(s)`);
 }
 


### PR DESCRIPTION
Makes a release dry run surface missing or unauthorized publish credentials.

## Why

`dry_run=true` skips the entire `publish` job via `if: ${{ ! inputs.dry_run }}`,
and every credential check lived in that job. So a dry run could report success
while a live run was guaranteed to fail. That is exactly what happened with
0.9.0: the dry run passed, then the live dispatch died at
`Preflight release credential identities` with `TAP_TOKEN is required.`

`TAP_TOKEN` has never been set on this repository — `git log -S` shows the
requirement arrived with `b0df2dd`, the 0.8.0 workflow rework, and no live
release has run on the new workflow since. So the first live dispatch was always
going to hit it, and a dry run could never have warned.

## Change

`scripts/release/preflight.sh` is now also wired into the always-running `verify`
job, so both dry and live runs prove the npm and tap credentials authenticate.
The script is entirely read-only (`npm whoami`, `npm owner ls`, `gh api`), so it
is safe on a dry run.

The live preflight in `publish` stays, guarding against secret rotation between
the two jobs.

## Secret scoping

The secrets are declared at **step** level, not job level. The `verify` job's
next step is `Run full verification`, which executes `make check` — the entire
test suite. Job-level `env` would make both tokens readable by any test in that
suite; step-level `env` does not. The contract test now enforces this: it fails
if either token appears in the verify job's config block, or inside the
`Run full verification` step.

`verify` keeps `permissions: contents: read` — `preflight.sh` passes
`GH_TOKEN="$TAP_TOKEN"` explicitly, so it needs no job permissions.

## Testing

- `make check` — green
- Mutation-tested both new assertions: removing the verify preflight, and
  hoisting the secrets to job level, each fail the contract test
- The next dry run is expected to **fail** on `TAP_TOKEN is required.` until that
  secret is configured. That failure is the fix working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release dry runs now validate npm and Homebrew publishing credentials before release validation.
  * Dry-run summaries clearly indicate whether publishing credentials were verified.

* **Documentation**
  * Added an Unreleased changelog entry describing the credential preflight process and its limited scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->