### PR TITLE
fix: clear inherited Electron state for default profile

### DIFF
--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -922,7 +922,7 @@ run_desktop_app() {
   note "Log: $log_file"
 
   if [[ "$profile" == "default" ]]; then
-    (umask 077 && open -n --env "CODEX_HOME=$codex_home" --stdout "$log_file" --stderr "$log_file" -a "$app" "$workspace") \
+    (umask 077 && open -n --env "CODEX_HOME=$codex_home" --env "CODEX_ELECTRON_USER_DATA_PATH=" --stdout "$log_file" --stderr "$log_file" -a "$app" "$workspace") \
       || die "Cannot launch $product app: $app"
   else
     (umask 077 && open -n --env "CODEX_HOME=$codex_home" --env "CODEX_ELECTRON_USER_DATA_PATH=$user_data_dir" --stdout "$log_file" --stderr "$log_file" -a "$app" "$workspace" --args "--user-data-dir=$user_data_dir") \

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -8,7 +8,7 @@ pkgbase = codex-profile
 	depends = bash
 	source = codex-profile-0.9.1::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/bin/codex-profile
 	source = LICENSE-0.9.1::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/LICENSE
-	sha256sums = 8b8ffa84f9412679f720acf3f1b6c7e90881fbc07fa92788a69ca90f27917cc3
+	sha256sums = 5b156f542204bb2212d86be82a8c49bf862843ac31496d750f8a17ad90e49587
 	sha256sums = 9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364
 
 pkgname = codex-profile

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -12,7 +12,7 @@ source=(
   "LICENSE-$pkgver::https://raw.githubusercontent.com/Ducksss/codex-profiles/v$pkgver/LICENSE"
 )
 sha256sums=(
-  '8b8ffa84f9412679f720acf3f1b6c7e90881fbc07fa92788a69ca90f27917cc3'
+  '5b156f542204bb2212d86be82a8c49bf862843ac31496d750f8a17ad90e49587'
   '9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364'
 )
 

--- a/test/cli/desktop-test.sh
+++ b/test/cli/desktop-test.sh
@@ -60,7 +60,8 @@ test_app_default_reuses_the_stock_chatgpt_session() {
   write_fake_chatgpt_open_tools "$fake_bin"
 
   run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
-    CHATGPT_APP="$chatgpt_app" "$SCRIPT" app default "$tmp/workspace"
+    CHATGPT_APP="$chatgpt_app" CODEX_ELECTRON_USER_DATA_PATH="$tmp/inherited-electron-user-data" \
+    "$SCRIPT" app default "$tmp/workspace"
 
   assert_status 0
   assert_contains "Desktop scope: stock ChatGPT session"


### PR DESCRIPTION
## Summary

- explicitly clear inherited `CODEX_ELECTRON_USER_DATA_PATH` when launching the default ChatGPT profile
- prevent a caller or Codex host process from leaking its Electron user-data directory into the stock session
- make the desktop regression test inject inherited state so CI exercises the isolation boundary
- refresh the AUR checksums for the CLI change

## Verification

- `make test` (pass)
- `make lint` (pass)
- `bash test/cli/desktop-test.sh` with an inherited Electron path (pass)