### PR TITLE
docs(docs): scope the symlink breakage claims to verified operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project follows semantic versioning for tagged releases.
 ### Documented
 
 - Explained that store-level session-store symlinks under a named `CODEX_HOME`
-  fail current Codex Desktop path containment, so fork and side chats break.
-  `init --share-with` does not create those links. Desktop account identity
-  follows `CODEX_HOME/auth.json`, not Electron user-data alone; this tool still
-  does not copy `auth.json`.
+  fail current Codex Desktop path containment, so fork and side chats break. A
+  shared `state_5.sqlite` also breaks archive and delete, which name the
+  `sessions` directory in the error. `init --share-with` does not create those
+  links. Desktop account identity follows `CODEX_HOME/auth.json`, not Electron
+  user-data alone; this tool still does not copy `auth.json`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -310,11 +310,11 @@ The target must not already exist. `auth.json`, `sessions/`, `logs/`,
 `electron-user-data/`, caches, skills, and connector/app state are never
 linked. Do not add those store-level links by hand either: current Codex
 Desktop canonicalizes rollout paths, so a `sessions/` symlink that escapes the
-selected `CODEX_HOME` makes fork, side chats, archive, and rename fail. The
-command does not read or copy authentication data. Allowlisted
-links are live: edits from either profile affect the same source configuration,
-and plugins or configuration can themselves contain sensitive or executable
-content. Review the source before linking across trust domains.
+selected `CODEX_HOME` makes fork and side chats fail. The command does not read
+or copy authentication data. Allowlisted links are live: edits from either
+profile affect the same source configuration, and plugins or configuration can
+themselves contain sensitive or executable content. Review the source before
+linking across trust domains.
 
 ### Inspect Codex-local status
 
@@ -682,8 +682,10 @@ connectors, plans, limits, or cloud tasks.
 Current Codex Desktop resolves the rollout path before checking that it stays
 under `CODEX_HOME`. If `sessions/` or `state_5.sqlite` inside a named home is a
 symlink into another home, the resolved path is outside the selected home and
-fork, side chats, archive, and rename fail. `init --share-with` does not create
-those links. Do not symlink the session store.
+fork and side chats fail. A shared `state_5.sqlite` also breaks archive and
+delete, which scope rollouts to `sessions/` and name that directory in the
+error. `init --share-with` does not create those links. Do not symlink the
+session store.
 
 Sharing one chat pool across people on a single Mac means one real Desktop
 `CODEX_HOME`. Separate ChatGPT logins then need that account's `auth.json`

--- a/docs/index.html
+++ b/docs/index.html
@@ -195,7 +195,7 @@
           "name": "Why does fork fail with rollout path must be in Codex home directory?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Current Codex Desktop resolves the rollout path before checking that it stays under CODEX_HOME. A sessions/ or state_5.sqlite symlink from a named home into another home makes that check fail, so fork, side chats, archive, and rename break. init --share-with never creates those links. Do not symlink the session store. Sharing chats across people means one real Desktop CODEX_HOME. Separate ChatGPT logins then require selecting that account's auth.json; the account chip follows CODEX_HOME auth.json, not Electron user-data alone. This tool does not copy auth.json."
+            "text": "Current Codex Desktop resolves the rollout path before checking that it stays under CODEX_HOME. A sessions/ or state_5.sqlite symlink from a named home into another home makes that check fail, so fork and side chats break. A shared state_5.sqlite also breaks archive and delete, which scope rollouts to sessions/ and name that directory in the error. init --share-with never creates those links. Do not symlink the session store. Sharing chats across people means one real Desktop CODEX_HOME. Separate ChatGPT logins then require selecting that account's auth.json; the account chip follows CODEX_HOME auth.json, not Electron user-data alone. This tool does not copy auth.json."
           }
         }
       ]
@@ -897,7 +897,7 @@ codex-profile doctor</code></pre>
         </article>
         <article>
           <h3>Why does fork fail with rollout path must be in Codex home directory?</h3>
-          <p>Current Codex Desktop resolves the rollout path before checking that it stays under CODEX_HOME. A sessions/ or state_5.sqlite symlink from a named home into another home makes that check fail, so fork, side chats, archive, and rename break. init --share-with never creates those links. Do not symlink the session store. Sharing chats across people means one real Desktop CODEX_HOME. Separate ChatGPT logins then require selecting that account's auth.json; the account chip follows CODEX_HOME auth.json, not Electron user-data alone. This tool does not copy auth.json.</p>
+          <p>Current Codex Desktop resolves the rollout path before checking that it stays under CODEX_HOME. A sessions/ or state_5.sqlite symlink from a named home into another home makes that check fail, so fork and side chats break. A shared state_5.sqlite also breaks archive and delete, which scope rollouts to sessions/ and name that directory in the error. init --share-with never creates those links. Do not symlink the session store. Sharing chats across people means one real Desktop CODEX_HOME. Separate ChatGPT logins then require selecting that account's auth.json; the account chip follows CODEX_HOME auth.json, not Electron user-data alone. This tool does not copy auth.json.</p>
         </article>
       </div>
     </section>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -37,9 +37,10 @@ homes and, on macOS, named ChatGPT windows with separate local state.
 - Do not symlink `sessions/`, `archived_sessions/`, `history.jsonl`,
   `session_index.jsonl`, or `state_5.sqlite` from a named home into another
   home. Current Codex Desktop canonicalizes rollout paths, then requires the
