### PR TITLE
docs(docs): adopt the reviewed wording for the symlink guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,11 @@ Profile-to-path mapping: `default -> ~/.codex`; any other name `<x> -> ~/.codex-
   `package-lock.json` version fields, `docs/index.html`,
   `packaging/aur/PKGBUILD`, and `packaging/aur/.SRCINFO`. CI and the GEO test
   enforce this synchronization.
-- Document user-facing changes under `## Unreleased` in `CHANGELOG.md`.
+- Document user-facing changes under `## Unreleased` in `CHANGELOG.md`. Release
+  preparation then promotes those entries into a dated `## <version> - <date>`
+  section matching the newly tracked version, and the GEO test requires that
+  dated heading to exist. Leave already-tagged entries in the section whose tag
+  shipped them.
 - Keep the scope contract explicit: `cli`/`login`/`env`/`use` are Codex-only;
   `app default` preserves stock ChatGPT Desktop state; named `app` launches use
   matching `CODEX_HOME` and Electron data for the entire ChatGPT window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project follows semantic versioning for tagged releases.
 
 - Explained that store-level session-store symlinks under a named `CODEX_HOME`
   fail current Codex Desktop path containment, so fork and side chats break. A
-  shared `state_5.sqlite` also breaks archive and delete, which name the
+  shared `state_5.sqlite` also breaks archive and delete, which mention the
   `sessions` directory in the error. `init --share-with` does not create those
   links. Desktop account identity follows `CODEX_HOME/auth.json`, not Electron
   user-data alone; this tool still does not copy `auth.json`.

--- a/README.md
+++ b/README.md
@@ -309,12 +309,12 @@ plugins/
 The target must not already exist. `auth.json`, `sessions/`, `logs/`,
 `electron-user-data/`, caches, skills, and connector/app state are never
 linked. Do not add those store-level links by hand either: current Codex
-Desktop canonicalizes rollout paths, so a `sessions/` symlink that escapes the
-selected `CODEX_HOME` makes fork and side chats fail. The command does not read
-or copy authentication data. Allowlisted links are live: edits from either
-profile affect the same source configuration, and plugins or configuration can
-themselves contain sensitive or executable content. Review the source before
-linking across trust domains.
+Desktop canonicalizes rollout paths, so a `sessions/` symlink or a shared
+`state_5.sqlite` that escapes the selected `CODEX_HOME` makes fork and side
+chats fail. The command does not read or copy authentication data. Allowlisted
+links are live: edits from either profile affect the same source configuration,
+and plugins or configuration can themselves contain sensitive or executable
+content. Review the source before linking across trust domains.
 
 ### Inspect Codex-local status
 
@@ -683,9 +683,9 @@ Current Codex Desktop resolves the rollout path before checking that it stays
 under `CODEX_HOME`. If `sessions/` or `state_5.sqlite` inside a named home is a
 symlink into another home, the resolved path is outside the selected home and
 fork and side chats fail. A shared `state_5.sqlite` also breaks archive and
-delete, which scope rollouts to `sessions/` and name that directory in the
-error. `init --share-with` does not create those links. Do not symlink the
-session store.
+delete, which restrict rollout paths to `sessions/` and mention that directory
+in the error. `init --share-with` does not create those links. Do not symlink
+the session store.
 
 Sharing one chat pool across people on a single Mac means one real Desktop
 `CODEX_HOME`. Separate ChatGPT logins then need that account's `auth.json`

--- a/docs/index.html
+++ b/docs/index.html
@@ -204,7 +204,7 @@
           "name": "Why does fork fail with rollout path must be in Codex home directory?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Current Codex Desktop resolves the rollout path before checking that it stays under CODEX_HOME. A sessions/ or state_5.sqlite symlink from a named home into another home makes that check fail, so fork and side chats break. A shared state_5.sqlite also breaks archive and delete, which scope rollouts to sessions/ and name that directory in the error. init --share-with never creates those links. Do not symlink the session store. Sharing chats across people means one real Desktop CODEX_HOME. Separate ChatGPT logins then require selecting that account's auth.json; the account chip follows CODEX_HOME auth.json, not Electron user-data alone. This tool does not copy auth.json."
