### PR TITLE
release(feat): prepare codex-profiles 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows semantic versioning for tagged releases.
 
 ## Unreleased
 
+## 0.9.1 - 2026-08-30
+
 ### Documented
 
 - Explained that store-level session-store symlinks under a named `CODEX_HOME`
@@ -16,16 +18,11 @@ and this project follows semantic versioning for tagged releases.
   links. Desktop account identity follows `CODEX_HOME/auth.json`, not Electron
   user-data alone; this tool still does not copy `auth.json`.
 
-### Changed
+### Tests
 
-- Release dry runs now preflight the npm and Homebrew tap credentials, so a
-  missing or unauthorized publish secret fails before a live run reaches the
-  tag and publish steps. The secrets stay scoped to that step rather than the
-  whole verification job.
-- Added a `skip_homebrew` release input that publishes npm, the GitHub Release,
-  and Pages without touching the Homebrew tap. A skipped release neither
-  requires nor consults tap credentials, and both run summaries state that the
-  tap keeps its current version.
+- The npm package smoke test now gives `npm pack` the same throwaway cache the
+  install step already used, so a broken or unwritable user npm cache no longer
+  fails the test for reasons unrelated to the package.
 
 ## 0.9.0 - 2026-08-23
 
@@ -48,6 +45,14 @@ and this project follows semantic versioning for tagged releases.
   skips a stale record on stderr instead of failing the whole listing and
   emitting truncated JSON, `launcher create` rebuilds the missing app, and
   `launcher remove` clears the leftover record.
+- Release dry runs now preflight the npm and Homebrew tap credentials, so a
+  missing or unauthorized publish secret fails before a live run reaches the
+  tag and publish steps. The secrets stay scoped to that step rather than the
+  whole verification job.
+- Added a `skip_homebrew` release input that publishes npm, the GitHub Release,
+  and Pages without touching the Homebrew tap. A skipped release neither
+  requires nor consults tap credentials, and both run summaries state that the
+  tap keeps its current version.
 
 ## 0.8.0 - 2026-07-15
 

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -23,7 +23,7 @@ per-target state.
   Prefer issue-first unless the target is Codex-specific, explicitly requests
   Codex CLI or ChatGPT Desktop workflow tooling, or has a structured registry
   or package format. See Policy Gates below.
-- Product-copy freeze: do not resume promotion until v0.9.0 is published and
+- Product-copy freeze: do not resume promotion until v0.9.1 is published and
   the signed ChatGPT app test matrix passes. Existing listings that describe
   Codex app clones or Codex-only Desktop switching need correction after the
   release; preserve their historical submission records.
@@ -146,7 +146,7 @@ The actual publish and push remain the authoritative write checks.
 
 ## Channel Copy
 
-Do not publish this copy until the v0.9.0 release gate passes. The word `work`
+Do not publish this copy until the v0.9.1 release gate passes. The word `work`
 in examples is a user-selected name, not the ChatGPT mode named Work.
 
 Hacker News `Show HN` title:

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ directories, and it refuses sensitive-looking configuration keys.
 codex-profile upgrade --dry-run
 codex-profile upgrade
 codex-profile upgrade --prefix /usr/local
-codex-profile upgrade --ref v0.9.0
+codex-profile upgrade --ref v0.9.1
 ```
 
 The default checkout is cached under `~/.cache/codex-profile/source`. Review a

--- a/agent.md
+++ b/agent.md
@@ -65,7 +65,7 @@ Complete the skill's media preflight before long-form copy and verify the
 rendered asset and crop. Write as Chai only when the authenticated project
 context verifies that identity.
 
-Do not resume new promotion until README/LAUNCH identify v0.9.0 as released and
+Do not resume new promotion until README/LAUNCH identify v0.9.1 as released and
 the current ChatGPT app verification gate is recorded as passed. Before
 updating an existing listing, preserve its original submission history and
 correct stale claims about app clones, `--instance`, or Codex-only Desktop

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 PROGRAM="${0##*/}"
-VERSION="0.9.0"
+VERSION="0.9.1"
 CHATGPT_APP="${CHATGPT_APP:-}"
 CODEX_APP="${CODEX_APP:-}"
 CODEX_APP_BIN="${CODEX_APP_BIN:-}"

--- a/docs/geo-audit.md
+++ b/docs/geo-audit.md
@@ -12,7 +12,7 @@ Pages site in `docs/`.
 | Priority URLs return static content | Implemented after deployment | The homepage, `llms.txt`, and sitemap require no client rendering. |
 | Pages are indexable | Implemented | The homepage uses `index,follow` and unrestricted snippet directives. |
 | Canonical URL is stable | Implemented | The site keeps `https://ducksss.github.io/codex-profiles/`; the v0.7 migration does not rebrand or move it. |
