### PR TITLE
build: allow a release to skip the Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ on:
         description: "Live release only: tested ChatGPT version and bundle ID; no account data."
         required: false
         type: string
+      skip_homebrew:
+        description: "Publish without updating the Homebrew tap; the tap stays on its current version."
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -68,6 +73,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+          SKIP_HOMEBREW: ${{ inputs.skip_homebrew }}
         run: |
           scripts/release/preflight.sh
 
@@ -95,11 +101,15 @@ jobs:
       - name: Verification summary
         env:
           TAG: ${{ steps.release.outputs.tag }}
+          SKIP_HOMEBREW: ${{ inputs.skip_homebrew }}
         run: |
           if [[ "$DRY_RUN" == "true" ]]; then
             echo "Validated $TAG and publish credentials. Dry run made no release changes." | tee -a "$GITHUB_STEP_SUMMARY"
           else
             echo "Validated $TAG for live publication." | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+          if [[ "$SKIP_HOMEBREW" == "true" ]]; then
+            echo "Homebrew tap update is skipped; the tap keeps its current version." | tee -a "$GITHUB_STEP_SUMMARY"
           fi
 
   publish:
@@ -157,6 +167,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
+          SKIP_HOMEBREW: ${{ inputs.skip_homebrew }}
         run: |
           scripts/release/preflight.sh
 
@@ -226,7 +237,7 @@ jobs:
           scripts/release/verify-distribution.sh standalone
 
       - name: Update Homebrew tap
-        if: ${{ ! inputs.dry_run }}
+        if: ${{ ! inputs.dry_run && ! inputs.skip_homebrew }}
         env:
           TAP_TOKEN: ${{ secrets.TAP_TOKEN }}
           V: ${{ needs.verify.outputs.version }}
@@ -246,5 +257,10 @@ jobs:
         env:
           V: ${{ needs.verify.outputs.version }}
           TAG: ${{ needs.verify.outputs.tag }}
+          SKIP_HOMEBREW: ${{ inputs.skip_homebrew }}
         run: |
           echo "Released codex-profile $V and verified Pages from $TAG." | tee -a "$GITHUB_STEP_SUMMARY"
+          if [[ "$SKIP_HOMEBREW" == "true" ]]; then
+            echo "The Homebrew tap was not updated; publish it separately for $V." \
+              | tee -a "$GITHUB_STEP_SUMMARY"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project follows semantic versioning for tagged releases.
   missing or unauthorized publish secret fails before a live run reaches the
   tag and publish steps. The secrets stay scoped to that step rather than the
   whole verification job.
+- Added a `skip_homebrew` release input that publishes npm, the GitHub Release,
+  and Pages without touching the Homebrew tap. A skipped release neither
+  requires nor consults tap credentials, and both run summaries state that the
+  tap keeps its current version.
 
 ## 0.9.0 - 2026-08-23
 

--- a/scripts/release/preflight.sh
+++ b/scripts/release/preflight.sh
@@ -7,8 +7,15 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 # shellcheck source=scripts/release/lib.sh
 source "$SCRIPT_DIR/lib.sh"
 cd "$ROOT_DIR"
+skip_homebrew="${SKIP_HOMEBREW:-false}"
+[[ "$skip_homebrew" == "true" || "$skip_homebrew" == "false" ]] || {
+  echo "SKIP_HOMEBREW must be true or false." >&2
+  exit 1
+}
 [[ -n "${NPM_TOKEN:-}" ]] || { echo "NPM_TOKEN is required." >&2; exit 1; }
-[[ -n "${TAP_TOKEN:-}" ]] || { echo "TAP_TOKEN is required." >&2; exit 1; }
+if [[ "$skip_homebrew" != "true" ]]; then
+  [[ -n "${TAP_TOKEN:-}" ]] || { echo "TAP_TOKEN is required." >&2; exit 1; }
+fi
 
 registry="https://registry.npmjs.org/"
 npm_user=""
@@ -35,6 +42,12 @@ if ! awk -v expected="$npm_user" '
   exit 1
 fi
 unset npm_owners npm_user
+
+if [[ "$skip_homebrew" == "true" ]]; then
+  echo "Skipping Homebrew tap credentials; this release leaves the tap unchanged."
+  echo "Release credential identities passed preflight."
+  exit 0
+fi
 
 tap_account_push=""
 if ! tap_account_push="$(

--- a/test/release/state-test.sh
+++ b/test/release/state-test.sh
@@ -100,6 +100,36 @@ set -e
 [[ "$missing_secret_status" -ne 0 ]] || fail "preflight accepted missing npm token"
 [[ "$missing_secret_output" != *'tap-token'* ]] || fail "preflight leaked tap token"
 