-  result to stay under `CODEX_HOME`. Those store-level links make fork, side
-  chats, archive, and rename fail with "rollout path must be in Codex home
-  directory".
+  result to stay under `CODEX_HOME`. Those store-level links make fork and
+  side chats fail with "rollout path must be in Codex home directory". A
+  shared `state_5.sqlite` also breaks archive and delete, which scope rollouts
+  to `sessions/` and name that directory in the error.
 - Desktop account identity follows `auth.json` in the active `CODEX_HOME`, not
   Electron user-data alone. Pointing a named window at a shared home without
   selecting that account's `auth.json` leaves the previous login on screen.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -37,10 +37,13 @@ homes and, on macOS, named ChatGPT windows with separate local state.
 - Do not symlink `sessions/`, `archived_sessions/`, `history.jsonl`,
   `session_index.jsonl`, or `state_5.sqlite` from a named home into another
   home. Current Codex Desktop canonicalizes rollout paths, then requires the
-  result to stay under `CODEX_HOME`. Those store-level links make fork and
-  side chats fail with "rollout path must be in Codex home directory". A
-  shared `state_5.sqlite` also breaks archive and delete, which scope rollouts
-  to `sessions/` and name that directory in the error.
+  result to stay under `CODEX_HOME`, so a `sessions/` or `archived_sessions/`
+  symlink, or a shared `state_5.sqlite`, makes fork and side chats fail with
+  "rollout path must be in Codex home directory". A shared `state_5.sqlite`
+  also breaks archive and delete, which scope rollouts to `sessions/` and name
+  that directory in the error. `history.jsonl` and `session_index.jsonl` hold
+  no rollout paths; sharing them leaks prompt history and thread names across
+  homes instead.
 - Desktop account identity follows `auth.json` in the active `CODEX_HOME`, not
   Electron user-data alone. Pointing a named window at a shared home without
   selecting that account's `auth.json` leaves the previous login on screen.


### PR DESCRIPTION
## Summary

Follow-up to #41. That PR's FAQ said a cross-home session-store symlink makes
"fork, side chats, archive, and rename" fail. Fork and side chats are right;
the other two were over-stated. Verified against `openai/codex`
`codex-rs/thread-store/src/local/`:

- `helpers.rs::scoped_rollout_path` canonicalizes **both** the root and the
  rollout path, then requires `starts_with`.
- **Fork / side chats** (`rollout_lineage.rs`) pass the home itself as root
  (`root_name = "Codex home"`). A `sessions/` symlink or a shared
  `state_5.sqlite` resolves outside it, so these fail — exactly as documented.
- **Archive / delete** (`archive_thread.rs`, `delete_thread.rs`) pass
  `codex_home/sessions` as root (`root_name = "sessions"`). With a plain
  `sessions/` symlink, root and rollout canonicalize to the same target and
  containment **passes**. Only a shared `state_5.sqlite`, which hands the index
  paths in the other home, breaks them — and the error names the `sessions`
  directory, not `Codex home`.
- **Rename** (`update_thread_metadata.rs`, which carries the title patch, and
  `thread_sections.rs::rename_thread_section`) never calls the containment
  check. It is unaffected.

So: rename is dropped from the enumeration, and archive is kept but qualified
to the shared-index case with its own error string. The guidance itself is
unchanged — do not symlink the session store.

Updated all five sites that carried the claim: the README `--share-with`
paragraph and FAQ answer, both copies in `docs/index.html` (JSON-LD and visible
article), `docs/llms.txt`, and the still-unreleased CHANGELOG entry. `AGENTS.md`
already said only "fork and side chats" and needed no change.

## Test plan

- [x] `make check` (exit 0)
- [x] `node test/site/geo-test.mjs` — FAQ JSON-LD still matches visible copy
      verbatim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified which symlink and shared-state configurations affect specific operations.
  * Documented that `sessions/` or `archived_sessions/` links can prevent fork and side chats.
  * Documented that a shared `state_5.sqlite` can prevent archive and delete.
  * Updated error-message guidance to identify the `sessions/` directory when rollout paths fall outside the supported home directory.
  * Noted that shared history files may expose prompt history and thread names across homes.
  * Removed outdated references indicating that rename is affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->