+            "text": "Current Codex Desktop resolves the rollout path before checking that it stays under CODEX_HOME. A sessions/ or state_5.sqlite symlink from a named home into another home makes that check fail, so fork and side chats break. A shared state_5.sqlite also breaks archive and delete, which restrict rollout paths to sessions/ and mention that directory in the error. init --share-with never creates those links. Do not symlink the session store. Sharing chats across people means one real Desktop CODEX_HOME. Separate ChatGPT logins then require selecting that account's auth.json; the account chip follows CODEX_HOME auth.json, not Electron user-data alone. This tool does not copy auth.json."
           }
         }
       ]
@@ -1225,7 +1225,7 @@
         </article>
         <article>
           <h3>Why does fork fail with rollout path must be in Codex home directory?</h3>
-          <p>Current Codex Desktop resolves the rollout path before checking that it stays under CODEX_HOME. A sessions/ or state_5.sqlite symlink from a named home into another home makes that check fail, so fork and side chats break. A shared state_5.sqlite also breaks archive and delete, which scope rollouts to sessions/ and name that directory in the error. init --share-with never creates those links. Do not symlink the session store. Sharing chats across people means one real Desktop CODEX_HOME. Separate ChatGPT logins then require selecting that account's auth.json; the account chip follows CODEX_HOME auth.json, not Electron user-data alone. This tool does not copy auth.json.</p>
+          <p>Current Codex Desktop resolves the rollout path before checking that it stays under CODEX_HOME. A sessions/ or state_5.sqlite symlink from a named home into another home makes that check fail, so fork and side chats break. A shared state_5.sqlite also breaks archive and delete, which restrict rollout paths to sessions/ and mention that directory in the error. init --share-with never creates those links. Do not symlink the session store. Sharing chats across people means one real Desktop CODEX_HOME. Separate ChatGPT logins then require selecting that account's auth.json; the account chip follows CODEX_HOME auth.json, not Electron user-data alone. This tool does not copy auth.json.</p>
         </article>
       </div>
     </section>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -40,10 +40,10 @@ homes and, on macOS, named ChatGPT windows with separate local state.
   result to stay under `CODEX_HOME`, so a `sessions/` or `archived_sessions/`
   symlink, or a shared `state_5.sqlite`, makes fork and side chats fail with
   "rollout path must be in Codex home directory". A shared `state_5.sqlite`
-  also breaks archive and delete, which scope rollouts to `sessions/` and name
-  that directory in the error. `history.jsonl` and `session_index.jsonl` hold
-  no rollout paths; sharing them leaks prompt history and thread names across
-  homes instead.
+  also breaks archive and delete, which restrict rollout paths to `sessions/`
+  and mention that directory in the error. `history.jsonl` and
+  `session_index.jsonl` hold no rollout paths; sharing them leaks prompt
+  history and thread names across homes instead.
 - Desktop account identity follows `auth.json` in the active `CODEX_HOME`, not
   Electron user-data alone. Pointing a named window at a shared home without
   selecting that account's `auth.json` leaves the previous login on screen.


### PR DESCRIPTION
## Summary

Applies the two actionable CodeRabbit findings from #43 to every copy of the
symlink guidance:

1. **Name a shared `state_5.sqlite` in the `--share-with` paragraph.** It
   previously mentioned only `sessions/` there while the FAQ named both, so the
   two README passages disagreed.
2. **"restrict rollout paths to `sessions/` and mention that directory"** in
   place of "scope rollouts to `sessions/` and name that directory".

Updated in README (both passages), `docs/llms.txt`, both copies in
`docs/index.html` (JSON-LD and the visible article), and the 0.9.1 changelog
entry. The two `index.html` copies stay byte-identical so the geo-test's
JSON-LD-matches-visible-copy assertion still holds. Paragraphs rewrapped to the
repository's column width.

## Not applied

The third finding, on #46, asked to keep the 0.9.1 entry under `## Unreleased`
until the release publishes. That cannot be done here: `test/site/geo-test.mjs`
requires a dated heading matching `package.json`, so with the tracked version at
0.9.1 the suite fails without `## 0.9.1 - 2026-08-30`. Dating the section at
prep time is also exactly what the 0.9.0 prep did. Explained on the thread.

## Test plan

- [x] `make check` (exit 0)
- [x] `node test/site/geo-test.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that sharing the `state_5.sqlite` database can cause fork, side chat, archive, and delete operations to fail.
  - Updated guidance to identify the `sessions/` directory when rollout paths are restricted.
  - Explained that sharing history and session index files may expose prompt history and thread names.
  - Refined changelog wording and conventions for documenting unreleased and versioned changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->