+set +e
+missing_tap_output="$({
+  PATH="$fake_bin:$PATH" RELEASE_TEST_LOG="$log_file" NPM_TOKEN="npm-token" TAP_TOKEN="" "$PREFLIGHT"
+} 2>&1)"
+missing_tap_status=$?
+set -e
+[[ "$missing_tap_status" -ne 0 ]] || fail "preflight accepted a missing tap token"
+[[ "$missing_tap_output" == *'TAP_TOKEN is required.'* ]] || fail "preflight did not name the missing tap token"
+
+# Skipping the tap must not require or consult tap credentials.
+: > "$log_file"
+skip_output="$(
+  PATH="$fake_bin:$PATH" RELEASE_TEST_LOG="$log_file" \
+    NPM_TOKEN="npm-token" TAP_TOKEN="" SKIP_HOMEBREW=true "$PREFLIGHT"
+)"
+[[ "$skip_output" == *'leaves the tap unchanged'* ]] || fail "skipped preflight did not report the skipped tap"
+grep -F 'npm:whoami --registry' "$log_file" >/dev/null || fail "skipped preflight skipped npm identity"
+! grep -F 'gh:api repos/Ducksss/homebrew-tap' "$log_file" >/dev/null \
+  || fail "skipped preflight still consulted the tap"
+
+set +e
+bad_flag_output="$({
+  PATH="$fake_bin:$PATH" RELEASE_TEST_LOG="$log_file" \
+    NPM_TOKEN="npm-token" TAP_TOKEN="tap-token" SKIP_HOMEBREW=yes "$PREFLIGHT"
+} 2>&1)"
+bad_flag_status=$?
+set -e
+[[ "$bad_flag_status" -ne 0 ]] || fail "preflight accepted a non-boolean SKIP_HOMEBREW"
+[[ "$bad_flag_output" == *'SKIP_HOMEBREW must be true or false.'* ]] || fail "preflight did not reject SKIP_HOMEBREW"
+
 run_verify_state() {
   local scenario="$1"
   local expected_status="$2"

--- a/test/release/workflow-contract-test.mjs
+++ b/test/release/workflow-contract-test.mjs
@@ -29,6 +29,7 @@ const requiredLiterals = [
   "version:",
   "dry_run:",
   "desktop_smoke_attestation:",
+  "skip_homebrew:",
   "group: release",
   "cancel-in-progress: false",
   "needs: verify",
@@ -129,9 +130,30 @@ for (const [name, literals] of Object.entries({
 }
 
 for (const name of publishSteps.slice(1, -1)) {
-  assert.ok(
-    stepBlock(name).includes("if: ${{ ! inputs.dry_run }}"),
+  assert.match(
+    stepBlock(name),
+    /if: \$\{\{ ! inputs\.dry_run( &&[^}]*)? \}\}/,
     `${name} should remain live-only`,
+  );
+}
+
+// skip_homebrew lets a release publish npm, the GitHub Release, and Pages while
+// leaving the tap on its current version. Both preflights must learn about it,
+// or a skipped release would still demand tap credentials.
+for (const name of ["Preflight publish credentials", "Preflight release credential identities"]) {
+  assert.ok(
+    stepBlock(name).includes("SKIP_HOMEBREW: ${{ inputs.skip_homebrew }}"),
+    `${name} should receive skip_homebrew`,
+  );
+}
+assert.ok(
+  stepBlock("Update Homebrew tap").includes("if: ${{ ! inputs.dry_run && ! inputs.skip_homebrew }}"),
+  "the tap update should be skipped when skip_homebrew is set",
+);
+for (const name of ["Verification summary", "Release summary"]) {
+  assert.ok(
+    stepBlock(name).includes("SKIP_HOMEBREW: ${{ inputs.skip_homebrew }}"),
+    `${name} should report whether the tap was skipped`,
   );
 }
 


### PR DESCRIPTION
Adds a `skip_homebrew` release input so 0.9.0 can publish now, with the Homebrew
tap updated separately once `TAP_TOKEN` exists.

## Why

`TAP_TOKEN` has never been configured on this repository, and the requirement
arrived with `b0df2dd` (the 0.8.0 workflow rework), so no live release has ever
run on the current workflow. The tap step blocks the whole release even though
npm, the GitHub Release, and Pages are ready.

## Behavior

With `skip_homebrew=true`:

- `preflight.sh` neither requires nor consults tap credentials — no `TAP_TOKEN`,
  no `gh api repos/Ducksss/homebrew-tap` call
- the `Update Homebrew tap` step is skipped
- both the verification and release summaries state that the tap keeps its
  current version

Default is `false`, so the strict all-channel behavior is unchanged.

## The tradeoff, stated plainly

The tap currently pins `v0.7.0`. A skipped release leaves Homebrew users on
0.7.0 while npm moves to 0.9.0. That divergence is exactly what the all-or-
nothing preflight was protecting against, which is why the skip is explicit,
opt-in per dispatch, and reported in both summaries rather than silent. Running
a normal release later — or the AUR-style manual tap update — brings it back in
line.

`SKIP_HOMEBREW` is also validated as a strict boolean, so a typo like
`SKIP_HOMEBREW=yes` fails loudly instead of being read as falsey and quietly
demanding tap credentials.

## Testing

- `make check` — green
- `state-test.sh` now covers: the skip path performs npm identity checks but
  never touches the tap; a missing `TAP_TOKEN` still fails when not skipping;
  a non-boolean flag is rejected
- Mutation-tested the new contract assertions: removing the tap's
  `skip_homebrew` guard, and dropping the flag from the verify preflight, each
  fail the contract test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a release option to skip updating the Homebrew tap.
  - Releases can proceed without Homebrew tap credentials when this option is enabled.
  - Release and verification summaries now indicate when the tap was not updated.

- **Bug Fixes**
  - Added validation to ensure the skip option accepts only true or false values.

- **Tests**
  - Added coverage for skipped tap updates, missing credentials, and invalid option values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->