### PR TITLE
test(fix): give npm pack a throwaway cache in the package smoke test

### DIFF
--- a/test/install/npm-package-test.sh
+++ b/test/install/npm-package-test.sh
@@ -13,7 +13,9 @@ if ! command -v npm >/dev/null 2>&1; then
   exit 0
 fi
 
-pack_json="$(npm pack --json --pack-destination "$TMP_PREFIX")"
+pack_json="$(npm pack --json \
+  --cache "$TMP_PREFIX/npm-cache" \
+  --pack-destination "$TMP_PREFIX")"
 tarball_name="$(
   node -e '
     const value = JSON.parse(process.argv[1]);


### PR DESCRIPTION
## Summary

Partially addresses #7 — specifically the one proposal from that issue that was
still unapplied.

`test/install/npm-package-test.sh` isolates the cache for `npm install`
(`--cache "$TMP_PREFIX/npm-cache"`) but not for the `npm pack` above it, which
fell back to the caller's global npm cache. A broken or unwritable user cache —
the `EPERM` reported in #7 — then fails the smoke test for reasons unrelated to
the package being tested. This passes the same temp cache to `pack`.

## On the rest of #7

The failure-masking that issue describes **no longer exists**, and is already
guarded against regression. Verified on current `main`:

- `npm-package-test` is a single-command recipe delegating to a script that
  starts with `set -euo pipefail`. `install-smoke-test` and `path-smoke-test`
  both open with `@set -eu;`.
- `scripts/check` also runs `set -euo pipefail` and invokes each `*-test.sh`
  directly, so a failing test propagates to `make check` and CI.
- `test/install/makefile-test.sh` already mutation-tests these recipes:
  `require_mutation_failure` replaces an assertion with a failing one and
  requires the target to fail, and `require_print_then_fail_mutation` covers the
  exact masking scenario — a producer that prints the expected value but exits
  non-zero must still fail the target. It also asserts that exactly two recipes
  carry `set -eu; ... mktemp -d`, so the strictness cannot be quietly dropped.

Empirically confirmed by stubbing `npm` so `npm pack` exits 1: the script exits
`1`, and `scripts/check test` exits `1` and halts.

One loose end not changed here: `package.json`'s `"pack:check": "npm pack
--dry-run --silent"` is referenced nowhere in the repo or CI. It is the exact
command #7 reported failing, and it has no temp cache. Worth either wiring into
the check suite or dropping — left alone pending a maintainer call.

Recommend closing #7 once this lands.

## Test plan

- [x] `make check` (exit 0, includes shellcheck lint)
- [x] `bash test/install/npm-package-test.sh` passes
- [x] With a stubbed failing `npm pack`, the script still exits 1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved npm package smoke testing by using a temporary cache directory during package creation.
  * Preserved the existing temporary destination for generated packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->