-| Sitemap is current | Implemented | The sitemap lists the canonical homepage and LLM summary with 2026-08-23 modification dates. |
+| Sitemap is current | Implemented | The sitemap lists the canonical homepage and LLM summary with 2026-08-30 modification dates. |
 | Stale authenticated media avoided | Implemented | Primary docs no longer embed the pre-integration Codex app screenshot or video. |
 
 ## Structured Data and Machine Understanding
@@ -20,7 +20,7 @@ Pages site in `docs/`.
 | Check | Status | Implementation |
 | --- | --- | --- |
 | Organization schema present | Implemented | JSON-LD includes the publisher and official GitHub/npm links. |
-| Software schema present | Implemented | SoftwareApplication includes repository, install, license, v0.9.0, platforms, and current features. |
+| Software schema present | Implemented | SoftwareApplication includes repository, install, license, v0.9.1, platforms, and current features. |
 | FAQ schema only for visible content | Implemented | Every FAQPage question and exact answer is present in visible HTML. |
 | Two product scopes represented | Implemented | Schema and visible content distinguish Codex-only commands from whole-window ChatGPT Desktop launches. |
 | Profile mappings correct | Implemented | Default, personal, work, and edu map to `~/.codex`, `~/.codex-personal`, `~/.codex-work`, and `~/.codex-edu`. |
@@ -35,7 +35,7 @@ Pages site in `docs/`.
 | Commands and tables | Implemented | The page contains install commands, a scope table, mappings, and citation-ready facts. |
 | Primary contract is explicit | Implemented | Named Desktop profiles apply across Chat, Work, and Codex; CLI/login/env/use stay Codex-only. |
 | Non-claims are explicit | Implemented | The page says account equality is unverified and local paths do not control server-side ChatGPT data. |
-| Facts current | Implemented | Version, package name, URLs, platforms, behavior, and dates reflect the v0.9.0 contract as of 2026-08-23. |
+| Facts current | Implemented | Version, package name, URLs, platforms, behavior, and dates reflect the v0.9.1 contract as of 2026-08-30. |
 
 ## Entity, Trust, and Brand Authority
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,7 @@
         "macOS",
         "Linux"
       ],
-      "softwareVersion": "0.9.0",
+      "softwareVersion": "0.9.1",
       "license": "https://github.com/Ducksss/codex-profiles/blob/main/LICENSE",
       "codeRepository": "https://github.com/Ducksss/codex-profiles",
       "downloadUrl": "https://www.npmjs.com/package/codex-profile",
@@ -98,7 +98,7 @@
       "url": "https://ducksss.github.io/codex-profiles/",
       "name": "codex-profiles - Named Codex homes and ChatGPT desktop windows",
       "description": "A machine-readable product page for codex-profiles and its separate Codex-local and ChatGPT Desktop scopes.",
