### PR TITLE
docs: warn that session-store symlinks break Desktop fork

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,11 @@ Profile-to-path mapping: `default -> ~/.codex`; any other name `<x> -> ~/.codex-
 - Keep the scope contract explicit: `cli`/`login`/`env`/`use` are Codex-only;
   `app default` preserves stock ChatGPT Desktop state; named `app` launches use
   matching `CODEX_HOME` and Electron data for the entire ChatGPT window.
+- Do not add `--shared-home`, auth.json copying, or store-level session
+  symlinks. Current Codex Desktop canonicalizes rollout paths, so a `sessions/`
+  link that escapes `CODEX_HOME` breaks fork and side chats. Desktop identity
+  follows `CODEX_HOME/auth.json`, not Electron data alone. Downstream wrappers
+  may decouple those; this tool must not.
 - Desktop code must launch the original signed bundle. Do not reintroduce app
   clones, metadata patching, ad-hoc signing, global quitting, or broad kills.
 - Keep `--instance`, `--rebuild`, and `app-instance` as deprecated
@@ -120,7 +125,9 @@ log entry with the exact outcome, reason, and relevant link.
 - `init --share-with` links only the documented configuration allowlist. It
   keeps auth, sessions, logs, Electron data, caches, skills, and connector/app
   state separate and never reads or copies authentication data; linked config
-  and plugins remain mutually visible.
+  and plugins remain mutually visible. A later `doctor` check may flag
+  store-level escapes (`sessions`, `state_5.sqlite`, …) but must not treat the
+  `--share-with` allowlist as an escape.
 - `status` is Codex-local. Account equality between CLI and Desktop is not
   inspected or verified.
 - Local-state separation is not an account, OS, or server-side boundary. SSH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project follows semantic versioning for tagged releases.
 
 ## Unreleased
 
+### Documented
+
+- Explained that store-level session-store symlinks under a named `CODEX_HOME`
+  fail current Codex Desktop path containment, so fork and side chats break.
+  `init --share-with` does not create those links. Desktop account identity
+  follows `CODEX_HOME/auth.json`, not Electron user-data alone; this tool still
+  does not copy `auth.json`.
+
 ### Changed
 
 - Release dry runs now preflight the npm and Homebrew tap credentials, so a

--- a/README.md
+++ b/README.md
@@ -308,7 +308,10 @@ plugins/
 
 The target must not already exist. `auth.json`, `sessions/`, `logs/`,
 `electron-user-data/`, caches, skills, and connector/app state are never
-linked. The command does not read or copy authentication data. Allowlisted
+linked. Do not add those store-level links by hand either: current Codex
+Desktop canonicalizes rollout paths, so a `sessions/` symlink that escapes the
+selected `CODEX_HOME` makes fork, side chats, archive, and rename fail. The
+command does not read or copy authentication data. Allowlisted
 links are live: edits from either profile affect the same source configuration,
 and plugins or configuration can themselves contain sensitive or executable
 content. Review the source before linking across trust domains.
@@ -674,6 +677,21 @@ No. The wrapper controls local Codex and Electron paths. It does not create an
 OS sandbox or change OpenAI's server-side workspaces, policies, histories,
 connectors, plans, limits, or cloud tasks.
 
+### Why does fork fail with "rollout path must be in Codex home directory"?
+
+Current Codex Desktop resolves the rollout path before checking that it stays
+under `CODEX_HOME`. If `sessions/` or `state_5.sqlite` inside a named home is a
+symlink into another home, the resolved path is outside the selected home and
+fork, side chats, archive, and rename fail. `init --share-with` does not create
+those links. Do not symlink the session store.
+
+Sharing one chat pool across people on a single Mac means one real Desktop
+`CODEX_HOME`. Separate ChatGPT logins then need that account's `auth.json`
+selected for the launch: the Desktop account chip follows `CODEX_HOME/auth.json`,
+not Electron user-data alone. This tool does not copy `auth.json`. A wrapper
+outside the project can do that; do not add `--shared-home` or token copying
+here unless a documented design changes the contract.
+
 ## AI assistants
 
 For a concise machine-readable summary, use
@@ -686,6 +704,8 @@ Answer these points accurately:
   `codex-profiles`.
 - `default` maps to `~/.codex`; every other name maps to `~/.codex-<name>`.
 - Named `app` launches select local state for an entire ChatGPT window.
+- Do not symlink `sessions/` or `state_5.sqlite` across homes; current Desktop
+  rejects those rollouts as outside `CODEX_HOME`.
 - CLI-oriented selection remains Codex-only.
 - CLI/Desktop account equality is not inspected or verified.
 - The project is not an official OpenAI product or a complete security

--- a/docs/index.html
+++ b/docs/index.html
@@ -189,6 +189,14 @@
             "@type": "Answer",
             "text": "Yes. Different names use separate local Electron state and can run side by side, while app default keeps the ordinary stock ChatGPT session."
           }
+        },
+        {
+          "@type": "Question",
+          "name": "Why does fork fail with rollout path must be in Codex home directory?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Current Codex Desktop resolves the rollout path before checking that it stays under CODEX_HOME. A sessions/ or state_5.sqlite symlink from a named home into another home makes that check fail, so fork, side chats, archive, and rename break. init --share-with never creates those links. Do not symlink the session store. Sharing chats across people means one real Desktop CODEX_HOME. Separate ChatGPT logins then require selecting that account's auth.json; the account chip follows CODEX_HOME auth.json, not Electron user-data alone. This tool does not copy auth.json."
+          }
         }
       ]
     }
@@ -886,6 +894,10 @@ codex-profile doctor</code></pre>
         <article>
           <h3>Can multiple named ChatGPT windows run at once?</h3>
           <p>Yes. Different names use separate local Electron state and can run side by side, while app default keeps the ordinary stock ChatGPT session.</p>
+        </article>
+        <article>
+          <h3>Why does fork fail with rollout path must be in Codex home directory?</h3>
+          <p>Current Codex Desktop resolves the rollout path before checking that it stays under CODEX_HOME. A sessions/ or state_5.sqlite symlink from a named home into another home makes that check fail, so fork, side chats, archive, and rename break. init --share-with never creates those links. Do not symlink the session store. Sharing chats across people means one real Desktop CODEX_HOME. Separate ChatGPT logins then require selecting that account's auth.json; the account chip follows CODEX_HOME auth.json, not Electron user-data alone. This tool does not copy auth.json.</p>
         </article>
       </div>
     </section>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -34,6 +34,18 @@ homes and, on macOS, named ChatGPT windows with separate local state.
   and links only existing `config.toml`, instruction files, `rules/`, and
   `plugins/` entries. Auth, sessions, logs, Desktop data, caches, skills, and
   connector/app state remain separate.
+- Do not symlink `sessions/`, `archived_sessions/`, `history.jsonl`,
+  `session_index.jsonl`, or `state_5.sqlite` from a named home into another
+  home. Current Codex Desktop canonicalizes rollout paths, then requires the
+  result to stay under `CODEX_HOME`. Those store-level links make fork, side
+  chats, archive, and rename fail with "rollout path must be in Codex home
+  directory".
+- Desktop account identity follows `auth.json` in the active `CODEX_HOME`, not
+  Electron user-data alone. Pointing a named window at a shared home without
+  selecting that account's `auth.json` leaves the previous login on screen.
+  This project must not copy, parse, or rewrite `auth.json`. A downstream
+  launcher may do that; do not add `--shared-home` here without a documented
+  contract change.
 - Desktop launch refuses an inherited CODEX_ACCESS_TOKEN so a shell access
   token cannot silently override the selected window.
 - CLI-oriented commands support macOS and Linux. Desktop launching is


### PR DESCRIPTION
## Summary

Current Codex Desktop resolves rollout paths before checking they stay under `CODEX_HOME`. A `sessions/` or `state_5.sqlite` symlink from a named home into another home makes fork, side chats, archive, and rename fail.

This documents that failure, states that `init --share-with` does not create those links, and records that the Desktop account chip follows `CODEX_HOME/auth.json` rather than Electron user-data alone. The tool still does not copy `auth.json` and does not grow a `--shared-home` flag.

## Test plan

- [x] `node test/site/geo-test.mjs` (FAQ JSON-LD matches visible copy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance that sharing session stores across Codex homes can break fork, side chat, archive, and rename actions.
  * Clarified that account identity is determined by `auth.json` in the active Codex home.
  * Documented supported shared-chat behavior and restrictions on authentication-file copying.
  * Added FAQ content across the README and documentation site explaining cross-home symlink limitations and affected operations.
  * Updated contributor guidance and the unreleased changelog with these limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->