### PR TITLE
fix: close post-merge review gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project follows semantic versioning for tagged releases.
   changes, and made package tests distinguish published tags from new release
   candidates.
 - Honored configured retry backoff when Neon or Airtable omits `Retry-After`,
-  and stopped placing the Neon database password in `psql` process arguments.
+  rejected credential-bearing non-URL database strings, and stopped placing
+  the Neon database password in `psql` process arguments.
 
 ## 0.9.1 - 2026-08-30
 

--- a/scripts/migrate-outreach-to-neon.mjs
+++ b/scripts/migrate-outreach-to-neon.mjs
@@ -25,6 +25,7 @@ import { dirname, join, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { setTimeout as sleep } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
+import { retryAfterDelay } from './retry-after.mjs';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
 const FORMAT = 'codex-profiles-airtable-snapshot-v1';
@@ -175,15 +176,6 @@ function retryDelay() {
   return value;
 }
 
-function responseRetryDelay(response, fallback) {
-  const value = response.headers.get('retry-after');
-  if (value === null) return fallback;
-  const seconds = Number(value);
-  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
-  const at = Date.parse(value);
-  return Number.isFinite(at) ? Math.max(0, at - Date.now()) : fallback;
-}
-
 async function airtableGet(url, airtableToken) {
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
@@ -195,7 +187,10 @@ async function airtableGet(url, airtableToken) {
       if (!RETRY_STATUSES.has(response.status) || attempt === 2) {
         fail(`Airtable GET -> ${response.status}: ${text}`);
       }
-      await sleep(responseRetryDelay(response, retryDelay() * 2 ** attempt));
+      await sleep(retryAfterDelay(
+        response.headers.get('retry-after'),
+        retryDelay() * 2 ** attempt,
+      ));
     } catch (error) {
       if (attempt === 2) fail(`Airtable GET failed: ${error.message}`);
       await sleep(retryDelay() * 2 ** attempt);
@@ -340,7 +335,12 @@ function databaseConnection() {
   secrets.add(value);
   const env = { ...process.env };
   delete env.NEON_DATABASE_URL;
-  if (!/^postgres(?:ql)?:\/\//.test(value)) return { argument: value, env };
+  if (!value.includes('://')) {
+    if (/\s|=/.test(value)) {
+      fail('NEON_DATABASE_URL must be a PostgreSQL URL or a plain database name.', 2);
+    }
+    return { argument: value, env };
+  }
   let parsed;
   try {
     parsed = new URL(value);
@@ -351,7 +351,12 @@ function databaseConnection() {
     fail('NEON_DATABASE_URL must use postgres:// or postgresql://.', 2);
   }
   if (parsed.password) {
-    const password = decodeURIComponent(parsed.password);
+    let password;
+    try {
+      password = decodeURIComponent(parsed.password);
+    } catch (error) {
+      fail(`Invalid password encoding in NEON_DATABASE_URL: ${error.message}`, 2);
+    }
     secrets.add(password);
     env.PGPASSWORD = password;
     parsed.password = '';

--- a/scripts/outreach-tracker.mjs
+++ b/scripts/outreach-tracker.mjs
@@ -32,6 +32,7 @@ import { readFileSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
+import { retryAfterDelay } from './retry-after.mjs';
 
 const EXIT = { OK: 0, ERROR: 1, USAGE: 2, CLAIM_LOST: 3 };
 const JWT_AUDIENCE = 'codex-profiles-outreach';
@@ -131,15 +132,6 @@ function transientStatus(status) {
   return status === 429 || status === 502 || status === 503 || status === 504;
 }
 
-function retryDelay(response, fallback) {
-  const value = response.headers.get('retry-after');
-  if (value === null) return fallback;
-  const seconds = Number(value);
-  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
-  const at = Date.parse(value);
-  return Number.isFinite(at) ? Math.max(0, at - Date.now()) : fallback;
-}
-
 async function rpcRequest(name, body, { start } = {}) {
   const url = `${dataApiUrl()}/rpc/${name}`;
   let lastError;
@@ -167,7 +159,10 @@ async function rpcRequest(name, body, { start } = {}) {
       }
       lastError = new Error(`Neon RPC ${name} -> ${response.status}: ${text}`);
       if (!transientStatus(response.status) || attempt === 2) throw lastError;
-      await sleep(retryDelay(response, RETRY_DELAY_MS * 2 ** attempt));
+      await sleep(retryAfterDelay(
+        response.headers.get('retry-after'),
+        RETRY_DELAY_MS * 2 ** attempt,
+      ));
     } catch (error) {
       lastError = error;
       if (attempt === 2 || /Neon RPC/.test(error.message)) throw error;

--- a/scripts/retry-after.mjs
+++ b/scripts/retry-after.mjs
@@ -1,0 +1,12 @@
+export function retryAfterDelay(value, fallback, now = Date.now()) {
+  if (!Number.isFinite(fallback) || fallback < 0) {
+    throw new TypeError('fallback delay must be a non-negative number');
+  }
+  if (value === null || value === undefined) return fallback;
+  const text = String(value).trim();
+  if (!text) return fallback;
+  const seconds = Number(text);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const at = Date.parse(text);
+  return Number.isFinite(at) ? Math.max(0, at - now) : fallback;
+}

--- a/test/outreach/migration-test.mjs
+++ b/test/outreach/migration-test.mjs
@@ -55,7 +55,6 @@ const records = {
   }],
 };
 let rateLimitMetadata = true;
-const metadataRequestTimes = [];
 let leakToken = false;
 
 function canonical(value) {
@@ -81,7 +80,6 @@ const server = createServer((request, response) => {
     return;
   }
   if (url.pathname.endsWith('/meta/bases/test-base/tables')) {
-    metadataRequestTimes.push(Date.now());
     if (rateLimitMetadata) {
       rateLimitMetadata = false;
       send(response, 429, { error: 'slow down' });
@@ -108,7 +106,7 @@ const env = {
   AIRTABLE_TOKEN: token,
   AIRTABLE_BASE: 'test-base',
   AIRTABLE_API_ROOT: `http://127.0.0.1:${address.port}/v0`,
-  AIRTABLE_RETRY_DELAY_MS: '100',
+  AIRTABLE_RETRY_DELAY_MS: '1',
 };
 
 function run(args, overrides = {}) {
@@ -129,8 +127,6 @@ function run(args, overrides = {}) {
 try {
   const exported = await run(['export', '--out', snapshotPath]);
   assert.equal(exported.status, 0, exported.stderr);
-  assert.ok(metadataRequestTimes[1] - metadataRequestTimes[0] >= 80,
-    'missing Retry-After bypassed Airtable backoff');
   assert.equal(statSync(snapshotPath).mode & 0o777, 0o600);
   const snapshot = JSON.parse(readFileSync(snapshotPath, 'utf8'));
   assert.equal(snapshot.format, 'codex-profiles-airtable-snapshot-v1');
@@ -183,6 +179,20 @@ printf '%s\\n' '{"ok":true}'
   assert.doesNotMatch(psqlArguments, /secret/);
   assert.equal(readFileSync(psqlPasswordPath, 'utf8'), 'secret');
   assert.equal(readFileSync(psqlNeonEnvPath, 'utf8'), 'unset');
+
+  const unsafeConninfo = await run(['verify', '--in', snapshotPath], {
+    NEON_DATABASE_URL: 'host=example.test dbname=neondb user=owner password=conninfo-secret',
+  });
+  assert.equal(unsafeConninfo.status, 2);
+  assert.match(unsafeConninfo.stderr, /PostgreSQL URL or a plain database name/);
+  assert.doesNotMatch(unsafeConninfo.stderr, /conninfo-secret/);
+
+  const wrongProtocol = await run(['verify', '--in', snapshotPath], {
+    NEON_DATABASE_URL: 'mysql://owner:protocol-secret@example.test/neondb',
+  });
+  assert.equal(wrongProtocol.status, 2);
+  assert.match(wrongProtocol.stderr, /postgres:\/\/ or postgresql:\/\//);
+  assert.doesNotMatch(wrongProtocol.stderr, /protocol-secret/);
 
   const tampered = JSON.parse(readFileSync(snapshotPath, 'utf8'));
   tampered.tables.targets.records[0].fields.Key = 'tampered';

--- a/test/outreach/retry-after-test.mjs
+++ b/test/outreach/retry-after-test.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { retryAfterDelay } from '../../scripts/retry-after.mjs';
+
+const fallback = 500;
+const now = Date.parse('2026-09-02T00:00:00Z');
+
+assert.equal(retryAfterDelay(null, fallback, now), fallback);
+assert.equal(retryAfterDelay(undefined, fallback, now), fallback);
+assert.equal(retryAfterDelay('', fallback, now), fallback);
+assert.equal(retryAfterDelay('not-a-delay', fallback, now), fallback);
+assert.equal(retryAfterDelay('0', fallback, now), 0);
+assert.equal(retryAfterDelay('2', fallback, now), 2000);
+assert.equal(retryAfterDelay('Wed, 02 Sep 2026 00:00:03 GMT', fallback, now), 3000);
+assert.equal(retryAfterDelay('Tue, 01 Sep 2026 23:59:59 GMT', fallback, now), 0);
+assert.throws(() => retryAfterDelay(null, -1, now), /non-negative/);

--- a/test/outreach/tracker-test.mjs
+++ b/test/outreach/tracker-test.mjs
@@ -34,7 +34,6 @@ let nextLogId = 1;
 let failNext;
 let failAfterNext;
 let requests = 0;
-let requestTimes = [];
 
 function decodeJson(segment) {
   return JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'));
@@ -174,7 +173,6 @@ function send(response, status, body, headers = {}) {
 
 const server = createServer(async (request, response) => {
   requests++;
-  requestTimes.push(Date.now());
   const token = authenticate(request);
   const name = new URL(request.url, 'http://localhost').pathname.split('/').at(-1);
   const body = await readJson(request);
@@ -272,11 +270,9 @@ try {
   assert.equal(retried.status, 0, retried.stderr);
   assert.ok(requests >= 2);
 
-  requestTimes = [];
   failNext = { status: 503, message: 'temporarily unavailable' };
-  const delayedRetry = await run(['get', 'alpha', '--json'], { OUTREACH_RETRY_DELAY_MS: '100' });
-  assert.equal(delayedRetry.status, 0, delayedRetry.stderr);
-  assert.ok(requestTimes[1] - requestTimes[0] >= 80, 'missing Retry-After bypassed backoff');
+  const missingHeaderRetry = await run(['get', 'alpha', '--json']);
+  assert.equal(missingHeaderRetry.status, 0, missingHeaderRetry.stderr);
 
   failNext = { status: 500, includeToken: true };
   const failed = await run(['get', 'alpha']);


### PR DESCRIPTION
## Summary

- reject credential-bearing libpq conninfo and unsupported database URL schemes before spawning psql
- share pure Retry-After parsing across Neon and Airtable clients
- replace scheduler-sensitive backoff assertions with deterministic fixed-clock unit tests

## Repository protection

main now requires an up-to-date pull request and successful Shell checks, macOS smoke test, and Nix package checks. Force pushes and deletion are disabled, and admin enforcement is enabled.

## Verification

- make check
- focused retry, tracker, migration, and temporary-Postgres integration tests