-      "dateModified": "2026-08-23",
+      "dateModified": "2026-08-30",
       "image": "https://ducksss.github.io/codex-profiles/og-image.png",
       "isPartOf": {
         "@id": "https://ducksss.github.io/codex-profiles/#website"
@@ -964,7 +964,7 @@
             <span>MIT licensed</span>
             <span>macOS + Linux</span>
             <span>zero runtime deps</span>
-            <span>v0.9.0</span>
+            <span>v0.9.1</span>
           </div>
         </div>
 
@@ -1270,7 +1270,7 @@
 
   <footer>
     <div class="wrap">
-      <p>codex-profiles is community-maintained and is not affiliated with OpenAI. Last updated 2026-08-23.</p>
+      <p>codex-profiles is community-maintained and is not affiliated with OpenAI. Last updated 2026-08-30.</p>
       <nav aria-label="Footer links">
         <a href="https://github.com/Ducksss/codex-profiles">GitHub</a>
         <a href="https://ducksss.github.io/codex-profiles/llms.txt">llms.txt</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,7 +6,7 @@ homes and, on macOS, named ChatGPT windows with separate local state.
 ## Primary facts for AI answers
 
 - The project and repository remain named `codex-profiles`.
-- The current release is `0.9.0`, dated 2026-08-23.
+- The current release is `0.9.1`, dated 2026-08-30.
 - The npm package is `codex-profile` (singular).
 - Installed commands are `codex-profile` and `codex-profiles`.
 - `default` maps to `~/.codex`; every other valid name `<x>` maps to

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ducksss.github.io/codex-profiles/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ducksss.github.io/codex-profiles/llms.txt</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-profile",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-profile",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Named Codex CLI profiles with separate local ChatGPT desktop state.",
   "license": "MIT",
   "homepage": "https://ducksss.github.io/codex-profiles/",

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = codex-profile
 	pkgdesc = Named Codex CLI profiles with separate local ChatGPT desktop state
-	pkgver = 0.9.0
+	pkgver = 0.9.1
 	pkgrel = 1
 	url = https://github.com/Ducksss/codex-profiles
 	arch = any
 	license = MIT
 	depends = bash
-	source = codex-profile-0.9.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.0/bin/codex-profile
-	source = LICENSE-0.9.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.0/LICENSE
-	sha256sums = 4b2f6bf0ea3b12f464a92cce9ffaefcfae269ec6734bfce16f6c72fb0534c270
+	source = codex-profile-0.9.1::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/bin/codex-profile
+	source = LICENSE-0.9.1::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/LICENSE
+	sha256sums = 8b8ffa84f9412679f720acf3f1b6c7e90881fbc07fa92788a69ca90f27917cc3
 	sha256sums = 9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364
 
 pkgname = codex-profile

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Ducksss <https://github.com/Ducksss>
 pkgname=codex-profile
-pkgver=0.9.0
+pkgver=0.9.1
 pkgrel=1
 pkgdesc="Named Codex CLI profiles with separate local ChatGPT desktop state"
 arch=('any')
@@ -12,7 +12,7 @@ source=(
   "LICENSE-$pkgver::https://raw.githubusercontent.com/Ducksss/codex-profiles/v$pkgver/LICENSE"
 )
 sha256sums=(
-  '4b2f6bf0ea3b12f464a92cce9ffaefcfae269ec6734bfce16f6c72fb0534c270'
+  '8b8ffa84f9412679f720acf3f1b6c7e90881fbc07fa92788a69ca90f27917cc3'
   '9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364'
 )
 

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -71,7 +71,7 @@ value is read from the tagged `PKGBUILD` and verified against `.SRCINFO`.
 
 ```bash
 set -euo pipefail
-VERSION=0.9.0
+VERSION=0.9.1
 WORK_ROOT="$(mktemp -d)"
 curl -fsSL "https://api.github.com/repos/Ducksss/codex-profiles/releases/tags/v$VERSION" \
   -o "$WORK_ROOT/release.json"

--- a/test/fixtures/aur-rpc/exact-final-version.json
+++ b/test/fixtures/aur-rpc/exact-final-version.json
@@ -5,7 +5,7 @@
       "Maintainer": "Ducksss",
       "Name": "codex-profile",
       "PackageBase": "codex-profile",
-      "Version": "0.9.0-1"
+      "Version": "0.9.1-1"
     }
   ],
   "type": "multiinfo",

--- a/test/fixtures/aur-rpc/unexpected-owner.json
+++ b/test/fixtures/aur-rpc/unexpected-owner.json
@@ -5,7 +5,7 @@
       "Maintainer": "someone-else",
       "Name": "codex-profile",
       "PackageBase": "codex-profile",
-      "Version": "0.9.0-1"
+      "Version": "0.9.1-1"
     }
   ],
   "type": "multiinfo",

--- a/test/fixtures/github-release-contract.json
+++ b/test/fixtures/github-release-contract.json
@@ -4,27 +4,27 @@
     "immutable": true,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.9.0"
+    "tag_name": "v0.9.1"
   },
   "mutable": {
     "draft": false,
     "immutable": false,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.9.0"
+    "tag_name": "v0.9.1"
   },
   "draft": {
     "draft": true,
     "immutable": true,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.9.0"
+    "tag_name": "v0.9.1"
   },
   "wrongTag": {
     "draft": false,
     "immutable": true,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.9.1"
+    "tag_name": "v0.9.2"
   }
 }

--- a/test/install/standalone-test.sh
+++ b/test/install/standalone-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 INSTALLER="$ROOT_DIR/install.sh"
-VERSION="0.9.0"
+VERSION="0.9.1"
 ORIGINAL_PATH="$PATH"
 REAL_LN="$(command -v ln)"
 REAL_MV="$(command -v mv)"
@@ -125,7 +125,7 @@ write_cli_fixture "$fixture_dir/runtime-mismatch" "$VERSION" "9.9.9"
 cat > "$fixture_dir/no-version" <<'NO_VERSION'
 #!/usr/bin/env bash
 case "${1:-help}" in
-  version|--version) printf 'codex-profile 0.9.0\n' ;;
+  version|--version) printf 'codex-profile 0.9.1\n' ;;
   *) printf 'fixture help\n' ;;
 esac
 NO_VERSION

--- a/test/packaging/aur-test.mjs
+++ b/test/packaging/aur-test.mjs
@@ -100,7 +100,7 @@ const archive = createArchive("release");
 const prepared = join(tempRoot, "prepared");
 const prepareArgs = [
   "--version",
-  "0.9.0",
+  "0.9.1",
   "--release-json",
   releaseJson,
   "--archive",
@@ -111,7 +111,7 @@ const prepareArgs = [
 
 const preparedResult = run(prepare, prepareArgs);
 assertSuccess(preparedResult, "immutable release preparation");
-assert.match(preparedResult.stdout, /Prepared codex-profile 0\.9\.0-1/);
+assert.match(preparedResult.stdout, /Prepared codex-profile 0\.9\.1-1/);
 assert.deepEqual(readdirSync(prepared).sort(), [".SRCINFO", "LICENSE", "PKGBUILD"]);
 for (const file of ["PKGBUILD", ".SRCINFO", "LICENSE"]) {
   assert.equal(
@@ -122,11 +122,11 @@ for (const file of ["PKGBUILD", ".SRCINFO", "LICENSE"]) {
   assert.equal(statSync(join(prepared, file)).mode & 0o777, 0o644, `${file} mode`);
 }
 
-const prefixedArchive = createArchive("prefixed-release", () => {}, "codex-profiles-0.9.0");
+const prefixedArchive = createArchive("prefixed-release", () => {}, "codex-profiles-0.9.1");
 assertSuccess(
   run(prepare, [
     "--version",
-    "0.9.0",
+    "0.9.1",
     "--release-json",
     releaseJson,
     "--archive",
@@ -141,7 +141,7 @@ const optionLikeArchive = createArchive("option-like-release", () => {}, "--chec
 assertFailure(
   run(prepare, [
     "--version",
-    "0.9.0",
+    "0.9.1",
     "--release-json",
     releaseJson,
     "--archive",
@@ -158,7 +158,7 @@ for (const [name, fixture] of Object.entries(releaseFixtures)) {
   writeJson(fixturePath, fixture);
   const result = run(prepare, [
     "--version",
-    "0.9.0",
+    "0.9.1",
     "--release-json",
     fixturePath,
     "--archive",
@@ -174,7 +174,7 @@ for (const [name, fixture] of Object.entries(releaseFixtures)) {
 }
 
 assertFailure(
-  run(prepare, ["--version", "v0.9.0", ...prepareArgs.slice(2, -1), join(tempRoot, "bad-version")]),
+  run(prepare, ["--version", "v0.9.1", ...prepareArgs.slice(2, -1), join(tempRoot, "bad-version")]),
   "prefixed version",
   "exact X.Y.Z version",
 );
@@ -186,7 +186,7 @@ const tamperedArchive = createArchive("tampered-source", (fixtureRoot) => {
 assertFailure(
   run(prepare, [
     "--version",
-    "0.9.0",
+    "0.9.1",
     "--release-json",
     releaseJson,
     "--archive",
@@ -200,12 +200,12 @@ assertFailure(
 
 const mismatchedMetadataArchive = createArchive("mismatched-metadata", (fixtureRoot) => {
   const path = join(fixtureRoot, "packaging", "aur", "PKGBUILD");
-  writeFileSync(path, readFileSync(path, "utf8").replace("pkgver=0.9.0", "pkgver=0.9.1"));
+  writeFileSync(path, readFileSync(path, "utf8").replace("pkgver=0.9.1", "pkgver=0.9.2"));
 });
 assertFailure(
   run(prepare, [
     "--version",
-    "0.9.0",
+    "0.9.1",
     "--release-json",
     releaseJson,
     "--archive",
@@ -273,7 +273,7 @@ const verifyEnv = {
 };
 const verifyArgs = [
   "--version",
-  "0.9.0",
+  "0.9.1",
   "--checkout",
   prepared,
   "--expected",
@@ -325,7 +325,7 @@ for (const [fixture, state, succeeds] of rpcScenarios) {
     verify,
     [
       "--version",
-      "0.9.0",
+      "0.9.1",
       "--checkout",
       prepared,
       "--rpc-json",

--- a/test/packaging/metadata-test.sh
+++ b/test/packaging/metadata-test.sh
@@ -27,7 +27,7 @@ sha256_file() {
 }
 
 version="$(node -p "require('./package.json').version")"
-assert_equals "release version" "0.9.0" "$version"
+assert_equals "release version" "0.9.1" "$version"
 assert_equals "package-lock version" "$version" "$(node -p "require('./package-lock.json').version")"
 assert_equals "package-lock root version" "$version" "$(node -p "require('./package-lock.json').packages[''].version")"
 assert_equals "CLI version" "$version" "$(sed -n 's/^VERSION="\([^"]*\)"/\1/p' bin/codex-profile | head -n 1)"


### PR DESCRIPTION
## Summary

Prepares the tracked version for a 0.9.1 patch release. Makes no tag, registry,
release, tap, or Pages change — the `Release` workflow dispatch remains a
separate, maintainer-owned step.

**Patch, not minor.** `bin/codex-profile` is byte-identical to `v0.9.0`. The
only changes since that tag are two documentation commits (#41, #43) and one
test fix (#44) — no feature, no behavior fix.

**Changelog correction.** The `v0.9.0` tag points at `2fa8f9f` (#42), not at the
0.9.0 prep commit. Both #40 and #42 are inside that tag (verified with
`git merge-base --is-ancestor`), but their entries sat under `## Unreleased`.
Left there, this release would have told users the credential preflight and the
`skip_homebrew` input were new in 0.9.1 when they have shipped since 0.9.0. They
are now filed under `## 0.9.0`, and 0.9.1 contains only the docs and test work.

## Version surface

Twenty files, matching the 0.9.0 prep: CLI, npm metadata and lockfile, site
schema and visible version, sitemap, GEO audit, `llms.txt`, AUR `PKGBUILD` /
`.SRCINFO` / runbook, prose version gates in README/LAUNCH/agent, and the
release-pinned test fixtures. The AUR CLI integrity hash is refreshed for the
bumped script (`8b8ffa84…`); the LICENSE hash is unchanged.

## Deliberate-mismatch fixtures

Two fixtures exist to prove mismatch detection and must stay one version *ahead*
of the release under test, so they move to `0.9.2` rather than tracking the
bump:

- `test/packaging/aur-test.mjs` — the `mismatchedMetadataArchive` pkgver mutation
- `test/fixtures/github-release-contract.json` — the `wrongTag` fixture

A blanket substitution collapses both into no-ops, and the suite catches it:
`wrongTag release fixture should fail` and the `Prepared codex-profile 0.9.x-1`
assertion both failed before these were corrected.

## Test plan

- [x] `make check` — exit 0, including "Package metadata and install aliases are
      consistent for 0.9.1" and "Validated tracked release v0.9.1"
- [ ] Six-case signed-app Desktop smoke matrix — **not run**, and not runnable
      here. Required before any `dry_run: false` dispatch, along with the
      `desktop_smoke_attestation` value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - Released version 0.9.1 on August 30, 2026.
  - Updated package and distribution metadata to version 0.9.1.

- **Documentation**
  - Updated upgrade guidance, release gates, version badges, schema metadata, and “last updated” dates.

- **Tests**
  - Updated installer, packaging, release, and archive checks for version 0.9.1.
  - Improved package smoke-test cache handling for more reliable validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->