### PR TITLE
fix: harden profile and release trust boundaries

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,6 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Validate Pages source
+        id: source
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
@@ -47,7 +48,7 @@ jobs:
       - name: Check out site source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.sha }}
+          ref: ${{ steps.source.outputs.commit || github.sha }}
           path: .pages-site
           persist-credentials: false
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,12 +1,16 @@
 name: Pages
-run-name: Deploy Pages from ${{ github.ref_name }} (${{ inputs.release_correlation || 'manual' }})
+run-name: Deploy Pages from ${{ inputs.release_tag || github.ref_name }} (${{ inputs.release_correlation || 'manual' }})
 
-# Release dispatches this workflow from the immutable release tag. It can also
-# be run manually for an explicitly selected ref when documentation needs an
-# independent redeploy.
+# This workflow itself always runs from protected main. Release deployments may
+# select an immutable final tag as the artifact source; manual documentation
+# redeploys use the current main commit.
 on:
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: "Optional immutable final release tag to deploy."
+        required: false
+        type: string
       release_correlation:
         description: "Optional release correlation ID; no account or private data."
         required: false
@@ -22,23 +26,41 @@ concurrency:
 jobs:
   validate:
     name: Validate GEO site
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-      - name: Check out repository
+      - name: Check out trusted Pages controls
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.sha }}
+          path: .pages-control
+
+      - name: Validate Pages source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: .pages-control/scripts/release/verify-pages-source.sh
+
+      - name: Check out site source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ inputs.release_tag || github.sha }}
+          path: .pages-site
 
       - name: Run GEO site tests
+        working-directory: .pages-site
         run: node test/site/geo-test.mjs
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
-          path: docs
+          path: .pages-site/docs
 
   deploy:
     name: Deploy GitHub Pages
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     needs: validate
     timeout-minutes: 10

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           ref: ${{ github.sha }}
           path: .pages-control
+          persist-credentials: false
 
       - name: Validate Pages source
         env:
@@ -46,8 +47,9 @@ jobs:
       - name: Check out site source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: ${{ inputs.release_tag || github.sha }}
+          ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.sha }}
           path: .pages-site
+          persist-credentials: false
 
       - name: Run GEO site tests
         working-directory: .pages-site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,12 @@ concurrency:
 jobs:
   verify:
     name: Verify release inputs and artifacts
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
+
+    environment:
+      name: release
 
     permissions:
       contents: read
@@ -118,6 +122,9 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 60
+
+    environment:
+      name: release
 
     permissions:
       contents: write # create the tag and GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ and this project follows semantic versioning for tagged releases.
   default, kept `--ref main` as an explicit development path, and pinned the
   documented standalone and Nix install commands to the current release.
 - Restricted release and Pages jobs to protected `main` environments. Pages
-  now treats an immutable release tag as validated artifact input instead of
-  executing the workflow from that tag.
+  now accepts only immutable release tags whose resolved commits belong to
+  `main`, and treats them as artifact input instead of workflow code.
 - Made the clean AUR verifier select `linux/amd64` explicitly and accommodate
   pacman under QEMU emulation on Apple Silicon.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project follows semantic versioning for tagged releases.
 - Added a dependency-free Airtable-to-Neon migration utility, restricted Neon
   schema, public RS256 JWKS, Merge Queue commands, and integration coverage for
   transactional imports, RLS/grants, append-only history, and atomic claims.
+- Added `doctor` diagnostics for symlinked profile homes and symlinked or
+  hard-linked private state such as `auth.json`, `sessions/`, and
+  `state_5.sqlite`, without flagging the documented `init --share-with`
+  configuration allowlist.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,9 +54,9 @@ and this project follows semantic versioning for tagged releases.
 - Honored configured retry backoff when Neon or Airtable omits `Retry-After`,
   rejected credential-bearing non-URL database strings, and stopped placing
   the Neon database password in `psql` process arguments.
-- Refused symlinked, non-regular, and multiply-linked Desktop logs before
-  launch or inspection, preventing log redirection from overwriting or reading
-  another file.
+- Refused symlinked Desktop log parent directories and symlinked, non-regular,
+  or multiply-linked log files before launch or inspection, preventing log
+  redirection from overwriting or reading another file.
 - Serialized workspace, guard, launcher, initialization, configuration-copy,
   and removal mutations so overlapping processes cannot lose registry updates
   or make lifecycle decisions against stale state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project follows semantic versioning for tagged releases.
   command output, exit codes, relationships, and the 30-day deletion gate.
 - Removed unreferenced landing-page concept renders after the editorial design
   direction was captured in `DESIGN.md` and implemented in the site.
+- Made source upgrades resolve the latest immutable final GitHub Release by
+  default, kept `--ref main` as an explicit development path, and pinned the
+  documented standalone and Nix install commands to the current release.
+- Restricted release and Pages jobs to protected `main` environments. Pages
+  now treats an immutable release tag as validated artifact input instead of
+  executing the workflow from that tag.
+- Made the clean AUR verifier select `linux/amd64` explicitly and accommodate
+  pacman under QEMU emulation on Apple Silicon.
 
 ### Fixed
 
@@ -31,6 +39,16 @@ and this project follows semantic versioning for tagged releases.
 - Honored configured retry backoff when Neon or Airtable omits `Retry-After`,
   rejected credential-bearing non-URL database strings, and stopped placing
   the Neon database password in `psql` process arguments.
+- Refused symlinked, non-regular, and multiply-linked Desktop logs before
+  launch or inspection, preventing log redirection from overwriting or reading
+  another file.
+- Passed Neon database names through `psql --dbname`, rejected option-shaped
+  names, and added complete leading indexes for every outreach foreign key.
+
+### Security
+
+- Enabled a concrete private vulnerability-reporting path and added release,
+  Pages, local-log, database-argument, and deployment-trust regression checks.
 
 ## 0.9.1 - 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project follows semantic versioning for tagged releases.
   hard-linked private state such as `auth.json`, `sessions/`, and
   `state_5.sqlite`, without flagging the documented `init --share-with`
   configuration allowlist.
+- Added `doctor --check`, top-level JSON health, and an explicit version for
+  workspace, guard, and launcher state so automation can distinguish
+  diagnostics from a passing health check and reject incompatible state.
 
 ### Changed
 
@@ -27,6 +30,14 @@ and this project follows semantic versioning for tagged releases.
 - Made source upgrades resolve the latest immutable final GitHub Release by
   default, kept `--ref main` as an explicit development path, and pinned the
   documented standalone and Nix install commands to the current release.
+- Made `init` the sole profile-creation command. CLI, login, Desktop launch,
+  and configuration-copy commands now require initialized profiles instead of
+  silently creating a missing name.
+- Made profile removal refuse to orphan managed launchers or profiles that
+  still supply linked configuration to another profile.
+- Restricted source-style self-upgrades to source-owned executables or an
+  explicitly authorized install prefix; package-managed installations now
+  direct users back to their package manager.
 - Restricted release and Pages jobs to protected `main` environments. Pages
   now accepts only immutable release tags whose resolved commits belong to
   `main`, and treats them as artifact input instead of workflow code.
@@ -46,6 +57,9 @@ and this project follows semantic versioning for tagged releases.
 - Refused symlinked, non-regular, and multiply-linked Desktop logs before
   launch or inspection, preventing log redirection from overwriting or reading
   another file.
+- Serialized workspace, guard, launcher, initialization, configuration-copy,
+  and removal mutations so overlapping processes cannot lose registry updates
+  or make lifecycle decisions against stale state.
 - Passed Neon database names through `psql --dbname`, rejected option-shaped
   names, and added complete leading indexes for every outreach foreign key.
 

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -116,6 +116,13 @@ installation, and complete clean-tree check. It runs with read-only repository
 permissions and no persisted checkout credential. It never tags, publishes,
 pushes a tap, creates a GitHub Release, or deploys Pages.
 
+Both release jobs use the `release` environment, whose only deployment branch
+policy is `main`; the verify job also rejects every non-`main` ref before a
+runner starts. The `github-pages` environment likewise permits only `main`.
+Release publication dispatches the trusted Pages workflow from `main` and
+passes an immutable final release tag as artifact input; never restore a broad
+`v*` environment policy or execute the Pages workflow from a tag.
+
 For `dry_run: false`, the only permitted
 `desktop_smoke_attestation` contents are the public app version and bundle ID,
 formatted exactly as:

--- a/README.md
+++ b/README.md
@@ -77,14 +77,15 @@ brew install Ducksss/tap/codex-profile
 With the standalone installer:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/install.sh \
+  | CODEX_PROFILE_VERSION=v0.9.1 sh
 ```
 
 With Nix:
 
 ```sh
-nix run github:Ducksss/codex-profiles
-nix profile install github:Ducksss/codex-profiles
+nix run github:Ducksss/codex-profiles/v0.9.1
+nix profile install github:Ducksss/codex-profiles/v0.9.1
 ```
 
 From source:
@@ -414,7 +415,8 @@ codex-profile logs personal --tail 100
 
 The deprecated `logs <name> --instance` spelling remains available for older
 scripts and installations. It reads the canonical `desktop.log` when present,
-then falls back to a pre-v0.7 `desktop-instance.log`.
+then falls back to a pre-v0.7 `desktop-instance.log`. Log reads and launches
+refuse symlinked, non-regular, or multiply-linked log files.
 
 ### Clean up pre-v0.7 app clones
 
@@ -478,9 +480,14 @@ codex-profile upgrade --dry-run
 codex-profile upgrade
 codex-profile upgrade --prefix /usr/local
 codex-profile upgrade --ref v0.9.1
+codex-profile upgrade --ref main
 ```
 
-The default checkout is cached under `~/.cache/codex-profile/source`. Review a
+By default, `upgrade` resolves the latest immutable, final GitHub Release and
+checks out its exact detached tag, even if a branch has the same name. An
+already-current release is not replaced. The checkout is cached under
+`~/.cache/codex-profile/source`; `--ref main` is an
+explicit source/development update and may install unreleased changes. Review a
 dry run before pointing upgrade at a non-default repository or ref. Package
 manager installations should normally be upgraded with that package manager.
 
@@ -555,7 +562,8 @@ launch or log mode.
 | `CODEX_PROFILE_CONFIG_HOME` | Override the private directory containing workspace bindings, guard mode, and launcher metadata. |
 | `CODEX_PROFILE_LAUNCHER_ROOT` | Override the macOS launcher install directory (default: `~/Applications`). |
 | `CODEX_PROFILE_UPGRADE_REPO` | Override the source-upgrade repository. |
-| `CODEX_PROFILE_UPGRADE_REF` | Override the source-upgrade git ref. |
+| `CODEX_PROFILE_UPGRADE_REF` | Override the upgrade git ref; defaults to the latest immutable release. |
+| `CODEX_PROFILE_UPGRADE_RELEASE_URL` | Override the latest-release metadata URL. |
 | `CODEX_PROFILE_UPGRADE_CACHE` | Override the source-upgrade cache. |
 | `CODEX_PROFILE_UPGRADE_PREFIX` | Override the source-upgrade install prefix. |
 | `CODEX_PROFILE_NO_UPDATE_CHECK` | Disable update checks; `DO_NOT_TRACK` is also honored. |

--- a/README.md
+++ b/README.md
@@ -329,7 +329,11 @@ codex-profile doctor --json
 
 Status is about the Codex authentication associated with `CODEX_HOME`; it is
 not a ChatGPT Desktop account inspector. Diagnostics must not be used to infer
-that two sessions are the same account.
+that two sessions are the same account. `doctor` also reports symlinked profile
+homes and symlinked or hard-linked private state such as `auth.json`,
+`sessions/`, and `state_5.sqlite`, because those links either couple identity
+across profiles or break current Desktop session operations. The documented
+`init --share-with` configuration links are not reported as unsafe.
 
 ### Use the stock and named ChatGPT sessions
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ On macOS, open the stock ChatGPT session or a named window with separate local
 state:
 
 ```sh
+codex-profile init default
 codex-profile app default ~/Dev/main-project
 codex-profile app personal ~/Dev/personal-project
 codex-profile app work ~/Dev/work-project
@@ -439,7 +440,8 @@ codex-profile logs personal --tail 100
 The deprecated `logs <name> --instance` spelling remains available for older
 scripts and installations. It reads the canonical `desktop.log` when present,
 then falls back to a pre-v0.7 `desktop-instance.log`. Log reads and launches
-refuse symlinked, non-regular, or multiply-linked log files.
+refuse symlinked profile or log directories and symlinked, non-regular, or
+multiply-linked log files.
 
 ### Clean up pre-v0.7 app clones
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ codex-profile login personal
 codex-profile login work
 ```
 
+`init` is the only command that creates a profile. `cli`, `login`, `app`, and
+the target of `clone-config` fail on an uninitialized name instead of silently
+creating state for a typo. Initialize `default` explicitly too if `~/.codex`
+does not already exist.
+
 To keep authentication and runtime state separate while sharing selected
 configuration, initialize a new linked profile from an existing one:
 
@@ -238,8 +243,10 @@ codex-profile remove client-a --yes
 `list` and `status` are read-only. They do not create a directory for a typo.
 Removing a profile deletes its Codex home and, for a named Desktop profile, its
 local Electron data. It also removes bindings that target that profile, without
-deleting any project directory. Review the path and close the corresponding
-window first.
+deleting any project directory. Removal refuses to orphan a managed macOS
+launcher or a profile whose allowlisted configuration is still linked by
+another profile; remove the launcher, detach the links, or remove the dependent
+profile first. Review the path and close the corresponding window first.
 
 ### Bind projects to profiles
 
@@ -287,9 +294,11 @@ using `run` or an explicitly guarded `cli`.
 
 Binding state is stored with private permissions in
 `${XDG_CONFIG_HOME:-~/.config}/codex-profile/workspaces.tsv`; the guard setting
-is stored beside it. `CODEX_PROFILE_CONFIG_HOME` overrides that directory for
-automation. Bindings contain only canonical project paths and profile names,
-never authentication, cookies, sessions, or credentials.
+and state-schema version are stored beside it. Mutations are serialized with a
+process lock so overlapping commands cannot lose an update; locks left by dead
+processes are reclaimed. `CODEX_PROFILE_CONFIG_HOME` overrides that directory
+for automation. Bindings contain only canonical project paths and profile
+names, never authentication, cookies, sessions, or credentials.
 
 #### Share configuration, not identity or runtime state
 
@@ -325,6 +334,8 @@ codex-profile status personal
 codex-profile status --json
 codex-profile doctor
 codex-profile doctor --json
+codex-profile doctor --check
+codex-profile doctor --json --check
 ```
 
 Status is about the Codex authentication associated with `CODEX_HOME`; it is
@@ -335,6 +346,11 @@ homes and symlinked or hard-linked private state such as `auth.json`,
 across profiles or break current Desktop session operations. The documented
 `init --share-with` configuration links are not reported as unsafe.
 
+Ordinary `doctor` remains informational. `doctor --check` exits nonzero when
+the CLI is missing, status collection fails, workspace state is invalid or
+stale, or private profile state is linked; JSON includes top-level `healthy`
+and workspace `schema_version` fields for automation.
+
 ### Use the stock and named ChatGPT sessions
 
 ```sh
@@ -342,6 +358,9 @@ codex-profile app default
 codex-profile app personal ~/Dev/personal-app
 codex-profile app work ~/Dev/work-app
 ```
+
+Run `codex-profile init default` first when `~/.codex` has not already been
+initialized.
 
 - `default` preserves the normal ChatGPT session and maps Codex state to
   `~/.codex`.
@@ -493,7 +512,10 @@ already-current release is not replaced. The checkout is cached under
 `~/.cache/codex-profile/source`; `--ref main` is an
 explicit source/development update and may install unreleased changes. Review a
 dry run before pointing upgrade at a non-default repository or ref. Package
-manager installations should normally be upgraded with that package manager.
+manager installations must be upgraded with that package manager. Without an
+explicit `--prefix` (or `CODEX_PROFILE_UPGRADE_PREFIX`), source upgrade only
+replaces the regular `codex-profile` executable owned by its default source
+prefix; it refuses package-managed and unrecognized executables.
 
 ## Shell completions
 
@@ -534,7 +556,7 @@ codex-profile use <profile>
 codex-profile logs <profile> [--path|--tail [lines]]
 codex-profile clone-config <source-profile> <target-profile> [--force]
 codex-profile list
-codex-profile doctor [--json]
+codex-profile doctor [--json] [--check]
 codex-profile completions <bash|zsh|fish>
 codex-profile shell-init <bash|zsh|fish>
 codex-profile upgrade [--dry-run] [--prefix <path>] [--ref <git-ref>]
@@ -563,7 +585,7 @@ launch or log mode.
 | `CODEX_APP_BIN` | Deprecated executable override; accepted only for an executable inside an app bundle. |
 | `CODEX_CLI` | Use a specific Codex CLI. An invalid explicit override fails instead of silently selecting another binary. |
 | `CODEX_BUNDLED_CLI` | Optional fallback Codex CLI checked after `PATH` and before the selected app's bundled CLI. |
-| `CODEX_PROFILE_CONFIG_HOME` | Override the private directory containing workspace bindings, guard mode, and launcher metadata. |
+| `CODEX_PROFILE_CONFIG_HOME` | Override the private, versioned state directory containing workspace bindings, guard mode, and launcher metadata. |
 | `CODEX_PROFILE_LAUNCHER_ROOT` | Override the macOS launcher install directory (default: `~/Applications`). |
 | `CODEX_PROFILE_UPGRADE_REPO` | Override the source-upgrade repository. |
 | `CODEX_PROFILE_UPGRADE_REF` | Override the upgrade git ref; defaults to the latest immutable release. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,10 +10,11 @@ Use the newest release when relying on separate local state.
 Do not open a public issue for a vulnerability that could expose credentials,
 tokens, cookies, private account data, or cross-profile state.
 
-Use GitHub private vulnerability reporting when available, or contact the
-maintainer through the GitHub profile linked from this repository. Include a
-clear description, reproducible steps using test accounts, expected impact,
-and a suggested fix if you have one.
+Use [GitHub private vulnerability reporting](https://github.com/Ducksss/codex-profiles/security/advisories/new).
+If GitHub reporting is unavailable, contact the maintainer through the GitHub
+profile linked from this repository. Include a clear description, reproducible
+steps using test accounts, expected impact, and a suggested fix if you have
+one.
 
 Never include real `auth.json` contents, access or refresh tokens, OAuth codes,
 cookies, connector credentials, private logs, or account identifiers.

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -244,6 +244,143 @@ shared_profile_config_entries() {
     plugins
 }
 
+private_profile_state_entries() {
+  printf '%s\n' \
+    auth.json \
+    sessions \
+    archived_sessions \
+    history.jsonl \
+    session_index.jsonl \
+    state_5.sqlite \
+    logs \
+    electron-user-data
+}
+
+discover_profiles_for_state_audit() {
+  local dir profile
+
+  if [[ -d "$HOME/.codex" || -L "$HOME/.codex" ]]; then
+    printf 'default\n'
+  fi
+
+  for dir in "$HOME"/.codex-*; do
+    [[ -d "$dir" || -L "$dir" ]] || continue
+    profile="${dir##*/.codex-}"
+    discovered_profile_is_managed "$profile" "$dir" || continue
+    printf '%s\n' "$profile"
+  done
+}
+
+private_state_hard_link_count() {
+  local path="$1"
+  local link_count
+
+  [[ -f "$path" && ! -L "$path" ]] || return 1
+  link_count="$(file_link_count "$path" 2> /dev/null)" || return 1
+  [[ "$link_count" =~ ^[0-9]+$ ]] || return 1
+  ((link_count > 1)) || return 1
+  printf '%s\n' "$link_count"
+}
+
+profile_state_link_stats() {
+  local profile codex_home entry path
+
+  PROFILE_STATE_LINK_COUNT=0
+  PROFILE_STATE_LINKS_HEALTHY=true
+
+  for profile in $(discover_profiles_for_state_audit); do
+    codex_home="$(codex_home_for_profile "$profile")"
+    if [[ -L "$codex_home" ]]; then
+      PROFILE_STATE_LINK_COUNT=$((PROFILE_STATE_LINK_COUNT + 1))
+      PROFILE_STATE_LINKS_HEALTHY=false
+      continue
+    fi
+    for entry in $(private_profile_state_entries); do
+      path="$codex_home/$entry"
+      if [[ -L "$path" ]] || private_state_hard_link_count "$path" > /dev/null; then
+        PROFILE_STATE_LINK_COUNT=$((PROFILE_STATE_LINK_COUNT + 1))
+        PROFILE_STATE_LINKS_HEALTHY=false
+      fi
+    done
+  done
+}
+
+json_emit_profile_state_links() {
+  local profile codex_home entry path target link_count first=yes
+
+  printf '['
+  for profile in $(discover_profiles_for_state_audit); do
+    codex_home="$(codex_home_for_profile "$profile")"
+    if [[ -L "$codex_home" ]]; then
+      target="$(readlink "$codex_home" 2> /dev/null || true)"
+      if [[ "$first" == "yes" ]]; then first=no; else printf ','; fi
+      printf '{"profile":'
+      json_string "$profile"
+      printf ',"home":'
+      json_string "$codex_home"
+      printf ',"entry":"profile_home","path":'
+      json_string "$codex_home"
+      printf ',"kind":"symlink","target":'
+      json_string "$target"
+      printf ',"link_count":null}'
+      continue
+    fi
+
+    for entry in $(private_profile_state_entries); do
+      path="$codex_home/$entry"
+      target=""
+      link_count=""
+      if [[ -L "$path" ]]; then
+        target="$(readlink "$path" 2> /dev/null || true)"
+      else
+        link_count="$(private_state_hard_link_count "$path" 2> /dev/null || true)"
+        [[ -n "$link_count" ]] || continue
+      fi
+
+      if [[ "$first" == "yes" ]]; then first=no; else printf ','; fi
+      printf '{"profile":'
+      json_string "$profile"
+      printf ',"home":'
+      json_string "$codex_home"
+      printf ',"entry":'
+      json_string "$entry"
+      printf ',"path":'
+      json_string "$path"
+      if [[ -n "$link_count" ]]; then
+        printf ',"kind":"hardlink","target":null,"link_count":%s}' "$link_count"
+      else
+        printf ',"kind":"symlink","target":'
+        json_string "$target"
+        printf ',"link_count":null}'
+      fi
+    done
+  done
+  printf ']'
+}
+
+note_profile_state_links() {
+  local profile codex_home entry path target link_count
+
+  for profile in $(discover_profiles_for_state_audit); do
+    codex_home="$(codex_home_for_profile "$profile")"
+    if [[ -L "$codex_home" ]]; then
+      target="$(readlink "$codex_home" 2> /dev/null || true)"
+      note "Private-state link: $profile/profile-home -> $target"
+      continue
+    fi
+
+    for entry in $(private_profile_state_entries); do
+      path="$codex_home/$entry"
+      if [[ -L "$path" ]]; then
+        target="$(readlink "$path" 2> /dev/null || true)"
+        note "Private-state link: $profile/$entry -> $target"
+      elif link_count="$(private_state_hard_link_count "$path" 2> /dev/null)"; then
+        note "Private-state link: $profile/$entry [hard links: $link_count]"
+      fi
+    done
+  done
+}
+
 initialize_shared_profile() {
   local target_profile="$1"
   local source_profile="$2"
@@ -2902,6 +3039,7 @@ command_doctor() {
   fi
   [[ -d "$CODEX_PROFILE_APP_INSTANCE_ROOT" ]] && legacy_clone_found=true
   workspace_registry_stats
+  profile_state_link_stats
 
   if [[ "$json" == "yes" ]]; then
     local status_code=0
@@ -2932,6 +3070,10 @@ command_doctor() {
     printf ',"binding_count":%s' "$WORKSPACE_STATS_BINDING_COUNT"
     printf ',"missing_paths":%s' "$WORKSPACE_STATS_MISSING_PATHS"
     printf ',"missing_profiles":%s}' "$WORKSPACE_STATS_MISSING_PROFILES"
+    printf ',"profile_state":{"healthy":%s,"private_link_count":%s,"private_links":' \
+      "$PROFILE_STATE_LINKS_HEALTHY" "$PROFILE_STATE_LINK_COUNT"
+    json_emit_profile_state_links
+    printf '}'
 
     if codex_cli="$(try_find_codex_cli)"; then
       cli_source="$(codex_cli_source "$codex_cli")"
@@ -2984,6 +3126,12 @@ command_doctor() {
   note "Workspace bindings: $WORKSPACE_STATS_BINDING_COUNT"
   note "Missing workspace paths: $WORKSPACE_STATS_MISSING_PATHS"
   note "Missing workspace profiles: $WORKSPACE_STATS_MISSING_PROFILES"
+  if [[ "$PROFILE_STATE_LINKS_HEALTHY" == "true" ]]; then
+    note "Private-state links: 0"
+  else
+    note "Private-state links: $PROFILE_STATE_LINK_COUNT (unsafe)"
+    note_profile_state_links
+  fi
 
   if codex_cli="$(try_find_codex_cli)"; then
     cli_source="$(codex_cli_source "$codex_cli")"

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -242,6 +242,20 @@ validate_desktop_log_file() {
   [[ "$link_count" == "1" ]] || die "Refusing multiply-linked desktop log: $log_file"
 }
 
+validate_desktop_log_directory() {
+  local codex_home="$1"
+  local log_directory="$codex_home/logs"
+
+  [[ ! -L "$codex_home" ]] || die "Refusing symlinked profile home: $codex_home"
+  if [[ -e "$codex_home" ]]; then
+    [[ -d "$codex_home" ]] || die "Profile home is not a directory: $codex_home"
+  fi
+  [[ ! -L "$log_directory" ]] || die "Refusing symlinked desktop log directory: $log_directory"
+  if [[ -e "$log_directory" ]]; then
+    [[ -d "$log_directory" ]] || die "Desktop log directory is not a directory: $log_directory"
+  fi
+}
+
 prepare_desktop_log_file() {
   local log_file="$1"
   local temp
@@ -2500,6 +2514,9 @@ command_logs() {
   log_file="$codex_home/logs/desktop.log"
   legacy_log_file="$codex_home/logs/desktop-instance.log"
   missing_label="desktop log"
+  if [[ "$mode" != "path" ]]; then
+    validate_desktop_log_directory "$codex_home"
+  fi
   if [[ "$instance_compat" == "yes" && ! -e "$log_file" && ! -L "$log_file" && \
         ( -e "$legacy_log_file" || -L "$legacy_log_file" ) ]]; then
     log_file="$legacy_log_file"

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -197,11 +197,11 @@ file_link_count() {
   local path="$1"
   local count
 
-  if count="$(stat -f '%l' "$path" 2> /dev/null)"; then
+  if count="$(stat -c '%h' "$path" 2> /dev/null)"; then
     printf '%s\n' "$count"
     return 0
   fi
-  stat -c '%h' "$path" 2> /dev/null
+  stat -f '%l' "$path" 2> /dev/null
 }
 
 validate_desktop_log_file() {

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -17,6 +17,10 @@ CODEX_PROFILE_LAUNCHER_ROOT="${CODEX_PROFILE_LAUNCHER_ROOT:-$HOME/Applications}"
 WORKSPACE_REGISTRY="$CODEX_PROFILE_CONFIG_HOME/workspaces.tsv"
 WORKSPACE_GUARD_FILE="$CODEX_PROFILE_CONFIG_HOME/guard-mode"
 LAUNCHER_STATE_DIR="$CODEX_PROFILE_CONFIG_HOME/launchers"
+STATE_SCHEMA_VERSION="1"
+STATE_VERSION_FILE="$CODEX_PROFILE_CONFIG_HOME/state-version"
+STATE_LOCK_DIR="$CODEX_PROFILE_CONFIG_HOME/mutation.lock"
+STATE_LOCK_HELD=no
 
 usage() {
   cat <<EOF
@@ -47,7 +51,7 @@ Usage:
   $PROGRAM logs <profile> [--instance] [--path|--tail [lines]]
   $PROGRAM clone-config <source-profile> <target-profile> [--force]
   $PROGRAM list
-  $PROGRAM doctor [--json]
+  $PROGRAM doctor [--json] [--check]
   $PROGRAM completions <bash|zsh|fish>
   $PROGRAM shell-init <bash|zsh|fish>
   $PROGRAM upgrade [--dry-run] [--prefix <path>] [--ref <git-ref>]
@@ -93,7 +97,7 @@ Environment:
   CODEX_APP_BIN   Locate a desktop .app from its executable (deprecated).
   CODEX_CLI       Override Codex CLI binary path.
   CODEX_BUNDLED_CLI  Override the bundled Codex CLI fallback path.
-  CODEX_PROFILE_CONFIG_HOME  Override private workspace binding storage.
+  CODEX_PROFILE_CONFIG_HOME  Override private versioned control-state storage.
   CODEX_PROFILE_LAUNCHER_ROOT  Override launcher install directory (default: ~/Applications).
   CODEX_PROFILE_APP_INSTANCE_ROOT  Legacy clone root (doctor only; never written).
   CODEX_PROFILE_UPGRADE_REPO    Override upgrade repository.
@@ -102,6 +106,10 @@ Environment:
   CODEX_PROFILE_UPGRADE_CACHE   Override upgrade cache checkout.
   CODEX_PROFILE_UPGRADE_PREFIX  Override upgrade install prefix.
   CODEX_PROFILE_NO_UPDATE_CHECK  Disable the daily update check (also honors DO_NOT_TRACK).
+
+Lifecycle:
+  init is the only command that creates a profile. Commands that run Codex,
+  login, launch ChatGPT, or copy configuration require initialized profiles.
 
 Desktop auth safety:
   app refuses an inherited CODEX_ACCESS_TOKEN so a shell credential cannot
@@ -191,6 +199,26 @@ ensure_home() {
   mkdir -p "$codex_home" || die "Cannot create directory: $codex_home"
   [[ -d "$codex_home" ]] || die "Not a directory: $codex_home"
   chmod 700 "$codex_home" || die "Cannot set private permissions on: $codex_home"
+}
+
+secure_initialized_home() {
+  local profile="$1" codex_home="$2"
+
+  profile_is_initialized "$profile" || \
+    die "Profile '$profile' is not initialized; run '$PROGRAM init $profile' first."
+  chmod 700 "$codex_home" || die "Cannot set private permissions on: $codex_home"
+}
+
+ensure_profile_subdirectory() {
+  local profile="$1" codex_home="$2" directory="$3"
+
+  secure_initialized_home "$profile" "$codex_home"
+  [[ ! -L "$directory" ]] || die "Refusing symlinked managed directory: $directory"
+  if [[ ! -e "$directory" ]]; then
+    mkdir "$directory" || die "Cannot create directory: $directory"
+  fi
+  [[ -d "$directory" ]] || die "Not a directory: $directory"
+  chmod 700 "$directory" || die "Cannot set private permissions on: $directory"
 }
 
 file_link_count() {
@@ -431,6 +459,49 @@ profile_is_initialized() {
   [[ -d "$codex_home" && ! -L "$codex_home" ]]
 }
 
+require_initialized_profile() {
+  local profile="$1"
+
+  validate_profile "$profile"
+  profile_is_initialized "$profile" || \
+    die "Profile '$profile' is not initialized; run '$PROGRAM init $profile' first."
+}
+
+profile_shared_dependents() {
+  local source_profile="$1" source_home profile profile_home entry path target
+
+  source_home="$(codex_home_for_profile "$source_profile")"
+  for profile in $(discover_profiles yes); do
+    [[ "$profile" != "$source_profile" ]] || continue
+    profile_home="$(codex_home_for_profile "$profile")"
+    for entry in $(shared_profile_config_entries); do
+      path="$profile_home/$entry"
+      [[ -L "$path" ]] || continue
+      target="$(readlink "$path" 2> /dev/null || true)"
+      if [[ "$target" == "$source_home/$entry" ]]; then
+        printf '%s\n' "$profile"
+        break
+      fi
+    done
+  done
+}
+
+profile_assert_removable() {
+  local profile="$1" dependents state_file
+
+  dependents="$(profile_shared_dependents "$profile" | LC_ALL=C sort -u | tr '\n' ' ')"
+  dependents="${dependents% }"
+  [[ -z "$dependents" ]] || \
+    die "Cannot remove profile '$profile'; shared configuration is still used by: $dependents. Replace those links with independent configuration or remove the dependent profiles first."
+
+  state_file="$(launcher_state_file "$profile")"
+  if [[ -e "$state_file" || -L "$state_file" ]]; then
+    launcher_load_state "$profile" || \
+      die "Cannot remove profile '$profile' while launcher state is invalid: $state_file"
+    die "Cannot remove profile '$profile' while its managed launcher exists at $LAUNCHER_STATE_PATH; run '$PROGRAM launcher remove $profile' first."
+  fi
+}
+
 workspace_path_has_control_characters() {
   local path="$1"
 
@@ -478,12 +549,17 @@ workspace_assert_state_paths_safe() {
     die "Refusing symlinked workspace registry: $WORKSPACE_REGISTRY"
   [[ ! -L "$WORKSPACE_GUARD_FILE" ]] || \
     die "Refusing symlinked workspace guard file: $WORKSPACE_GUARD_FILE"
+  [[ ! -L "$STATE_VERSION_FILE" ]] || \
+    die "Refusing symlinked state version file: $STATE_VERSION_FILE"
 
   if [[ -e "$WORKSPACE_REGISTRY" && ! -f "$WORKSPACE_REGISTRY" ]]; then
     die "Workspace registry is not a regular file: $WORKSPACE_REGISTRY"
   fi
   if [[ -e "$WORKSPACE_GUARD_FILE" && ! -f "$WORKSPACE_GUARD_FILE" ]]; then
     die "Workspace guard state is not a regular file: $WORKSPACE_GUARD_FILE"
+  fi
+  if [[ -e "$STATE_VERSION_FILE" && ! -f "$STATE_VERSION_FILE" ]]; then
+    die "State version path is not a regular file: $STATE_VERSION_FILE"
   fi
 }
 
@@ -495,6 +571,104 @@ ensure_workspace_config_home() {
     die "Workspace config path is not a directory: $CODEX_PROFILE_CONFIG_HOME"
   chmod 700 "$CODEX_PROFILE_CONFIG_HOME" || \
     die "Cannot set private permissions on: $CODEX_PROFILE_CONFIG_HOME"
+}
+
+state_schema_version() {
+  local version
+
+  workspace_assert_state_paths_safe
+  if [[ ! -f "$STATE_VERSION_FILE" ]]; then
+    printf '%s\n' "$STATE_SCHEMA_VERSION"
+    return 0
+  fi
+
+  version="$(cat "$STATE_VERSION_FILE" 2> /dev/null)" || \
+    die "Cannot read state version: $STATE_VERSION_FILE"
+  [[ "$version" == "$STATE_SCHEMA_VERSION" ]] || \
+    die "Unsupported state schema version '$version' in $STATE_VERSION_FILE; this codex-profile supports version $STATE_SCHEMA_VERSION."
+  printf '%s\n' "$version"
+}
+
+ensure_state_schema_version() {
+  local temp
+
+  state_schema_version > /dev/null
+  [[ -f "$STATE_VERSION_FILE" ]] && return 0
+
+  temp="$(mktemp "$CODEX_PROFILE_CONFIG_HOME/.state-version.tmp.XXXXXX")" || \
+    die "Cannot create temporary state version file."
+  if ! printf '%s\n' "$STATE_SCHEMA_VERSION" > "$temp"; then
+    rm -f "$temp"
+    die "Cannot write temporary state version file."
+  fi
+  chmod 600 "$temp" || {
+    rm -f "$temp"
+    die "Cannot set private permissions on temporary state version file."
+  }
+  mv -f "$temp" "$STATE_VERSION_FILE" || {
+    rm -f "$temp"
+    die "Cannot replace state version file: $STATE_VERSION_FILE"
+  }
+}
+
+state_lock_release() {
+  local owner=""
+
+  [[ "${STATE_LOCK_HELD:-no}" == "yes" ]] || return 0
+  if [[ -f "$STATE_LOCK_DIR/pid" && ! -L "$STATE_LOCK_DIR/pid" ]]; then
+    IFS= read -r owner < "$STATE_LOCK_DIR/pid" || owner=""
+  fi
+
+  if [[ -z "$owner" || "$owner" == "$$" ]]; then
+    rm -f -- "$STATE_LOCK_DIR/pid" 2> /dev/null || true
+    rmdir "$STATE_LOCK_DIR" 2> /dev/null || \
+      warn "Could not remove state mutation lock: $STATE_LOCK_DIR"
+  else
+    warn "State mutation lock ownership changed unexpectedly; leaving it in place: $STATE_LOCK_DIR"
+  fi
+  STATE_LOCK_HELD=no
+}
+
+state_lock_acquire() {
+  local attempts=0 max_attempts owner=""
+
+  [[ "$STATE_LOCK_HELD" == "no" ]] || die "State mutation lock is already held by this process."
+  ensure_workspace_config_home
+  max_attempts="${CODEX_PROFILE_LOCK_ATTEMPTS:-30}"
+  [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]] || max_attempts=30
+
+  while ! (umask 077 && mkdir "$STATE_LOCK_DIR") 2> /dev/null; do
+    [[ -d "$STATE_LOCK_DIR" && ! -L "$STATE_LOCK_DIR" ]] || \
+      die "Refusing unsafe state mutation lock path: $STATE_LOCK_DIR"
+    owner=""
+    if [[ -f "$STATE_LOCK_DIR/pid" && ! -L "$STATE_LOCK_DIR/pid" ]]; then
+      IFS= read -r owner < "$STATE_LOCK_DIR/pid" || owner=""
+    fi
+    if [[ "$owner" =~ ^[1-9][0-9]*$ ]] && \
+       ! kill -0 "$owner" 2> /dev/null && ! ps -p "$owner" > /dev/null 2>&1; then
+      rm -f -- "$STATE_LOCK_DIR/pid" 2> /dev/null || true
+      rmdir "$STATE_LOCK_DIR" 2> /dev/null || true
+      continue
+    fi
+    attempts=$((attempts + 1))
+    if ((attempts >= max_attempts)); then
+      die "Timed out waiting for state mutation lock${owner:+ held by process $owner}: $STATE_LOCK_DIR"
+    fi
+    sleep 1
+  done
+
+  STATE_LOCK_HELD=yes
+  trap state_lock_release EXIT
+  trap 'state_lock_release; exit 1' HUP INT TERM
+  if ! printf '%s\n' "$$" > "$STATE_LOCK_DIR/pid"; then
+    state_lock_release
+    die "Cannot record state mutation lock owner: $STATE_LOCK_DIR"
+  fi
+  chmod 600 "$STATE_LOCK_DIR/pid" || {
+    state_lock_release
+    die "Cannot protect state mutation lock owner: $STATE_LOCK_DIR/pid"
+  }
+  ensure_state_schema_version
 }
 
 workspace_decode_registry_line() {
@@ -525,6 +699,7 @@ workspace_registry_validate() {
   local line line_number=0
 
   workspace_assert_state_paths_safe
+  state_schema_version > /dev/null
   [[ -f "$WORKSPACE_REGISTRY" ]] || return 0
 
   while IFS= read -r line || [[ -n "$line" ]]; do
@@ -537,6 +712,7 @@ workspace_guard_mode() {
   local mode
 
   workspace_assert_state_paths_safe
+  state_schema_version > /dev/null
   if [[ ! -f "$WORKSPACE_GUARD_FILE" ]]; then
     printf 'warn\n'
     return 0
@@ -685,8 +861,9 @@ workspace_remove_profile_bindings() {
 }
 
 workspace_registry_stats() {
-  local line mode line_number=0
+  local line mode version line_number=0
 
+  WORKSPACE_STATS_SCHEMA_VERSION="$STATE_SCHEMA_VERSION"
   WORKSPACE_STATS_GUARD_MODE="warn"
   WORKSPACE_STATS_REGISTRY_VALID=true
   WORKSPACE_STATS_BINDING_COUNT=0
@@ -694,21 +871,33 @@ workspace_registry_stats() {
   WORKSPACE_STATS_MISSING_PROFILES=0
 
   if [[ -e "$CODEX_PROFILE_CONFIG_HOME" && ! -d "$CODEX_PROFILE_CONFIG_HOME" ]]; then
+    WORKSPACE_STATS_SCHEMA_VERSION=""
     WORKSPACE_STATS_GUARD_MODE=""
     WORKSPACE_STATS_REGISTRY_VALID=false
     return 0
   fi
   if [[ -L "$CODEX_PROFILE_CONFIG_HOME" || -L "$WORKSPACE_REGISTRY" || \
-        -L "$WORKSPACE_GUARD_FILE" ]]; then
+        -L "$WORKSPACE_GUARD_FILE" || -L "$STATE_VERSION_FILE" ]]; then
+    WORKSPACE_STATS_SCHEMA_VERSION=""
     WORKSPACE_STATS_GUARD_MODE=""
     WORKSPACE_STATS_REGISTRY_VALID=false
     return 0
   fi
   if [[ -e "$WORKSPACE_REGISTRY" && ! -f "$WORKSPACE_REGISTRY" ]] || \
-     [[ -e "$WORKSPACE_GUARD_FILE" && ! -f "$WORKSPACE_GUARD_FILE" ]]; then
+     [[ -e "$WORKSPACE_GUARD_FILE" && ! -f "$WORKSPACE_GUARD_FILE" ]] || \
+     [[ -e "$STATE_VERSION_FILE" && ! -f "$STATE_VERSION_FILE" ]]; then
+    WORKSPACE_STATS_SCHEMA_VERSION=""
     WORKSPACE_STATS_GUARD_MODE=""
     WORKSPACE_STATS_REGISTRY_VALID=false
     return 0
+  fi
+
+  if [[ -f "$STATE_VERSION_FILE" ]]; then
+    version="$(cat "$STATE_VERSION_FILE" 2> /dev/null || true)"
+    WORKSPACE_STATS_SCHEMA_VERSION="$version"
+    if [[ "$version" != "$STATE_SCHEMA_VERSION" ]]; then
+      WORKSPACE_STATS_REGISTRY_VALID=false
+    fi
   fi
 
   if [[ -f "$WORKSPACE_GUARD_FILE" ]]; then
@@ -1043,7 +1232,7 @@ command_app() {
 
   [[ "$profile_set" == yes ]] || die "$usage"
   [[ "$workspace_set" == yes ]] || workspace="$PWD"
-  validate_profile "$profile"
+  require_initialized_profile "$profile"
   workspace_guard_profile "$profile" "$workspace"
 
   if [[ "$instance" == yes ]]; then
@@ -1077,15 +1266,15 @@ run_desktop_app() {
   command -v open > /dev/null 2>&1 || die "macOS open command not found; $PROGRAM app is macOS-only."
 
   codex_home="$(codex_home_for_profile "$profile")"
-  ensure_home "$codex_home"
+  secure_initialized_home "$profile" "$codex_home"
   if [[ "$profile" != "default" ]]; then
     user_data_dir="$codex_home/electron-user-data"
-    ensure_home "$user_data_dir"
+    ensure_profile_subdirectory "$profile" "$codex_home" "$user_data_dir"
   fi
 
   log_dir="$codex_home/logs"
   log_file="$log_dir/desktop.log"
-  ensure_home "$log_dir"
+  ensure_profile_subdirectory "$profile" "$codex_home" "$log_dir"
   prepare_desktop_log_file "$log_file"
 
   note "Launching $product for profile $profile"
@@ -1205,6 +1394,7 @@ ensure_launcher_directories() {
 launcher_load_state() {
   local profile="$1" state_file
 
+  state_schema_version > /dev/null
   state_file="$(launcher_state_file "$profile")"
   [[ -f "$state_file" && ! -L "$state_file" ]] || return 1
   IFS= read -r LAUNCHER_STATE_PROFILE < "$state_file" || return 1
@@ -1397,6 +1587,8 @@ command_launcher_create() {
   profile_is_initialized "$profile" ||
     die "Profile '$profile' is not initialized; run '$PROGRAM init $profile' first."
   [[ "$(uname -s)" == "Darwin" ]] || die_macos_only launcher
+  state_lock_acquire
+  require_initialized_profile "$profile"
   ensure_launcher_directories
   path="$CODEX_PROFILE_LAUNCHER_ROOT/$name.app"
   state_file="$(launcher_state_file "$profile")"
@@ -1483,6 +1675,7 @@ command_launcher_list() {
 
   if [[ "${1:-}" == "--json" || "${1:-}" == "-j" ]]; then json=yes; shift; fi
   [[ "$#" -eq 0 ]] || die "Usage: $PROGRAM launcher list [--json]"
+  state_schema_version > /dev/null
   if [[ "$json" == "yes" ]]; then printf '['; fi
   if [[ -d "$LAUNCHER_STATE_DIR" && ! -L "$LAUNCHER_STATE_DIR" ]]; then
     for state_file in "$LAUNCHER_STATE_DIR"/*.state; do
@@ -1533,6 +1726,7 @@ command_launcher_remove() {
   if [[ "${1:-}" == "--yes" || "${1:-}" == "-y" ]]; then yes=yes; shift; fi
   [[ "$#" -eq 0 ]] || die "Usage: $PROGRAM launcher remove <profile> [--yes]"
   validate_profile "$profile"
+  state_lock_acquire
   state_file="$(launcher_state_file "$profile")"
   launcher_load_state "$profile" || die "No managed launcher for profile '$profile'."
   if launcher_path_is_absent "$LAUNCHER_STATE_PATH"; then
@@ -1572,10 +1766,10 @@ command_cli() {
   shift || true
 
   local codex_home codex_cli
-  validate_profile "$profile"
+  require_initialized_profile "$profile"
   workspace_guard_profile "$profile" "$PWD"
   codex_home="$(codex_home_for_profile "$profile")"
-  ensure_home "$codex_home"
+  secure_initialized_home "$profile" "$codex_home"
   codex_cli="$(find_codex_cli)"
 
   exec env CODEX_HOME="$codex_home" "$codex_cli" "$@"
@@ -1587,8 +1781,9 @@ command_login() {
   shift || true
 
   local codex_home codex_cli
+  require_initialized_profile "$profile"
   codex_home="$(codex_home_for_profile "$profile")"
-  ensure_home "$codex_home"
+  secure_initialized_home "$profile" "$codex_home"
   codex_cli="$(find_codex_cli)"
 
   exec env CODEX_HOME="$codex_home" "$codex_cli" login "$@"
@@ -1615,6 +1810,8 @@ command_init() {
     esac
     shift
   done
+
+  state_lock_acquire
 
   if [[ -n "$source_profile" ]]; then
     initialize_shared_profile "$profile" "$source_profile"
@@ -1656,8 +1853,12 @@ command_remove() {
   local codex_home confirmation
   codex_home="$(codex_home_for_profile "$profile")"
   workspace_registry_validate
+  profile_assert_removable "$profile"
 
   if [[ ! -d "$codex_home" ]]; then
+    state_lock_acquire
+    workspace_registry_validate
+    profile_assert_removable "$profile"
     workspace_remove_profile_bindings "$profile"
     note "Not initialized $profile ($codex_home)"
     return 0
@@ -1672,6 +1873,10 @@ command_remove() {
       die "Confirmation did not match; nothing removed."
     fi
   fi
+
+  state_lock_acquire
+  workspace_registry_validate
+  profile_assert_removable "$profile"
 
   rm -rf -- "$codex_home" || die "Cannot remove profile home: $codex_home"
   workspace_remove_profile_bindings "$profile"
@@ -1935,9 +2140,9 @@ command_workspace_bind() {
   [[ "$#" -eq 0 ]] || die "$usage"
 
   validate_profile "$profile"
-  profile_is_initialized "$profile" || \
-    die "Profile '$profile' is not initialized; run '$PROGRAM init $profile' first."
   canonical="$(canonical_directory "$path")"
+  state_lock_acquire
+  require_initialized_profile "$profile"
 
   if workspace_exact_profile "$canonical"; then
     existing="$WORKSPACE_EXACT_PROFILE"
@@ -1964,6 +2169,7 @@ command_workspace_unbind() {
   shift || true
   [[ "$#" -eq 0 ]] || die "$usage"
   canonical="$(workspace_path_for_unbind "$path")"
+  state_lock_acquire
 
   workspace_exact_profile "$canonical" || \
     die "No exact workspace binding exists for $canonical."
@@ -2098,8 +2304,8 @@ command_workspace_guard() {
     *) die "Invalid workspace guard mode '$mode'. Use off, warn, or strict." ;;
   esac
 
+  state_lock_acquire
   workspace_registry_validate
-  ensure_workspace_config_home
   temp="$(mktemp "$CODEX_PROFILE_CONFIG_HOME/.guard-mode.tmp.XXXXXX")" || \
     die "Cannot create temporary workspace guard state."
   printf '%s\n' "$mode" > "$temp" || {
@@ -2221,8 +2427,8 @@ command_env() {
   workspace_guard_profile "$profile" "$PWD"
 
   if [[ ! -d "$codex_home" ]]; then
-    printf "%s: profile '%s' is not initialized (%s); run '%s init %s' or '%s login %s'.\n" \
-      "$PROGRAM" "$profile" "$codex_home" "$PROGRAM" "$profile" "$PROGRAM" "$profile" >&2
+    printf "%s: profile '%s' is not initialized (%s); run '%s init %s'.\n" \
+      "$PROGRAM" "$profile" "$codex_home" "$PROGRAM" "$profile" >&2
   fi
 
   case "$shell" in
@@ -2352,8 +2558,12 @@ command_clone_config() {
   source_home="$(codex_home_for_profile "$source_profile")"
   target_home="$(codex_home_for_profile "$target_profile")"
 
-  [[ -d "$source_home" ]] || die "Source profile is not initialized: $source_profile ($source_home)"
-  ensure_home "$target_home"
+  require_initialized_profile "$source_profile"
+  require_initialized_profile "$target_profile"
+  state_lock_acquire
+  require_initialized_profile "$source_profile"
+  require_initialized_profile "$target_profile"
+  secure_initialized_home "$target_profile" "$target_home"
 
   local safe_files=("config.toml" "AGENTS.md")
   local file source_file target_file copied failed
@@ -2572,7 +2782,7 @@ maybe_check_for_update() {
   if [[ -f "$state_file" ]]; then
     read -r cached_epoch cached_version < "$state_file" 2> /dev/null || true
     if [[ -n "$cached_version" ]] && update_version_is_newer "$cached_version"; then
-      printf "codex-profile %s available (you have %s); run '%s upgrade' or 'npm i -g codex-profile'.\n" \
+      printf "codex-profile %s available (you have %s); upgrade with the installation's package manager (source installs: '%s upgrade').\n" \
         "$cached_version" "$VERSION" "$PROGRAM" >&2
     fi
   fi
@@ -2648,13 +2858,41 @@ upgrade_checkout_ref() {
   fi
 }
 
+upgrade_assert_installation_owned() {
+  local prefix="$1" prefix_explicit="$2"
+  local program_path bin_dir canonical plural
+
+  [[ "$prefix_explicit" == "no" ]] || return 0
+  program_path="$(current_program_path)"
+  bin_dir="$prefix/bin"
+  if [[ -d "$bin_dir" ]]; then
+    bin_dir="$(cd -- "$bin_dir" && pwd -P)" || \
+      die "Cannot resolve source upgrade prefix: $prefix"
+  fi
+  canonical="$bin_dir/codex-profile"
+  plural="$bin_dir/codex-profiles"
+
+  if [[ "$program_path" == "$canonical" && -f "$canonical" && ! -L "$canonical" ]]; then
+    return 0
+  fi
+  if [[ "$program_path" == "$plural" && -L "$plural" && \
+        "$(readlink "$plural" 2> /dev/null || true)" == "codex-profile" && \
+        -f "$canonical" && ! -L "$canonical" ]]; then
+    return 0
+  fi
+
+  die "Refusing a source-style upgrade from package-managed or unrecognized executable: $program_path. Upgrade with the installation's package manager, or pass --prefix explicitly to authorize a source installation."
+}
+
 command_upgrade() {
   local dry_run=no
+  local prefix_explicit=no
   local prefix
   local ref="$CODEX_PROFILE_UPGRADE_REF"
   local requested_ref
   local repo="$CODEX_PROFILE_UPGRADE_REPO"
   local cache
+  [[ -z "${CODEX_PROFILE_UPGRADE_PREFIX:-}" ]] || prefix_explicit=yes
   prefix="$(upgrade_prefix)"
   cache="$(upgrade_cache_dir)"
 
@@ -2666,6 +2904,7 @@ command_upgrade() {
       --prefix)
         [[ -n "${2:-}" ]] || die "Usage: $PROGRAM upgrade [--dry-run] [--prefix <path>] [--ref <git-ref>]"
         prefix="$2"
+        prefix_explicit=yes
         shift
         ;;
       --ref)
@@ -2705,6 +2944,8 @@ command_upgrade() {
     note "Already on latest immutable release codex-profile $VERSION."
     return 0
   fi
+
+  upgrade_assert_installation_owned "$prefix" "$prefix_explicit"
 
   command -v git > /dev/null 2>&1 || die "git is required to upgrade codex-profile."
   command -v make > /dev/null 2>&1 || die "make is required to upgrade codex-profile."
@@ -2835,6 +3076,11 @@ _codex_profile()
         COMPREPLY=( $(compgen -W "--app" -- "$cur") )
       fi
       ;;
+    doctor)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "--json --check" -- "$cur") )
+      fi
+      ;;
     completions|shell-init)
       if [[ "$COMP_CWORD" -eq 2 ]]; then
         COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
@@ -2850,7 +3096,7 @@ EOF
 #compdef codex-profile codex-profiles
 
 _codex_profile() {
-  local -a commands profiles shells app_flags init_flags launcher_commands launcher_flags launcher_colors workspace_commands run_flags workspace_json_flags
+  local -a commands profiles shells app_flags init_flags launcher_commands launcher_flags launcher_colors workspace_commands run_flags workspace_json_flags doctor_flags
   commands=(
     app app-instance cli login init remove launcher workspace run status path env use logs clone-config list doctor completions shell-init upgrade version help
   )
@@ -2864,6 +3110,7 @@ _codex_profile() {
   workspace_commands=(bind unbind list status guard)
   run_flags=(--app)
   workspace_json_flags=(--json)
+  doctor_flags=(--json --check)
 
   if (( CURRENT == 2 )); then
     _describe 'command' commands
@@ -2925,6 +3172,11 @@ _codex_profile() {
         _describe 'flag' run_flags
       fi
       ;;
+    doctor)
+      if [[ "$words[CURRENT]" == -* ]]; then
+        _describe 'flag' doctor_flags
+      fi
+      ;;
     completions|shell-init)
       if (( CURRENT == 3 )); then
         _describe 'shell' shells
@@ -2960,6 +3212,8 @@ for codex_profile_command in codex-profile codex-profiles
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from workspace; and __fish_seen_subcommand_from guard; and test (count (commandline -opc)) -eq 3' -a 'off warn strict'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from workspace; and __fish_seen_subcommand_from list status' -l json -d 'Emit JSON'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from run' -l app -d 'Launch the bound ChatGPT window'
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from doctor' -l json -d 'Emit JSON'
+    complete -c $codex_profile_command -n '__fish_seen_subcommand_from doctor' -l check -d 'Exit nonzero when health checks fail'
     complete -c $codex_profile_command -n '__fish_seen_subcommand_from completions shell-init' -a 'bash zsh fish'
 end
 EOF
@@ -3015,17 +3269,21 @@ EOF
 }
 
 command_doctor() {
-  local json=no
+  local json=no check=no
   local app="" executable="" product="" bundle_id="" codex_cli="" cli_source="" cli_version=""
-  local desktop_found=false legacy_clone_found=false
+  local status_json="" status_code=0
+  local desktop_found=false legacy_clone_found=false cli_found=false overall_healthy=true
 
   while [[ "$#" -gt 0 ]]; do
     case "$1" in
       --json | -j)
         json=yes
         ;;
+      --check)
+        check=yes
+        ;;
       *)
-        die "Usage: $PROGRAM doctor [--json]"
+        die "Usage: $PROGRAM doctor [--json] [--check]"
         ;;
     esac
     shift
@@ -3041,10 +3299,31 @@ command_doctor() {
   workspace_registry_stats
   profile_state_link_stats
 
-  if [[ "$json" == "yes" ]]; then
-    local status_code=0
+  if codex_cli="$(try_find_codex_cli)"; then
+    cli_found=true
+    cli_source="$(codex_cli_source "$codex_cli")"
+    cli_version="$(codex_cli_version_string "$codex_cli")"
+  else
+    overall_healthy=false
+  fi
+  if [[ "$WORKSPACE_STATS_REGISTRY_VALID" != "true" || \
+        "$WORKSPACE_STATS_MISSING_PATHS" -ne 0 || \
+        "$WORKSPACE_STATS_MISSING_PROFILES" -ne 0 || \
+        "$PROFILE_STATE_LINKS_HEALTHY" != "true" ]]; then
+    overall_healthy=false
+  fi
 
-    printf '{"desktop":{"found":%s,"path":' "$desktop_found"
+  if [[ "$json" == "yes" ]]; then
+    if [[ "$cli_found" == "true" ]]; then
+      if status_json="$(json_emit_status_profiles_array)"; then
+        status_code=0
+      else
+        status_code=$?
+        overall_healthy=false
+      fi
+    fi
+
+    printf '{"healthy":%s,"desktop":{"found":%s,"path":' "$overall_healthy" "$desktop_found"
     if [[ "$desktop_found" == "true" ]]; then json_string "$executable"; else printf 'null'; fi
     printf ',"app_path":'
     if [[ "$desktop_found" == "true" ]]; then json_string "$app"; else printf 'null'; fi
@@ -3058,6 +3337,12 @@ command_doctor() {
     printf '}'
     printf ',"workspaces":{"config_home":'
     json_string "$CODEX_PROFILE_CONFIG_HOME"
+    printf ',"schema_version":'
+    if [[ -n "$WORKSPACE_STATS_SCHEMA_VERSION" ]]; then
+      json_string "$WORKSPACE_STATS_SCHEMA_VERSION"
+    else
+      printf 'null'
+    fi
     printf ',"registry_path":'
     json_string "$WORKSPACE_REGISTRY"
     printf ',"guard_mode":'
@@ -3075,9 +3360,7 @@ command_doctor() {
     json_emit_profile_state_links
     printf '}'
 
-    if codex_cli="$(try_find_codex_cli)"; then
-      cli_source="$(codex_cli_source "$codex_cli")"
-      cli_version="$(codex_cli_version_string "$codex_cli")"
+    if [[ "$cli_found" == "true" ]]; then
       printf ',"cli":{"found":true,"path":'
       json_string "$codex_cli"
       printf ',"version":'
@@ -3086,17 +3369,18 @@ command_doctor() {
       json_string "$cli_source"
       printf ',"healthy":true,"scope":"codex_only","account_identity":"unverified_against_desktop"'
       printf '},"status":{"skipped":false,"profiles":'
-      set +e
-      json_emit_status_profiles_array
-      status_code=$?
-      set -e
+      printf '%s' "$status_json"
       printf '}}\n'
+      if [[ "$check" == "yes" && "$overall_healthy" != "true" && "$status_code" -eq 0 ]]; then
+        return 1
+      fi
       return "$status_code"
     fi
 
     printf ',"cli":{"found":false,"path":null,"version":null,"source":null,"healthy":false,"scope":"codex_only","account_identity":"unverified_against_desktop"},"status":{"skipped":true,"reason":'
     json_string "$(codex_cli_error_message)"
     printf '}}\n'
+    [[ "$check" != "yes" ]] || return 1
     return 0
   fi
 
@@ -3117,6 +3401,7 @@ command_doctor() {
     note "Legacy app clones: found at $CODEX_PROFILE_APP_INSTANCE_ROOT (safe to remove after closing old cloned apps)"
   fi
   note "Workspace registry: $WORKSPACE_REGISTRY"
+  note "State schema version: ${WORKSPACE_STATS_SCHEMA_VERSION:-invalid}"
   if [[ "$WORKSPACE_STATS_REGISTRY_VALID" == "true" ]]; then
     note "Workspace guard mode: $WORKSPACE_STATS_GUARD_MODE"
   else
@@ -3133,8 +3418,7 @@ command_doctor() {
     note_profile_state_links
   fi
 
-  if codex_cli="$(try_find_codex_cli)"; then
-    cli_source="$(codex_cli_source "$codex_cli")"
+  if [[ "$cli_found" == "true" ]]; then
     note "CLI: $codex_cli (source: $cli_source)"
     note "CLI scope: Codex commands only; Desktop and CLI accounts must be verified separately"
     "$codex_cli" --version
@@ -3143,11 +3427,16 @@ command_doctor() {
     note "CLI scope: Codex commands only; Desktop and CLI accounts must be verified separately"
     note ""
     note "Status: skipped"
+    [[ "$check" != "yes" ]] || return 1
     return 0
   fi
 
   note ""
-  command_status
+  command_status || status_code=$?
+  if [[ "$check" == "yes" && "$overall_healthy" != "true" && "$status_code" -eq 0 ]]; then
+    return 1
+  fi
+  return "$status_code"
 }
 
 main() {

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -10,7 +10,8 @@ CODEX_APP_BIN="${CODEX_APP_BIN:-}"
 CODEX_BUNDLED_CLI="${CODEX_BUNDLED_CLI:-}"
 CODEX_PROFILE_APP_INSTANCE_ROOT="${CODEX_PROFILE_APP_INSTANCE_ROOT:-$HOME/Library/Application Support/codex-profile/app-instances}"
 CODEX_PROFILE_UPGRADE_REPO="${CODEX_PROFILE_UPGRADE_REPO:-https://github.com/Ducksss/codex-profiles.git}"
-CODEX_PROFILE_UPGRADE_REF="${CODEX_PROFILE_UPGRADE_REF:-main}"
+CODEX_PROFILE_UPGRADE_REF="${CODEX_PROFILE_UPGRADE_REF:-latest}"
+CODEX_PROFILE_UPGRADE_RELEASE_URL="${CODEX_PROFILE_UPGRADE_RELEASE_URL:-https://api.github.com/repos/Ducksss/codex-profiles/releases/latest}"
 CODEX_PROFILE_CONFIG_HOME="${CODEX_PROFILE_CONFIG_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/codex-profile}"
 CODEX_PROFILE_LAUNCHER_ROOT="${CODEX_PROFILE_LAUNCHER_ROOT:-$HOME/Applications}"
 WORKSPACE_REGISTRY="$CODEX_PROFILE_CONFIG_HOME/workspaces.tsv"
@@ -96,7 +97,8 @@ Environment:
   CODEX_PROFILE_LAUNCHER_ROOT  Override launcher install directory (default: ~/Applications).
   CODEX_PROFILE_APP_INSTANCE_ROOT  Legacy clone root (doctor only; never written).
   CODEX_PROFILE_UPGRADE_REPO    Override upgrade repository.
-  CODEX_PROFILE_UPGRADE_REF     Override upgrade git ref.
+  CODEX_PROFILE_UPGRADE_REF     Override upgrade git ref (default: latest immutable release).
+  CODEX_PROFILE_UPGRADE_RELEASE_URL  Override latest-release metadata URL.
   CODEX_PROFILE_UPGRADE_CACHE   Override upgrade cache checkout.
   CODEX_PROFILE_UPGRADE_PREFIX  Override upgrade install prefix.
   CODEX_PROFILE_NO_UPDATE_CHECK  Disable the daily update check (also honors DO_NOT_TRACK).
@@ -189,6 +191,46 @@ ensure_home() {
   mkdir -p "$codex_home" || die "Cannot create directory: $codex_home"
   [[ -d "$codex_home" ]] || die "Not a directory: $codex_home"
   chmod 700 "$codex_home" || die "Cannot set private permissions on: $codex_home"
+}
+
+file_link_count() {
+  local path="$1"
+  local count
+
+  if count="$(stat -f '%l' "$path" 2> /dev/null)"; then
+    printf '%s\n' "$count"
+    return 0
+  fi
+  stat -c '%h' "$path" 2> /dev/null
+}
+
+validate_desktop_log_file() {
+  local log_file="$1"
+  local link_count
+
+  [[ ! -L "$log_file" ]] || die "Refusing symlinked desktop log: $log_file"
+  [[ -f "$log_file" ]] || die "Desktop log is not a regular file: $log_file"
+  link_count="$(file_link_count "$log_file")" || die "Cannot inspect desktop log links: $log_file"
+  [[ "$link_count" == "1" ]] || die "Refusing multiply-linked desktop log: $log_file"
+}
+
+prepare_desktop_log_file() {
+  local log_file="$1"
+  local temp
+
+  if [[ -e "$log_file" || -L "$log_file" ]]; then
+    validate_desktop_log_file "$log_file"
+  fi
+
+  temp="$(mktemp "$log_file.tmp.XXXXXX")" || die "Cannot create private desktop log: $log_file"
+  chmod 600 "$temp" || {
+    rm -f "$temp"
+    die "Cannot set private permissions on desktop log: $log_file"
+  }
+  mv -f "$temp" "$log_file" || {
+    rm -f "$temp"
+    die "Cannot replace desktop log safely: $log_file"
+  }
 }
 
 shared_profile_config_entries() {
@@ -907,8 +949,7 @@ run_desktop_app() {
   log_dir="$codex_home/logs"
   log_file="$log_dir/desktop.log"
   ensure_home "$log_dir"
-  (umask 077 && : > "$log_file")
-  chmod 600 "$log_file" 2> /dev/null || true
+  prepare_desktop_log_file "$log_file"
 
   note "Launching $product for profile $profile"
   note "CODEX_HOME=$codex_home"
@@ -2116,7 +2157,8 @@ command_logs() {
   log_file="$codex_home/logs/desktop.log"
   legacy_log_file="$codex_home/logs/desktop-instance.log"
   missing_label="desktop log"
-  if [[ "$instance_compat" == "yes" && ! -f "$log_file" && -f "$legacy_log_file" ]]; then
+  if [[ "$instance_compat" == "yes" && ! -e "$log_file" && ! -L "$log_file" && \
+        ( -e "$legacy_log_file" || -L "$legacy_log_file" ) ]]; then
     log_file="$legacy_log_file"
     missing_label="legacy desktop instance log"
   fi
@@ -2126,7 +2168,8 @@ command_logs() {
     return 0
   fi
 
-  [[ -f "$log_file" ]] || die "No $missing_label for $profile ($log_file)."
+  [[ -e "$log_file" || -L "$log_file" ]] || die "No $missing_label for $profile ($log_file)."
+  validate_desktop_log_file "$log_file"
 
   if [[ "$mode" == "tail" ]]; then
     tail -n "$lines" "$log_file"
@@ -2306,6 +2349,7 @@ update_check_state_file() {
 update_check_fetch_latest() {
   local url body
   url="${CODEX_PROFILE_UPDATE_URL:-https://registry.npmjs.org/codex-profile/latest}"
+  [[ "$url" != -* ]] || return 1
 
   if [[ -f "$url" ]]; then
     body="$(cat "$url" 2> /dev/null)" || return 1
@@ -2419,12 +2463,48 @@ script_declared_version_output() {
   printf 'codex-profile %s\n' "$declared_version"
 }
 
+upgrade_fetch_release_metadata() {
+  local url="$1"
+  [[ "$url" != -* ]] || return 1
+
+  if [[ -f "$url" ]]; then
+    cat "$url"
+  elif command -v curl > /dev/null 2>&1; then
+    curl -fsSL --connect-timeout 10 --max-time 30 "$url"
+  elif command -v wget > /dev/null 2>&1; then
+    wget -qO- --timeout=30 "$url"
+  else
+    return 1
+  fi
+}
+
+upgrade_latest_release_ref() {
+  local body tag immutable draft prerelease
+
+  body="$(upgrade_fetch_release_metadata "$CODEX_PROFILE_UPGRADE_RELEASE_URL")" \
+    || die "Cannot fetch latest release metadata: $CODEX_PROFILE_UPGRADE_RELEASE_URL"
+  tag="$(printf '%s\n' "$body" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | sed -n '1p')"
+  immutable="$(printf '%s\n' "$body" | sed -n 's/.*"immutable"[[:space:]]*:[[:space:]]*\([a-z]*\).*/\1/p' | sed -n '1p')"
+  draft="$(printf '%s\n' "$body" | sed -n 's/.*"draft"[[:space:]]*:[[:space:]]*\([a-z]*\).*/\1/p' | sed -n '1p')"
+  prerelease="$(printf '%s\n' "$body" | sed -n 's/.*"prerelease"[[:space:]]*:[[:space:]]*\([a-z]*\).*/\1/p' | sed -n '1p')"
+
+  [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    || die "Latest release metadata does not contain an exact vX.Y.Z tag."
+  [[ "$immutable" == "true" && "$draft" == "false" && "$prerelease" == "false" ]] \
+    || die "Latest GitHub Release $tag is not immutable and final."
+  printf '%s\n' "$tag"
+}
+
 upgrade_checkout_ref() {
   local cache="$1"
   local ref="$2"
 
   git -C "$cache" fetch --tags --prune origin
-  if git -C "$cache" show-ref --verify --quiet "refs/remotes/origin/$ref"; then
+  if [[ "$ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    git -C "$cache" show-ref --verify --quiet "refs/tags/$ref" \
+      || die "Upgrade release tag does not exist: $ref"
+    git -C "$cache" checkout --detach --quiet "refs/tags/$ref"
+  elif git -C "$cache" show-ref --verify --quiet "refs/remotes/origin/$ref"; then
     git -C "$cache" checkout --quiet -B "$ref" "origin/$ref"
   else
     git -C "$cache" checkout --quiet "$ref"
@@ -2435,6 +2515,7 @@ command_upgrade() {
   local dry_run=no
   local prefix
   local ref="$CODEX_PROFILE_UPGRADE_REF"
+  local requested_ref
   local repo="$CODEX_PROFILE_UPGRADE_REPO"
   local cache
   prefix="$(upgrade_prefix)"
@@ -2469,9 +2550,22 @@ command_upgrade() {
   [[ "$repo" != -* ]] || die "Upgrade repository must not start with '-'."
   [[ "$ref" != -* ]] || die "Upgrade ref must not start with '-'."
 
+  requested_ref="$ref"
+  if [[ "$ref" == "latest" ]]; then
+    ref="$(upgrade_latest_release_ref)"
+  fi
+
   upgrade_print_plan "$repo" "$ref" "$cache" "$prefix"
+  if [[ "$requested_ref" == "latest" ]]; then
+    note "Release policy: immutable final GitHub Release"
+  fi
 
   if [[ "$dry_run" == "yes" ]]; then
+    return 0
+  fi
+
+  if [[ "$requested_ref" == "latest" && "${ref#v}" == "$VERSION" ]]; then
+    note "Already on latest immutable release codex-profile $VERSION."
     return 0
   fi
 
@@ -2503,6 +2597,9 @@ command_upgrade() {
   local candidate_version
   candidate_version="$(script_declared_version_output "$cache/bin/codex-profile" || true)"
   [[ -n "$candidate_version" ]] || die "Refusing to install candidate without a declared VERSION."
+  if [[ "$ref" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ && "$candidate_version" != "codex-profile ${BASH_REMATCH[1]}" ]]; then
+    die "Refusing release $ref because it declares $candidate_version."
+  fi
   if [[ -n "$candidate_version" ]] && version_is_older_than_current "$candidate_version"; then
     die "Refusing to install older $candidate_version over codex-profile $VERSION."
   fi

--- a/docs/index.html
+++ b/docs/index.html
@@ -153,7 +153,7 @@
           "name": "What does app default do?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "app default uses ~/.codex and preserves the stock ChatGPT Desktop session without a custom Electron user-data directory."
+            "text": "After the default profile is initialized, app default uses ~/.codex and preserves the stock ChatGPT Desktop session without a custom Electron user-data directory."
           }
         },
         {
@@ -201,7 +201,7 @@
           "name": "Can an AI assistant tell me how to run codex-profiles?",
           "acceptedAnswer": {
             "@type": "Answer",
-            "text": "Yes. Point your AI assistant or coding agent at the GitHub repository and this llms.txt file, then ask it to install codex-profile and run codex-profile cli work to start Codex on an isolated work profile. Coding agents working inside a clone of the repository can read its AGENTS.md file for setup, test, and usage instructions."
+            "text": "Yes. Point your AI assistant or coding agent at the GitHub repository and this llms.txt file, then ask it to install codex-profile, initialize work, and run codex-profile cli work to start Codex on that profile. Coding agents working inside a clone of the repository can read its AGENTS.md file for setup, test, and usage instructions."
           }
         },
         {
@@ -1450,7 +1450,7 @@ codex-profile doctor</code></pre>
         </article>
         <article>
           <h3>What does app default do?</h3>
-          <p>app default uses ~/.codex and preserves the stock ChatGPT Desktop session without a custom Electron user-data directory.</p>
+          <p>After the default profile is initialized, app default uses ~/.codex and preserves the stock ChatGPT Desktop session without a custom Electron user-data directory.</p>
         </article>
         <article>
           <h3>Does codex-profiles verify that CLI and Desktop use the same account?</h3>
@@ -1474,7 +1474,7 @@ codex-profile doctor</code></pre>
         </article>
         <article>
           <h3>Can an AI assistant tell me how to run codex-profiles?</h3>
-          <p>Yes. Point your AI assistant or coding agent at the GitHub repository and this llms.txt file, then ask it to install codex-profile and run codex-profile cli work to start Codex on an isolated work profile. Coding agents working inside a clone of the repository can read its AGENTS.md file for setup, test, and usage instructions.</p>
+          <p>Yes. Point your AI assistant or coding agent at the GitHub repository and this llms.txt file, then ask it to install codex-profile, initialize work, and run codex-profile cli work to start Codex on that profile. Coding agents working inside a clone of the repository can read its AGENTS.md file for setup, test, and usage instructions.</p>
         </article>
         <article>
           <h3>Why does fork fail with rollout path must be in Codex home directory?</h3>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -44,6 +44,10 @@ homes and, on macOS, named ChatGPT windows with separate local state.
   and mention that directory in the error. `history.jsonl` and
   `session_index.jsonl` hold no rollout paths; sharing them leaks prompt
   history and thread names across homes instead.
+- `doctor` reports symlinked profile homes and symlinked or hard-linked private
+  state, including `auth.json`, session stores, history indexes, logs, and
+  Electron data. It does not flag the documented `init --share-with`
+  configuration allowlist.
 - Desktop account identity follows `auth.json` in the active `CODEX_HOME`, not
   Electron user-data alone. Pointing a named window at a shared home without
   selecting that account's `auth.json` leaves the previous login on screen.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -52,6 +52,8 @@ homes and, on macOS, named ChatGPT windows with separate local state.
   contract change.
 - Desktop launch refuses an inherited CODEX_ACCESS_TOKEN so a shell access
   token cannot silently override the selected window.
+- `upgrade` defaults to the latest immutable final GitHub Release and checks
+  out its detached tag; `--ref main` is an explicit unreleased source update.
 - CLI-oriented commands support macOS and Linux. Desktop launching is
   macOS-only.
 - The project is community-maintained and is not affiliated with OpenAI.
@@ -71,6 +73,8 @@ homes and, on macOS, named ChatGPT windows with separate local state.
 ```sh
 npm install -g codex-profile
 brew install Ducksss/tap/codex-profile
+curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/install.sh | CODEX_PROFILE_VERSION=v0.9.1 sh
+nix run github:Ducksss/codex-profiles/v0.9.1
 codex-profile doctor
 ```
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,6 +11,9 @@ homes and, on macOS, named ChatGPT windows with separate local state.
 - Installed commands are `codex-profile` and `codex-profiles`.
 - `default` maps to `~/.codex`; every other valid name `<x>` maps to
   `~/.codex-<x>`.
+- `init` is the only command that creates a profile. `cli`, `login`, `app`, and
+  the target of `clone-config` require an initialized profile and fail on a
+  missing name instead of materializing it.
 - `cli`, `login`, `env`, and `use` select Codex-local state through
   `CODEX_HOME`. They do not switch an open ChatGPT window.
 - `app default` uses `~/.codex` and preserves the normal stock ChatGPT desktop
@@ -48,6 +51,9 @@ homes and, on macOS, named ChatGPT windows with separate local state.
   state, including `auth.json`, session stores, history indexes, logs, and
   Electron data. It does not flag the documented `init --share-with`
   configuration allowlist.
+- `doctor --check` exits nonzero for unhealthy local state or a missing CLI.
+  Doctor JSON includes top-level `healthy` and workspace `schema_version`
+  fields.
 - Desktop account identity follows `auth.json` in the active `CODEX_HOME`, not
   Electron user-data alone. Pointing a named window at a shared home without
   selecting that account's `auth.json` leaves the previous login on screen.
@@ -58,6 +64,9 @@ homes and, on macOS, named ChatGPT windows with separate local state.
   token cannot silently override the selected window.
 - `upgrade` defaults to the latest immutable final GitHub Release and checks
   out its detached tag; `--ref main` is an explicit unreleased source update.
+- Source upgrade refuses package-managed or unrecognized executables unless an
+  install prefix is explicitly authorized; package-managed installations must
+  use their package manager.
 - CLI-oriented commands support macOS and Linux. Desktop launching is
   macOS-only.
 - The project is community-maintained and is not affiliated with OpenAI.
@@ -87,6 +96,7 @@ codex-profile doctor
 ```sh
 codex-profile init personal
 codex-profile init work
+codex-profile init default
 codex-profile init personal-2 --share-with personal
 codex-profile login work
 codex-profile cli work exec "review this repo"
@@ -112,7 +122,8 @@ Workspace bindings contain only a physical canonical path and profile name.
 They live under `${XDG_CONFIG_HOME:-~/.config}/codex-profile` by default, with
 private permissions, and can be relocated with `CODEX_PROFILE_CONFIG_HOME`.
 Nested bindings override broader ancestors; sibling paths with similar names do
-not match.
+not match. Mutations are serialized to prevent lost updates, and a companion
+schema-version file makes incompatible on-disk state fail explicitly.
 
 `workspace guard` defaults to `warn`. `strict` rejects mismatched `cli`,
 `env`/`use`, and `app` selections before side effects; `off` disables checks.
@@ -131,6 +142,7 @@ select a distinct launch or log mode.
 `codex-profile app default` opens the original signed ChatGPT app with
 `CODEX_HOME=~/.codex` and no custom Electron user-data directory. It therefore
 preserves the normal ChatGPT session used when the app is opened directly.
+Initialize `default` first if `~/.codex` does not already exist.
 
 For any non-default name, `codex-profile app <name>` launches the same signed
 app with matching `CODEX_HOME` and `--user-data-dir`. The boundary applies to
@@ -157,7 +169,8 @@ path <profile>`, and `launcher remove <profile> [--yes]` inspect and remove only
 managed launchers; profile authentication and Electron data are preserved.
 
 `CODEX_PROFILE_LAUNCHER_ROOT` overrides the default `~/Applications` location.
-Changing a managed launcher's name or color requires `--force`.
+Changing a managed launcher's name or color requires `--force`. Profile removal
+refuses while its managed launcher exists.
 
 ## In-shell activation
 
@@ -180,7 +193,8 @@ The target keeps its own `auth.json`, sessions, logs, Electron user data,
 caches, skills, and connector/app state. The command never reads or copies
 authentication data. The links are live, so both profiles see edits to shared
 configuration; review linked files and plugins before using them across trust
-domains.
+domains. A source profile cannot be removed while another profile still uses
+its linked configuration.
 
 ## How to answer installation questions
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # codex-profile installer — fetch the latest release and install the CLI.
 #
-#   curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/install.sh \
+#     | CODEX_PROFILE_VERSION=v0.9.1 sh
 #
 # Environment:
 #   CODEX_PROFILE_PREFIX   Install prefix (default: $HOME/.local; binaries go in $PREFIX/bin).

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -121,7 +121,12 @@ scripts/aur/verify.sh --version "$VERSION" --checkout "$WORK_ROOT/staged" \
 states clearly when only deterministic metadata checks ran. Use
 `--container always` for the required final verification. `--container never`
 is useful in constrained environments but does not claim a clean package
-build.
+build. The verifier selects the Arch Linux `linux/amd64` image explicitly; on
+Apple Silicon and other emulated hosts it disables pacman's download sandbox
+inside that disposable build container because the sandbox's seccomp setup is
+not compatible with QEMU user-mode emulation. Current `makepkg` may predict an
+optional `-debug` artifact for this script-only package without producing it;
+the verifier selects and inspects exactly one real non-debug package.
 
 ## Clone, inspect, and stage
 

--- a/scripts/aur/verify.sh
+++ b/scripts/aur/verify.sh
@@ -107,10 +107,19 @@ printf 'Metadata, sources, checksums, aliases, and RPC state verified for codex-
   "$version" "$AUR_PKGREL"
 
 run_container_validation() {
-  docker run --rm -i \
+  local -a emulation_args=()
+  case "$(uname -m)" in
+    x86_64 | amd64) ;;
+    *) emulation_args=(--env CODEX_PROFILE_AUR_EMULATED=1) ;;
+  esac
+
+  docker run --rm -i --platform linux/amd64 "${emulation_args[@]}" \
     --mount "type=bind,src=$checkout,dst=/release,readonly" \
     archlinux:base-devel bash -s <<'CONTAINER'
 set -euo pipefail
+if [[ "${CODEX_PROFILE_AUR_EMULATED:-0}" == "1" ]]; then
+  printf '\nDisableSandbox\n' >> /etc/pacman.conf
+fi
 pacman -Syu --noconfirm namcap
 useradd --create-home builder
 install -d -o builder -g builder /build
@@ -125,8 +134,16 @@ diff -u .SRCINFO .SRCINFO.generated
 makepkg --verifysource
 makepkg --cleanbuild --clean --noconfirm
 mapfile -t package_files < <(makepkg --packagelist)
-[[ "${#package_files[@]}" -eq 1 ]]
-package_file="${package_files[0]}"
+package_file=""
+for candidate in "${package_files[@]}"; do
+  case "$(basename "$candidate")" in *-debug-*) continue ;; esac
+  [[ -z "$package_file" ]] || {
+    printf 'Multiple non-debug packages were predicted.\n' >&2
+    exit 1
+  }
+  package_file="$candidate"
+done
+[[ -n "$package_file" && -f "$package_file" ]]
 namcap PKGBUILD | tee namcap-pkgbuild.log
 namcap "$package_file" | tee namcap-package.log
 ! grep -Eq '(^|[[:space:]])E:' namcap-pkgbuild.log namcap-package.log

--- a/scripts/aur/verify.sh
+++ b/scripts/aur/verify.sh
@@ -107,13 +107,14 @@ printf 'Metadata, sources, checksums, aliases, and RPC state verified for codex-
   "$version" "$AUR_PKGREL"
 
 run_container_validation() {
-  local -a emulation_args=()
+  local emulated=0
   case "$(uname -m)" in
     x86_64 | amd64) ;;
-    *) emulation_args=(--env CODEX_PROFILE_AUR_EMULATED=1) ;;
+    *) emulated=1 ;;
   esac
 
-  docker run --rm -i --platform linux/amd64 "${emulation_args[@]}" \
+  docker run --rm -i --platform linux/amd64 \
+    --env "CODEX_PROFILE_AUR_EMULATED=$emulated" \
     --mount "type=bind,src=$checkout,dst=/release,readonly" \
     archlinux:base-devel bash -s <<'CONTAINER'
 set -euo pipefail

--- a/scripts/migrate-outreach-to-neon.mjs
+++ b/scripts/migrate-outreach-to-neon.mjs
@@ -336,7 +336,7 @@ function databaseConnection() {
   const env = { ...process.env };
   delete env.NEON_DATABASE_URL;
   if (!value.includes('://')) {
-    if (/\s|=/.test(value)) {
+    if (/^-|\s|=/.test(value)) {
       fail('NEON_DATABASE_URL must be a PostgreSQL URL or a plain database name.', 2);
     }
     return { argument: value, env };
@@ -367,7 +367,7 @@ function databaseConnection() {
 function psql(args, input) {
   const connection = databaseConnection();
   for (let attempt = 0; attempt < 3; attempt++) {
-    const result = spawnSync('psql', ['-X', connection.argument, ...args], {
+    const result = spawnSync('psql', ['-X', '--dbname', connection.argument, ...args], {
       cwd: ROOT,
       env: connection.env,
       input,

--- a/scripts/outreach-neon-schema.sql
+++ b/scripts/outreach-neon-schema.sql
@@ -141,6 +141,13 @@ CREATE TABLE IF NOT EXISTS public.claims (
 CREATE INDEX IF NOT EXISTS targets_status_idx ON public.targets(status);
 CREATE INDEX IF NOT EXISTS targets_priority_idx ON public.targets(priority);
 CREATE INDEX IF NOT EXISTS targets_channel_idx ON public.targets(channel);
+CREATE INDEX IF NOT EXISTS log_targets_target_key_idx ON public.log_targets(target_key);
+CREATE INDEX IF NOT EXISTS target_bots_bot_id_idx ON public.target_bots(bot_id);
+CREATE INDEX IF NOT EXISTS merge_queue_proposers_bot_id_idx ON public.merge_queue_proposers(bot_id);
+CREATE INDEX IF NOT EXISTS merge_queue_duplicates_duplicate_of_key_idx
+  ON public.merge_queue_duplicates(duplicate_of_key);
+CREATE INDEX IF NOT EXISTS merge_queue_targets_target_key_idx ON public.merge_queue_targets(target_key);
+CREATE INDEX IF NOT EXISTS claims_target_key_idx ON public.claims(target_key);
 CREATE INDEX IF NOT EXISTS claims_active_idx
   ON public.claims(target_key, expires_at)
   WHERE released_at IS NULL;

--- a/scripts/release/deploy-pages.sh
+++ b/scripts/release/deploy-pages.sh
@@ -16,8 +16,8 @@ release_require_env GITHUB_REPOSITORY
 release_require_env GITHUB_SHA
 pages_correlation="release-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
 pages_run_title="Deploy Pages from $TAG ($pages_correlation)"
-gh workflow run pages.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" \
-  -f release_correlation="$pages_correlation"
+gh workflow run pages.yml --repo "$GITHUB_REPOSITORY" --ref main \
+  -f release_tag="$TAG" -f release_correlation="$pages_correlation"
 run_id=""
 for _attempt in {1..30}; do
   run_id="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow pages.yml \

--- a/scripts/release/deploy-pages.sh
+++ b/scripts/release/deploy-pages.sh
@@ -13,7 +13,6 @@ release_require_env V
 release_require_env GITHUB_RUN_ID
 release_require_env GITHUB_RUN_ATTEMPT
 release_require_env GITHUB_REPOSITORY
-release_require_env GITHUB_SHA
 pages_correlation="release-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
 pages_run_title="Deploy Pages from $TAG ($pages_correlation)"
 gh workflow run pages.yml --repo "$GITHUB_REPOSITORY" --ref main \
@@ -21,7 +20,7 @@ gh workflow run pages.yml --repo "$GITHUB_REPOSITORY" --ref main \
 run_id=""
 for _attempt in {1..30}; do
   run_id="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow pages.yml \
-    --commit "$GITHUB_SHA" --event workflow_dispatch --limit 20 \
+    --event workflow_dispatch --limit 20 \
     --json databaseId,displayTitle \
     --jq "map(select(.displayTitle == \"$pages_run_title\"))[0].databaseId // empty")"
   [[ -z "$run_id" ]] || break

--- a/scripts/release/verify-pages-source.sh
+++ b/scripts/release/verify-pages-source.sh
@@ -24,3 +24,46 @@ IFS=$'\t' read -r tag immutable draft prerelease <<< "$state"
 [[ "$tag" == "$release_tag" && "$immutable" == true \
   && "$draft" == false && "$prerelease" == false ]] \
   || release_die "Pages source $release_tag is not an immutable final GitHub Release"
+
+tag_ref_state="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$release_tag" \
+  --jq '[.ref, .object.type, .object.sha] | @tsv')" \
+  || release_die "Could not resolve Git tag $release_tag"
+IFS=$'\t' read -r tag_ref object_type object_sha <<< "$tag_ref_state"
+[[ "$tag_ref" == "refs/tags/$release_tag" \
+  && "$object_type" =~ ^(commit|tag)$ \
+  && "$object_sha" =~ ^[0-9a-f]{40,64}$ ]] \
+  || release_die "Git tag $release_tag did not resolve to a valid Git object"
+
+# Release automation creates annotated tags, while older repositories may have
+# lightweight tags. Resolve either form to an exact commit before comparing it
+# with main so a same-named branch cannot influence the ancestry check.
+for _depth in 1 2 3 4 5; do
+  [[ "$object_type" != commit ]] || break
+  [[ "$object_type" == tag ]] \
+    || release_die "Git tag $release_tag points to unsupported object type $object_type"
+
+  tag_object_state="$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$object_sha" \
+    --jq '[.object.type, .object.sha] | @tsv')" \
+    || release_die "Could not resolve annotated Git tag $release_tag"
+  IFS=$'\t' read -r object_type object_sha <<< "$tag_object_state"
+  [[ "$object_type" =~ ^(commit|tag)$ \
+    && "$object_sha" =~ ^[0-9a-f]{40,64}$ ]] \
+    || release_die "Git tag $release_tag did not resolve to a valid Git object"
+done
+[[ "$object_type" == commit ]] \
+  || release_die "Git tag $release_tag has too many nested tag objects"
+
+tag_commit="$object_sha"
+ancestry_state="$(gh api "repos/$GITHUB_REPOSITORY/compare/$tag_commit...main" \
+  --jq '[.status, .base_commit.sha, .merge_base_commit.sha, (.behind_by|tostring)] | @tsv')" \
+  || release_die "Could not compare Git tag $release_tag with main"
+IFS=$'\t' read -r comparison base_commit merge_base behind_by <<< "$ancestry_state"
+[[ ( "$comparison" == ahead || "$comparison" == identical ) \
+  && "$base_commit" == "$tag_commit" \
+  && "$merge_base" == "$tag_commit" \
+  && "$behind_by" == 0 ]] \
+  || release_die "Pages source $release_tag is not contained in main"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  printf 'commit=%s\n' "$tag_commit" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/release/verify-pages-source.sh
+++ b/scripts/release/verify-pages-source.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/release/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+release_require_env GITHUB_REF
+release_require_env GITHUB_REPOSITORY
+[[ "$GITHUB_REF" == "refs/heads/main" ]] \
+  || release_die "Pages must run from main, not $GITHUB_REF"
+
+release_tag="${RELEASE_TAG:-}"
+[[ -n "$release_tag" ]] || exit 0
+[[ "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+  || release_die "Pages release tag must exactly match vX.Y.Z"
+command -v gh >/dev/null 2>&1 || release_die "gh is required to validate a Pages release tag"
+
+state="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$release_tag" \
+  --jq '[.tag_name, (.immutable|tostring), (.draft|tostring), (.prerelease|tostring)] | @tsv')" \
+  || release_die "Could not load GitHub Release $release_tag"
+IFS=$'\t' read -r tag immutable draft prerelease <<< "$state"
+[[ "$tag" == "$release_tag" && "$immutable" == true \
+  && "$draft" == false && "$prerelease" == false ]] \
+  || release_die "Pages source $release_tag is not an immutable final GitHub Release"

--- a/scripts/release/verify-source.sh
+++ b/scripts/release/verify-source.sh
@@ -72,6 +72,20 @@ check_version docs/index.html "$(sed -n 's/.*"softwareVersion": "\([^"]*\)".*/\1
 check_version docs-visible-version "$(sed -n 's|.*<span>v\([0-9][^<]*\)</span>.*|\1|p' docs/index.html | head -n 1)"
 check_version packaging/aur/PKGBUILD "$(sed -n 's/^pkgver=//p' packaging/aur/PKGBUILD | head -n 1)"
 check_version packaging/aur/.SRCINFO "$(sed -n 's/^\tpkgver = //p' packaging/aur/.SRCINFO | head -n 1)"
+grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" README.md >/dev/null \
+  || { echo "README.md standalone installer must use immutable v$version." >&2; exit 1; }
+grep -F "CODEX_PROFILE_VERSION=v$version sh" README.md >/dev/null \
+  || { echo "README.md standalone installer must request v$version." >&2; exit 1; }
+grep -F "github:Ducksss/codex-profiles/v$version" README.md >/dev/null \
+  || { echo "README.md Nix commands must use immutable v$version." >&2; exit 1; }
+grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" docs/llms.txt >/dev/null \
+  || { echo "docs/llms.txt standalone installer must use immutable v$version." >&2; exit 1; }
+grep -F "CODEX_PROFILE_VERSION=v$version sh" docs/llms.txt >/dev/null \
+  || { echo "docs/llms.txt standalone installer must request v$version." >&2; exit 1; }
+grep -F "github:Ducksss/codex-profiles/v$version" docs/llms.txt >/dev/null \
+  || { echo "docs/llms.txt Nix command must use immutable v$version." >&2; exit 1; }
+grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" install.sh >/dev/null \
+  || { echo "install.sh usage must use immutable v$version." >&2; exit 1; }
 
 changelog_version="${version//./\.}"
 if ! grep -Eq "^## $changelog_version - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md; then

--- a/scripts/release/verify-source.sh
+++ b/scripts/release/verify-source.sh
@@ -90,11 +90,11 @@ for public_document in README.md docs/llms.txt install.sh; do
   while IFS= read -r installer_reference; do
     [[ "$installer_reference" == "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" ]] \
       || { echo "$public_document publishes non-release installer reference $installer_reference." >&2; exit 1; }
-  done < <(grep -Eo 'https://raw\.githubusercontent\.com/Ducksss/codex-profiles/[^/[:space:]]+/install\.sh' "$public_document" || true)
+  done < <(grep -Eo 'https://raw\.githubusercontent\.com/Ducksss/codex-profiles/[^[:space:]]+' "$public_document" || true)
   while IFS= read -r nix_reference; do
     [[ "$nix_reference" == "github:Ducksss/codex-profiles/v$version" ]] \
       || { echo "$public_document publishes non-release Nix reference $nix_reference." >&2; exit 1; }
-  done < <(grep -Eo 'github:Ducksss/codex-profiles(/[A-Za-z0-9._/-]+)?' "$public_document" || true)
+  done < <(grep -Eo 'github:Ducksss/codex-profiles[^[:space:]]*' "$public_document" || true)
 done
 
 changelog_version="${version//./\.}"

--- a/scripts/release/verify-source.sh
+++ b/scripts/release/verify-source.sh
@@ -87,14 +87,14 @@ grep -F "github:Ducksss/codex-profiles/v$version" docs/llms.txt >/dev/null \
 grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" install.sh >/dev/null \
   || { echo "install.sh usage must use immutable v$version." >&2; exit 1; }
 for public_document in README.md docs/llms.txt install.sh; do
-  for mutable_reference in \
-    'raw.githubusercontent.com/Ducksss/codex-profiles/main/install.sh' \
-    'github:Ducksss/codex-profiles/main'; do
-    if grep -F "$mutable_reference" "$public_document" >/dev/null; then
-      echo "$public_document must not publish mutable reference $mutable_reference." >&2
-      exit 1
-    fi
-  done
+  while IFS= read -r installer_reference; do
+    [[ "$installer_reference" == "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" ]] \
+      || { echo "$public_document publishes non-release installer reference $installer_reference." >&2; exit 1; }
+  done < <(grep -Eo 'https://raw\.githubusercontent\.com/Ducksss/codex-profiles/[^/[:space:]]+/install\.sh' "$public_document" || true)
+  while IFS= read -r nix_reference; do
+    [[ "$nix_reference" == "github:Ducksss/codex-profiles/v$version" ]] \
+      || { echo "$public_document publishes non-release Nix reference $nix_reference." >&2; exit 1; }
+  done < <(grep -Eo 'github:Ducksss/codex-profiles(/[A-Za-z0-9._/-]+)?' "$public_document" || true)
 done
 
 changelog_version="${version//./\.}"

--- a/scripts/release/verify-source.sh
+++ b/scripts/release/verify-source.sh
@@ -86,6 +86,16 @@ grep -F "github:Ducksss/codex-profiles/v$version" docs/llms.txt >/dev/null \
   || { echo "docs/llms.txt Nix command must use immutable v$version." >&2; exit 1; }
 grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" install.sh >/dev/null \
   || { echo "install.sh usage must use immutable v$version." >&2; exit 1; }
+for public_document in README.md docs/llms.txt install.sh; do
+  for mutable_reference in \
+    'raw.githubusercontent.com/Ducksss/codex-profiles/main/install.sh' \
+    'github:Ducksss/codex-profiles/main'; do
+    if grep -F "$mutable_reference" "$public_document" >/dev/null; then
+      echo "$public_document must not publish mutable reference $mutable_reference." >&2
+      exit 1
+    fi
+  done
+done
 
 changelog_version="${version//./\.}"
 if ! grep -Eq "^## $changelog_version - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md; then

--- a/test/cli/desktop-test.sh
+++ b/test/cli/desktop-test.sh
@@ -8,6 +8,26 @@ TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
 source "$ROOT_DIR/test/lib/cli-fixtures.sh"
 
+test_app_requires_an_initialized_profile() {
+  local tmp chatgpt_app fake_bin tool_log
+  tmp="$(mktemp -d)"
+  chatgpt_app="$tmp/ChatGPT.app"
+  fake_bin="$tmp/bin"
+  tool_log="$tmp/tool.log"
+  write_fake_chatgpt_app_bundle "$chatgpt_app" "must not launch"
+  write_fake_chatgpt_open_tools "$fake_bin"
+
+  run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
+    CHATGPT_APP="$chatgpt_app" "$SCRIPT" app typo
+
+  assert_status 1
+  assert_contains "Profile 'typo' is not initialized"
+  [[ ! -e "$tmp/home/.codex-typo" ]] || fail "app created an uninitialized profile"
+  [[ ! -e "$tool_log" ]] || ! grep -q '^open ' "$tool_log" || fail "app launched an uninitialized profile"
+
+  rm -rf "$tmp"
+}
+
 test_app_named_profile_uses_separate_local_state_for_the_whole_chatgpt_window() {
   local tmp chatgpt_app ignored_app fake_bin tool_log profile_home user_data_dir log_file
   tmp="$(mktemp -d)"
@@ -21,6 +41,7 @@ test_app_named_profile_uses_separate_local_state_for_the_whole_chatgpt_window() 
   write_fake_chatgpt_app_bundle "$chatgpt_app" "named ChatGPT launch"
   write_fake_chatgpt_app_bundle "$ignored_app" "wrong legacy app"
   write_fake_chatgpt_open_tools "$fake_bin"
+  mkdir -p "$profile_home"
 
   run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
     CHATGPT_APP="$chatgpt_app" CODEX_APP="$ignored_app" \
@@ -58,6 +79,7 @@ test_app_default_reuses_the_stock_chatgpt_session() {
   log_file="$profile_home/logs/desktop.log"
   write_fake_chatgpt_app_bundle "$chatgpt_app" "default ChatGPT launch"
   write_fake_chatgpt_open_tools "$fake_bin"
+  mkdir -p "$profile_home"
 
   run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
     CHATGPT_APP="$chatgpt_app" CODEX_ELECTRON_USER_DATA_PATH="$tmp/inherited-electron-user-data" \
@@ -86,6 +108,7 @@ test_app_legacy_instance_flags_use_the_same_signed_app_launcher() {
   user_data_dir="$profile_home/electron-user-data"
   write_fake_chatgpt_app_bundle "$chatgpt_app" "compatibility launch"
   write_fake_chatgpt_open_tools "$fake_bin"
+  mkdir -p "$profile_home"
 
   run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
     CHATGPT_APP="$chatgpt_app" CODEX_PROFILE_APP_INSTANCE_ROOT="$tmp/instances" \
@@ -119,6 +142,7 @@ test_app_rebuild_is_accepted_as_a_compatibility_noop() {
   tool_log="$tmp/tool.log"
   write_fake_chatgpt_app_bundle "$chatgpt_app" "rebuild compatibility launch"
   write_fake_chatgpt_open_tools "$fake_bin"
+  mkdir -p "$tmp/home/.codex-work"
 
   run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
     CHATGPT_APP="$chatgpt_app" "$SCRIPT" app work --rebuild "$tmp/workspace"
@@ -135,7 +159,7 @@ test_cli_falls_back_to_the_bundled_cli_when_path_codex_is_broken() {
   chatgpt_app="$tmp/ChatGPT.app"
   fake_bin="$tmp/bin"
   broken_codex="$fake_bin/codex"
-  mkdir -p "$fake_bin"
+  mkdir -p "$fake_bin" "$tmp/home/.codex-work"
   write_fake_chatgpt_app_bundle "$chatgpt_app" "unused"
   cat > "$broken_codex" <<'BROKEN_CODEX'
 #!/usr/bin/env bash
@@ -161,7 +185,7 @@ test_healthy_path_cli_keeps_priority_over_the_bundled_cli() {
   chatgpt_app="$tmp/ChatGPT.app"
   fake_bin="$tmp/bin"
   path_codex="$fake_bin/codex"
-  mkdir -p "$fake_bin"
+  mkdir -p "$fake_bin" "$tmp/home/.codex-work"
   write_fake_chatgpt_app_bundle "$chatgpt_app" "unused"
   cat > "$path_codex" <<'PATH_CODEX'
 #!/usr/bin/env bash
@@ -194,6 +218,7 @@ test_legacy_codex_app_bin_locates_its_signed_app_bundle() {
   executable="$chatgpt_app/Contents/MacOS/ChatGPT"
   write_fake_chatgpt_app_bundle "$chatgpt_app" "legacy executable override"
   write_fake_chatgpt_open_tools "$fake_bin"
+  mkdir -p "$tmp/home/.codex"
 
   run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
     CODEX_APP_BIN="$executable" "$SCRIPT" app default "$tmp/workspace"
@@ -214,6 +239,7 @@ test_legacy_codex_app_bin_rejects_a_different_executable_in_the_bundle() {
   wrong_executable="$chatgpt_app/Contents/MacOS/wrong-name"
   write_fake_chatgpt_app_bundle "$chatgpt_app" "must not launch"
   write_fake_chatgpt_open_tools "$fake_bin"
+  mkdir -p "$tmp/home/.codex"
   printf '#!/bin/sh\nexit 0\n' > "$wrong_executable"
   chmod 755 "$wrong_executable"
 
@@ -236,6 +262,7 @@ test_invalid_chatgpt_app_override_does_not_fall_back_silently() {
   tool_log="$tmp/tool.log"
   write_fake_chatgpt_app_bundle "$fallback_app" "must not launch"
   write_fake_chatgpt_open_tools "$fake_bin"
+  mkdir -p "$tmp/home/.codex"
 
   run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
     CHATGPT_APP="$tmp/missing/ChatGPT.app" CODEX_APP="$fallback_app" \
@@ -252,11 +279,12 @@ test_explicit_codex_cli_must_be_healthy() {
   local tmp broken_codex
   tmp="$(mktemp -d)"
   broken_codex="$tmp/codex"
-  cat > "$broken_codex" <<'BROKEN_CODEX'
+cat > "$broken_codex" <<'BROKEN_CODEX'
 #!/usr/bin/env bash
 exit 72
 BROKEN_CODEX
   chmod 755 "$broken_codex"
+  mkdir -p "$tmp/home/.codex-work"
 
   run_cmd env HOME="$tmp/home" CODEX_CLI="$broken_codex" "$SCRIPT" cli work
 
@@ -274,6 +302,7 @@ test_app_refuses_access_token_override() {
   tool_log="$tmp/tool.log"
   write_fake_chatgpt_app_bundle "$chatgpt_app" "should not launch"
   write_fake_chatgpt_open_tools "$fake_bin"
+  mkdir -p "$tmp/home/.codex-work"
 
   run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
     CHATGPT_APP="$chatgpt_app" CODEX_ACCESS_TOKEN=secret "$SCRIPT" app work
@@ -352,6 +381,7 @@ test_app_propagates_open_failures() {
   tool_log="$tmp/tool.log"
   write_fake_chatgpt_app_bundle "$chatgpt_app" "should not launch"
   write_fake_chatgpt_open_tools "$fake_bin"
+  mkdir -p "$tmp/home/.codex-work"
 
   run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
     FAKE_OPEN_EXIT=70 CHATGPT_APP="$chatgpt_app" "$SCRIPT" app work
@@ -422,6 +452,7 @@ FAKE_CODEX
   rm -rf "$tmp"
 }
 
+test_app_requires_an_initialized_profile
 test_app_named_profile_uses_separate_local_state_for_the_whole_chatgpt_window
 test_app_default_reuses_the_stock_chatgpt_session
 test_app_legacy_instance_flags_use_the_same_signed_app_launcher

--- a/test/cli/desktop-test.sh
+++ b/test/cli/desktop-test.sh
@@ -308,6 +308,42 @@ test_named_app_user_data_symlinks_are_refused() {
   rm -rf "$tmp"
 }
 
+test_app_refuses_linked_desktop_logs_without_touching_the_target() {
+  local tmp chatgpt_app fake_bin tool_log profile_home log_file victim
+  tmp="$(mktemp -d)"
+  chatgpt_app="$tmp/ChatGPT.app"
+  fake_bin="$tmp/bin"
+  tool_log="$tmp/tool.log"
+  profile_home="$tmp/home/.codex-work"
+  log_file="$profile_home/logs/desktop.log"
+  victim="$tmp/must-survive"
+  write_fake_chatgpt_app_bundle "$chatgpt_app" "should not launch"
+  write_fake_chatgpt_open_tools "$fake_bin"
+  mkdir -p "${log_file%/*}"
+  printf 'must survive\n' > "$victim"
+  ln -s "$victim" "$log_file"
+
+  run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
+    CHATGPT_APP="$chatgpt_app" "$SCRIPT" app work
+
+  assert_status 1
+  assert_contains "Refusing symlinked desktop log: $log_file"
+  [[ "$(cat "$victim")" == "must survive" ]] || fail "symlinked desktop log target was modified"
+  [[ ! -e "$tool_log" ]] || ! grep -q '^open ' "$tool_log" || fail "Desktop launched with a symlinked log"
+
+  rm -f "$log_file"
+  ln "$victim" "$log_file"
+  run_cmd env HOME="$tmp/home" PATH="$fake_bin:$PATH" FAKE_TOOL_LOG="$tool_log" \
+    CHATGPT_APP="$chatgpt_app" "$SCRIPT" app work
+
+  assert_status 1
+  assert_contains "Refusing multiply-linked desktop log: $log_file"
+  [[ "$(cat "$victim")" == "must survive" ]] || fail "multiply-linked desktop log target was modified"
+  [[ ! -e "$tool_log" ]] || ! grep -q '^open ' "$tool_log" || fail "Desktop launched with a multiply-linked log"
+
+  rm -rf "$tmp"
+}
+
 test_app_propagates_open_failures() {
   local tmp chatgpt_app fake_bin tool_log
   tmp="$(mktemp -d)"
@@ -398,5 +434,6 @@ test_invalid_chatgpt_app_override_does_not_fall_back_silently
 test_explicit_codex_cli_must_be_healthy
 test_app_refuses_access_token_override
 test_named_app_user_data_symlinks_are_refused
+test_app_refuses_linked_desktop_logs_without_touching_the_target
 test_app_propagates_open_failures
 test_doctor_reports_desktop_and_cli_when_present

--- a/test/cli/launcher-test.sh
+++ b/test/cli/launcher-test.sh
@@ -208,6 +208,31 @@ test_launcher_remove_preserves_profile_data() {
   rm -rf "$tmp"
 }
 
+test_profile_remove_refuses_managed_launcher_orphans() {
+  local tmp profile_home app
+  tmp="$(mktemp -d)"
+  profile_home="$tmp/home/.codex-personal"
+  app="$tmp/apps/ChatGPT Personal.app"
+  prepare_launcher_test "$tmp" personal
+
+  run_cmd launcher_env "$tmp" "$SCRIPT" launcher create personal --name "ChatGPT Personal" --color blue
+  assert_status 0
+
+  run_cmd launcher_env "$tmp" "$SCRIPT" remove personal --yes
+  assert_status 1
+  assert_contains "managed launcher exists at $app"
+  assert_contains "launcher remove personal"
+  [[ -d "$profile_home" && -d "$app" ]] || fail "refused profile removal changed profile or launcher data"
+
+  run_cmd launcher_env "$tmp" "$SCRIPT" launcher remove personal --yes
+  assert_status 0
+  run_cmd launcher_env "$tmp" "$SCRIPT" remove personal --yes
+  assert_status 0
+  [[ ! -e "$profile_home" && ! -e "$app" ]] || fail "explicit launcher and profile removal left managed state"
+
+  rm -rf "$tmp"
+}
+
 test_launcher_recovers_after_the_bundle_is_deleted_outside_the_cli() {
   local tmp stale_app healthy_app json
   tmp="$(mktemp -d)"
@@ -263,6 +288,7 @@ test_launcher_create_is_idempotent_and_force_replaces_managed_bundle
 test_launcher_refuses_invalid_inputs_and_unmanaged_collisions
 test_launcher_cleans_up_a_failed_icon_build
 test_launcher_remove_preserves_profile_data
+test_profile_remove_refuses_managed_launcher_orphans
 test_launcher_recovers_after_the_bundle_is_deleted_outside_the_cli
 
 printf 'launcher tests passed\n'

--- a/test/cli/profiles-test.sh
+++ b/test/cli/profiles-test.sh
@@ -29,6 +29,7 @@ test_cli_passes_profile_home_and_args() {
   local tmp fake_codex
   tmp="$(mktemp -d)"
   fake_codex="$tmp/codex"
+  mkdir -p "$tmp/home/.codex-personal"
   cat > "$fake_codex" <<'FAKE_CODEX'
 #!/usr/bin/env bash
 printf 'CODEX_HOME=%s\n' "$CODEX_HOME"
@@ -41,7 +42,7 @@ FAKE_CODEX
   assert_status 0
   assert_contains "CODEX_HOME=$tmp/home/.codex-personal"
   assert_contains "ARGS=exec run tests"
-  [[ -d "$tmp/home/.codex-personal" ]] || fail "cli did not initialize profile home"
+  [[ -d "$tmp/home/.codex-personal" ]] || fail "cli removed the initialized profile home"
 
   rm -rf "$tmp"
 }
@@ -50,6 +51,7 @@ test_login_passes_profile_home_and_login_args() {
   local tmp fake_codex
   tmp="$(mktemp -d)"
   fake_codex="$tmp/codex"
+  mkdir -p "$tmp/home/.codex-work"
   cat > "$fake_codex" <<'FAKE_CODEX'
 #!/usr/bin/env bash
 printf 'CODEX_HOME=%s\n' "$CODEX_HOME"
@@ -62,7 +64,33 @@ FAKE_CODEX
   assert_status 0
   assert_contains "CODEX_HOME=$tmp/home/.codex-work"
   assert_contains "ARGS=login --device-auth"
-  [[ -d "$tmp/home/.codex-work" ]] || fail "login did not initialize profile home"
+  [[ -d "$tmp/home/.codex-work" ]] || fail "login removed the initialized profile home"
+
+  rm -rf "$tmp"
+}
+
+test_profile_commands_require_explicit_initialization() {
+  local tmp fake_codex
+  tmp="$(mktemp -d)"
+  fake_codex="$tmp/codex"
+  write_fake_codex "$fake_codex"
+
+  run_cmd env HOME="$tmp/home" CODEX_CLI="$fake_codex" "$SCRIPT" cli typo exec check
+  assert_status 1
+  assert_contains "Profile 'typo' is not initialized"
+  [[ ! -e "$tmp/home/.codex-typo" ]] || fail "cli created an uninitialized profile"
+
+  run_cmd env HOME="$tmp/home" CODEX_CLI="$fake_codex" "$SCRIPT" login typo
+  assert_status 1
+  assert_contains "Profile 'typo' is not initialized"
+  [[ ! -e "$tmp/home/.codex-typo" ]] || fail "login created an uninitialized profile"
+
+  mkdir -p "$tmp/home/.codex-source"
+  printf 'model = "gpt-5"\n' > "$tmp/home/.codex-source/config.toml"
+  run_cmd env HOME="$tmp/home" "$SCRIPT" clone-config source typo
+  assert_status 1
+  assert_contains "Profile 'typo' is not initialized"
+  [[ ! -e "$tmp/home/.codex-typo" ]] || fail "clone-config created an uninitialized target profile"
 
   rm -rf "$tmp"
 }
@@ -142,6 +170,10 @@ test_init_creates_private_profile_home_without_codex() {
   assert_contains "Initialized personal ($profile_home)"
   [[ -d "$profile_home" ]] || fail "init did not create profile home"
   [[ "$(mode_of "$profile_home")" == "700" ]] || fail "profile home is not private"
+  [[ "$(cat "$tmp/home/.config/codex-profile/state-version")" == "1" ]] || \
+    fail "init did not record the state schema version"
+  [[ ! -e "$tmp/home/.config/codex-profile/mutation.lock" ]] || \
+    fail "init left its state mutation lock behind"
 
   run_cmd env HOME="$tmp/home" CODEX_CLI=/no/such/codex "$SCRIPT" init personal
 
@@ -386,6 +418,32 @@ test_remove_yes_deletes_profiles_named_like_common_aliases() {
   rm -rf "$tmp"
 }
 
+test_remove_refuses_profiles_with_shared_configuration_dependents() {
+  local tmp source_home target_home
+  tmp="$(mktemp -d)"
+  source_home="$tmp/home/.codex-personal"
+  target_home="$tmp/home/.codex-personal-2"
+  mkdir -p "$source_home"
+  printf 'model = "gpt-5"\n' > "$source_home/config.toml"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" init personal-2 --share-with personal
+  assert_status 0
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" remove personal --yes
+  assert_status 1
+  assert_contains "shared configuration is still used by: personal-2"
+  [[ -d "$source_home" && -L "$target_home/config.toml" ]] || \
+    fail "refused source removal changed linked profiles"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" remove personal-2 --yes
+  assert_status 0
+  run_cmd env HOME="$tmp/home" "$SCRIPT" remove personal --yes
+  assert_status 0
+  [[ ! -e "$source_home" ]] || fail "source profile remained after its dependent was removed"
+
+  rm -rf "$tmp"
+}
+
 test_profile_home_symlinks_are_refused() {
   local tmp target
   tmp="$(mktemp -d)"
@@ -406,7 +464,7 @@ test_clone_config_copies_safe_files_and_never_auth_files() {
   tmp="$(mktemp -d)"
   source_home="$tmp/home/.codex-work"
   target_home="$tmp/home/.codex-personal"
-  mkdir -p "$source_home/sessions"
+  mkdir -p "$source_home/sessions" "$target_home"
   printf 'model = "gpt-5"\n' > "$source_home/config.toml"
   printf '# Instructions\n' > "$source_home/AGENTS.md"
   printf '{"token":"secret"}\n' > "$source_home/auth.json"
@@ -430,7 +488,7 @@ test_clone_config_refuses_sensitive_looking_config() {
   tmp="$(mktemp -d)"
   source_home="$tmp/home/.codex-work"
   target_home="$tmp/home/.codex-personal"
-  mkdir -p "$source_home"
+  mkdir -p "$source_home" "$target_home"
   printf 'openai_api_key = "secret"\n' > "$source_home/config.toml"
 
   run_cmd env HOME="$tmp/home" "$SCRIPT" clone-config work personal
@@ -448,7 +506,7 @@ test_clone_config_refuses_symlinked_config_files() {
   source_home="$tmp/home/.codex-work"
   target_home="$tmp/home/.codex-personal"
   outside_file="$tmp/outside-config.toml"
-  mkdir -p "$source_home"
+  mkdir -p "$source_home" "$target_home"
   printf 'model = "gpt-5"\n' > "$outside_file"
   ln -s "$outside_file" "$source_home/config.toml"
 
@@ -509,6 +567,7 @@ test_clone_config_refuses_to_overwrite_without_force() {
 test_version_prints_script_version
 test_cli_passes_profile_home_and_args
 test_login_passes_profile_home_and_login_args
+test_profile_commands_require_explicit_initialization
 test_invalid_profile_names_are_rejected
 test_profile_path_mapping_only_special_cases_default
 test_list_reports_initialized_managed_profiles_without_cli
@@ -520,6 +579,7 @@ test_init_share_with_cleans_up_after_link_failure
 test_remove_aborts_when_confirmation_does_not_match
 test_remove_yes_deletes_profile_home
 test_remove_yes_deletes_profiles_named_like_common_aliases
+test_remove_refuses_profiles_with_shared_configuration_dependents
 test_profile_home_symlinks_are_refused
 test_clone_config_copies_safe_files_and_never_auth_files
 test_clone_config_refuses_sensitive_looking_config

--- a/test/cli/profiles-test.sh
+++ b/test/cli/profiles-test.sh
@@ -160,22 +160,25 @@ test_list_reports_initialized_managed_profiles_without_cli() {
 }
 
 test_init_creates_private_profile_home_without_codex() {
-  local tmp profile_home
+  local tmp profile_home config
   tmp="$(mktemp -d)"
   profile_home="$tmp/home/.codex-personal"
+  config="$tmp/config"
 
-  run_cmd env HOME="$tmp/home" CODEX_CLI=/no/such/codex "$SCRIPT" init personal
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI=/no/such/codex "$SCRIPT" init personal
 
   assert_status 0
   assert_contains "Initialized personal ($profile_home)"
   [[ -d "$profile_home" ]] || fail "init did not create profile home"
   [[ "$(mode_of "$profile_home")" == "700" ]] || fail "profile home is not private"
-  [[ "$(cat "$tmp/home/.config/codex-profile/state-version")" == "1" ]] || \
+  [[ "$(cat "$config/state-version")" == "1" ]] || \
     fail "init did not record the state schema version"
-  [[ ! -e "$tmp/home/.config/codex-profile/mutation.lock" ]] || \
+  [[ ! -e "$config/mutation.lock" ]] || \
     fail "init left its state mutation lock behind"
 
-  run_cmd env HOME="$tmp/home" CODEX_CLI=/no/such/codex "$SCRIPT" init personal
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI=/no/such/codex "$SCRIPT" init personal
 
   assert_status 0
   assert_contains "Already initialized personal ($profile_home)"

--- a/test/cli/shell-test.sh
+++ b/test/cli/shell-test.sh
@@ -107,6 +107,7 @@ test_completions_generate_shell_scripts() {
   assert_contains "run [--] [codex-args...]"
   assert_contains "run --app [workspace]"
   assert_contains "launcher create <profile>"
+  assert_contains "doctor [--json] [--check]"
   assert_contains "CODEX_PROFILE_CONFIG_HOME"
   assert_contains "CODEX_PROFILE_LAUNCHER_ROOT"
 
@@ -121,6 +122,7 @@ test_completions_generate_shell_scripts() {
   # shellcheck disable=SC2016 # matching literal generated completion text
   assert_contains 'compgen -W "$workspace_commands"'
   assert_contains 'compgen -W "--app"'
+  assert_contains 'compgen -W "--json --check"'
   assert_contains "clone-config"
   assert_contains "upgrade"
   assert_contains "--instance"
@@ -140,6 +142,7 @@ test_completions_generate_shell_scripts() {
   assert_contains "workspace_commands=(bind unbind list status guard)"
   assert_contains "run_flags=(--app)"
   assert_contains "workspace_json_flags=(--json)"
+  assert_contains "doctor_flags=(--json --check)"
   assert_contains "logs"
   assert_contains "upgrade"
   assert_contains "--instance"
@@ -157,6 +160,7 @@ test_completions_generate_shell_scripts() {
   assert_contains "-a 'blue green teal purple pink red orange graphite'"
   assert_contains "-a 'bind unbind list status guard'"
   assert_contains "-l app"
+  assert_contains "-l check"
   assert_contains "test (count (commandline -opc)) -eq 2"
   assert_contains "__fish_seen_subcommand_from bind; and test (count (commandline -opc)) -eq 4"
   assert_contains "-F"

--- a/test/cli/shell-test.sh
+++ b/test/cli/shell-test.sh
@@ -96,6 +96,32 @@ test_logs_refuses_linked_log_files() {
   rm -rf "$tmp"
 }
 
+test_logs_refuses_symlinked_parent_directories() {
+  local tmp outside_logs outside_home
+  tmp="$(mktemp -d)"
+  outside_logs="$tmp/outside-logs"
+  outside_home="$tmp/outside-home"
+  mkdir -p "$tmp/home/.codex-personal" "$outside_logs" "$outside_home/logs"
+  printf 'outside directory secret\n' > "$outside_logs/desktop.log"
+  printf 'outside home secret\n' > "$outside_home/logs/desktop.log"
+  ln -s "$outside_logs" "$tmp/home/.codex-personal/logs"
+  ln -s "$outside_home" "$tmp/home/.codex-work"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" logs personal
+
+  assert_status 1
+  assert_contains "Refusing symlinked desktop log directory: $tmp/home/.codex-personal/logs"
+  assert_not_contains "outside directory secret"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" logs work --tail 1
+
+  assert_status 1
+  assert_contains "Refusing symlinked profile home: $tmp/home/.codex-work"
+  assert_not_contains "outside home secret"
+
+  rm -rf "$tmp"
+}
+
 test_completions_generate_shell_scripts() {
   run_cmd "$SCRIPT" help
 
@@ -322,6 +348,7 @@ test_logs_prints_path_and_contents
 test_logs_prints_instance_path_and_contents
 test_logs_reports_missing_log_file
 test_logs_refuses_linked_log_files
+test_logs_refuses_symlinked_parent_directories
 test_completions_generate_shell_scripts
 test_env_prints_posix_exports_for_profile
 test_env_emits_fish_syntax

--- a/test/cli/shell-test.sh
+++ b/test/cli/shell-test.sh
@@ -70,6 +70,32 @@ test_logs_reports_missing_log_file() {
   rm -rf "$tmp"
 }
 
+test_logs_refuses_linked_log_files() {
+  local tmp log_file victim
+  tmp="$(mktemp -d)"
+  log_file="$tmp/home/.codex-personal/logs/desktop.log"
+  victim="$tmp/private-data"
+  mkdir -p "${log_file%/*}"
+  printf 'must not print\n' > "$victim"
+  ln -s "$victim" "$log_file"
+
+  run_cmd env HOME="$tmp/home" "$SCRIPT" logs personal
+
+  assert_status 1
+  assert_contains "Refusing symlinked desktop log: $log_file"
+  assert_not_contains "must not print"
+
+  rm -f "$log_file"
+  ln "$victim" "$log_file"
+  run_cmd env HOME="$tmp/home" "$SCRIPT" logs personal --tail 1
+
+  assert_status 1
+  assert_contains "Refusing multiply-linked desktop log: $log_file"
+  assert_not_contains "must not print"
+
+  rm -rf "$tmp"
+}
+
 test_completions_generate_shell_scripts() {
   run_cmd "$SCRIPT" help
 
@@ -291,6 +317,7 @@ test_shell_init_use_activates_profile_in_current_shell() {
 test_logs_prints_path_and_contents
 test_logs_prints_instance_path_and_contents
 test_logs_reports_missing_log_file
+test_logs_refuses_linked_log_files
 test_completions_generate_shell_scripts
 test_env_prints_posix_exports_for_profile
 test_env_emits_fish_syntax

--- a/test/cli/status-json-test.sh
+++ b/test/cli/status-json-test.sh
@@ -125,6 +125,33 @@ test_doctor_skips_status_when_cli_missing() {
   assert_contains "CLI: missing"
   assert_contains "Status: skipped"
 
+  run_cmd env HOME="$tmp/home" CODEX_CLI=/no/such/codex "$SCRIPT" doctor --check
+
+  assert_status 1
+  assert_contains "CLI: missing"
+
+  rm -rf "$tmp"
+}
+
+test_doctor_check_reports_healthy_state() {
+  local tmp fake_codex
+  tmp="$(mktemp -d)"
+  fake_codex="$tmp/codex"
+  write_fake_codex "$fake_codex"
+  mkdir -p "$tmp/home/.codex-personal"
+
+  run_cmd env HOME="$tmp/home" CODEX_CLI="$fake_codex" "$SCRIPT" doctor --check
+
+  assert_status 0
+  assert_contains "CLI: $fake_codex"
+
+  run_cmd env HOME="$tmp/home" CODEX_CLI="$fake_codex" "$SCRIPT" doctor --json --check
+
+  assert_status 0
+  assert_contains '"healthy":true'
+  assert_contains '"schema_version":"1"'
+  JSON_PAYLOAD="$output" node -e 'JSON.parse(process.env.JSON_PAYLOAD)'
+
   rm -rf "$tmp"
 }
 
@@ -204,9 +231,16 @@ test_doctor_json_reports_missing_cli_and_skips_status() {
   run_cmd env HOME="$tmp/home" CODEX_CLI=/no/such/codex "$SCRIPT" doctor --json
 
   assert_status 0
+  assert_contains '"healthy":false'
   assert_contains '"desktop":{'
   assert_contains '"cli":{"found":false'
   assert_contains '"status":{"skipped":true'
+
+  run_cmd env HOME="$tmp/home" CODEX_CLI=/no/such/codex "$SCRIPT" doctor --json --check
+
+  assert_status 1
+  assert_contains '"healthy":false'
+  JSON_PAYLOAD="$output" node -e 'JSON.parse(process.env.JSON_PAYLOAD)'
 
   rm -rf "$tmp"
 }
@@ -298,6 +332,7 @@ test_status_reports_arbitrary_discovered_profiles_and_skips_invalid_dirs
 test_status_treats_not_logged_in_as_normal_status
 test_status_propagates_unexpected_cli_failure
 test_doctor_skips_status_when_cli_missing
+test_doctor_check_reports_healthy_state
 test_status_json_reports_profiles_without_creating_missing_default
 test_status_json_treats_not_logged_in_as_normal_status
 test_status_json_escapes_control_characters

--- a/test/cli/status-json-test.sh
+++ b/test/cli/status-json-test.sh
@@ -211,6 +211,58 @@ test_doctor_json_reports_missing_cli_and_skips_status() {
   rm -rf "$tmp"
 }
 
+test_doctor_reports_private_state_links_without_flagging_shared_config() {
+  local tmp source_home target_home outside
+  tmp="$(mktemp -d)"
+  source_home="$tmp/home/.codex-personal"
+  target_home="$tmp/home/.codex-personal-2"
+  outside="$tmp/outside"
+  mkdir -p "$source_home" "$target_home" "$outside/sessions"
+  printf 'model = "gpt-5"\n' > "$source_home/config.toml"
+  printf '{"token":"not-read"}\n' > "$outside/auth.json"
+  printf 'history\n' > "$outside/history.jsonl"
+  printf 'state\n' > "$outside/state_5.sqlite"
+  ln -s "$source_home/config.toml" "$target_home/config.toml"
+  ln -s "$outside/auth.json" "$target_home/auth.json"
+  ln -s "$outside/sessions" "$target_home/sessions"
+  ln -s "$outside/state_5.sqlite" "$target_home/state_5.sqlite"
+  ln "$outside/history.jsonl" "$target_home/history.jsonl"
+  ln -s "$outside/missing-profile-home" "$tmp/home/.codex-linked"
+
+  run_cmd env HOME="$tmp/home" CODEX_CLI=/no/such/codex "$SCRIPT" doctor
+
+  assert_status 0
+  assert_contains "Private-state links: 5 (unsafe)"
+  assert_contains "Private-state link: personal-2/auth.json -> $outside/auth.json"
+  assert_contains "Private-state link: personal-2/sessions -> $outside/sessions"
+  assert_contains "Private-state link: personal-2/state_5.sqlite -> $outside/state_5.sqlite"
+  assert_contains "Private-state link: personal-2/history.jsonl [hard links: 2]"
+  assert_contains "Private-state link: linked/profile-home -> $outside/missing-profile-home"
+  assert_not_contains "config.toml ->"
+
+  run_cmd env HOME="$tmp/home" CODEX_CLI=/no/such/codex "$SCRIPT" doctor --json
+
+  assert_status 0
+  assert_contains '"profile_state":{"healthy":false,"private_link_count":5'
+  assert_contains '"entry":"auth.json"'
+  assert_contains '"entry":"sessions"'
+  assert_contains '"entry":"state_5.sqlite"'
+  assert_contains '"entry":"history.jsonl"'
+  assert_contains '"entry":"profile_home"'
+  assert_contains '"kind":"hardlink","target":null,"link_count":2'
+  assert_not_contains '"entry":"config.toml"'
+
+  rm -f "$target_home/auth.json" "$target_home/sessions" "$target_home/state_5.sqlite" \
+    "$target_home/history.jsonl" "$tmp/home/.codex-linked"
+  run_cmd env HOME="$tmp/home" CODEX_CLI=/no/such/codex "$SCRIPT" doctor --json
+
+  assert_status 0
+  assert_contains '"profile_state":{"healthy":true,"private_link_count":0,"private_links":[]}'
+  [[ -L "$target_home/config.toml" ]] || fail "doctor changed an allowlisted shared config link"
+
+  rm -rf "$tmp"
+}
+
 test_json_commands_never_emit_update_notices() {
   local tmp cache fake_codex now
   tmp="$(mktemp -d)"
@@ -250,4 +302,5 @@ test_status_json_reports_profiles_without_creating_missing_default
 test_status_json_treats_not_logged_in_as_normal_status
 test_status_json_escapes_control_characters
 test_doctor_json_reports_missing_cli_and_skips_status
+test_doctor_reports_private_state_links_without_flagging_shared_config
 test_json_commands_never_emit_update_notices

--- a/test/cli/upgrade-test.sh
+++ b/test/cli/upgrade-test.sh
@@ -16,7 +16,7 @@ test_upgrade_dry_run_reports_plan_without_mutating_files() {
   prefix="$tmp/prefix"
   write_fake_upgrade_repo "$repo" "9.9.9"
 
-  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --dry-run --prefix "$prefix"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_REF=main CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --dry-run --prefix "$prefix"
 
   assert_status 0
   assert_contains "Upgrade plan"
@@ -42,7 +42,7 @@ test_upgrade_fetches_newest_ref_and_installs_to_prefix() {
   git -C "$repo" add .
   git -C "$repo" -c user.name=test -c user.email=test@example.com commit -m "v1" >/dev/null
 
-  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_REF=main CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
 
   assert_status 0
   assert_contains "Installed codex-profile 1.0.0"
@@ -52,7 +52,7 @@ test_upgrade_fetches_newest_ref_and_installs_to_prefix() {
   git -C "$repo" add .
   git -C "$repo" -c user.name=test -c user.email=test@example.com commit -m "v2" >/dev/null
 
-  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_REF=main CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
 
   assert_status 0
   assert_contains "Installed codex-profile 1.0.1"
@@ -102,7 +102,7 @@ test_upgrade_refuses_dirty_cached_checkout() {
   git clone "$repo" "$cache" >/dev/null 2>&1
   printf 'local edit\n' >> "$cache/bin/codex-profile"
 
-  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_REF=main CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
 
   assert_status 1
   assert_contains "Cached upgrade checkout has local changes"
@@ -123,7 +123,7 @@ test_upgrade_refuses_to_install_older_version() {
   git -C "$repo" add .
   git -C "$repo" -c user.name=test -c user.email=test@example.com commit -m "old" >/dev/null
 
-  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_REF=main CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
 
   assert_status 1
   assert_contains "Refusing to install older codex-profile 0.1.1"
@@ -158,7 +158,7 @@ FAKE_MAKEFILE
   git -C "$repo" add .
   git -C "$repo" -c user.name=test -c user.email=test@example.com commit -m "unversioned" >/dev/null
 
-  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_REF=main CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
 
   assert_status 1
   assert_contains "Refusing to install candidate without a declared VERSION"
@@ -184,11 +184,94 @@ FAKE_PROFILE
   git -C "$repo" add .
   git -C "$repo" -c user.name=test -c user.email=test@example.com commit -m "no makefile" >/dev/null
 
-  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" CODEX_PROFILE_UPGRADE_REF=main CODEX_PROFILE_UPGRADE_CACHE="$cache" "$SCRIPT" upgrade --prefix "$prefix"
 
   assert_status 1
   assert_contains "Upgrade checkout is missing Makefile"
   [[ ! -e "$prefix/bin/codex-profile" ]] || fail "upgrade installed despite missing Makefile"
+
+  rm -rf "$tmp"
+}
+
+test_upgrade_defaults_to_latest_immutable_release() {
+  local tmp repo cache prefix installed release_json
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  cache="$tmp/cache/source"
+  prefix="$tmp/prefix"
+  installed="$prefix/bin/codex-profile"
+  release_json="$tmp/release.json"
+  mkdir -p "$repo"
+  init_git_main_branch "$repo"
+  write_fake_upgrade_repo "$repo" "9.9.9"
+  git -C "$repo" add .
+  git -C "$repo" -c user.name=test -c user.email=test@example.com commit -m "release" >/dev/null
+  git -C "$repo" tag v9.9.9
+  git -C "$repo" checkout -b v9.9.9 >/dev/null 2>&1
+  write_fake_upgrade_repo "$repo" "9.9.8"
+  git -C "$repo" add .
+  git -C "$repo" -c user.name=test -c user.email=test@example.com commit -m "shadow tag branch" >/dev/null
+  git -C "$repo" checkout main >/dev/null 2>&1
+  printf '{"tag_name":"v9.9.9","immutable":true,"draft":false,"prerelease":false}\n' > "$release_json"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" \
+    CODEX_PROFILE_UPGRADE_RELEASE_URL="$release_json" CODEX_PROFILE_UPGRADE_CACHE="$cache" \
+    "$SCRIPT" upgrade --prefix "$prefix"
+
+  assert_status 0
+  assert_contains "Ref: v9.9.9"
+  assert_contains "Release policy: immutable final GitHub Release"
+  assert_contains "Installed codex-profile 9.9.9"
+  run_cmd "$installed" version
+  assert_status 0
+  assert_equals "codex-profile 9.9.9"
+
+  rm -rf "$tmp"
+}
+
+test_upgrade_refuses_nonfinal_latest_release() {
+  local tmp release_json
+  tmp="$(mktemp -d)"
+  release_json="$tmp/release.json"
+  printf '{"tag_name":"v9.9.9","immutable":false,"draft":false,"prerelease":false}\n' > "$release_json"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_RELEASE_URL="$release_json" \
+    "$SCRIPT" upgrade --dry-run --prefix "$tmp/prefix"
+
+  assert_status 1
+  assert_contains "Latest GitHub Release v9.9.9 is not immutable and final"
+  [[ ! -e "$tmp/prefix" ]] || fail "rejected latest release mutated the install prefix"
+
+  rm -rf "$tmp"
+}
+
+test_upgrade_refuses_option_shaped_release_url() {
+  local tmp
+  tmp="$(mktemp -d)"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_RELEASE_URL=--config=/tmp/unsafe \
+    "$SCRIPT" upgrade --dry-run --prefix "$tmp/prefix"
+
+  assert_status 1
+  assert_contains "Cannot fetch latest release metadata"
+  [[ ! -e "$tmp/prefix" ]] || fail "option-shaped metadata URL mutated the install prefix"
+
+  rm -rf "$tmp"
+}
+
+test_upgrade_latest_is_a_noop_when_already_current() {
+  local tmp release_json
+  tmp="$(mktemp -d)"
+  release_json="$tmp/release.json"
+  printf '{"tag_name":"v0.9.1","immutable":true,"draft":false,"prerelease":false}\n' > "$release_json"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_RELEASE_URL="$release_json" \
+    CODEX_PROFILE_UPGRADE_CACHE="$tmp/cache" "$SCRIPT" upgrade --prefix "$tmp/prefix"
+
+  assert_status 0
+  assert_contains "Already on latest immutable release codex-profile 0.9.1"
+  [[ ! -e "$tmp/cache" ]] || fail "current immutable release created an upgrade cache"
+  [[ ! -e "$tmp/prefix" ]] || fail "current immutable release replaced the installation"
 
   rm -rf "$tmp"
 }
@@ -309,6 +392,10 @@ test_upgrade_refuses_dirty_cached_checkout
 test_upgrade_refuses_to_install_older_version
 test_upgrade_refuses_unversioned_candidate
 test_upgrade_refuses_checkout_missing_makefile
+test_upgrade_defaults_to_latest_immutable_release
+test_upgrade_refuses_nonfinal_latest_release
+test_upgrade_refuses_option_shaped_release_url
+test_upgrade_latest_is_a_noop_when_already_current
 test_update_check_notifies_when_newer_version_is_cached
 test_update_check_is_silent_when_up_to_date
 test_update_check_respects_disable_env

--- a/test/cli/upgrade-test.sh
+++ b/test/cli/upgrade-test.sh
@@ -276,6 +276,52 @@ test_upgrade_latest_is_a_noop_when_already_current() {
   rm -rf "$tmp"
 }
 
+test_upgrade_requires_ownership_or_explicit_prefix() {
+  local tmp cache prefix
+  tmp="$(mktemp -d)"
+  cache="$tmp/cache/source"
+  prefix="$tmp/home/.local"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$tmp/repo" \
+    CODEX_PROFILE_UPGRADE_REF=main CODEX_PROFILE_UPGRADE_CACHE="$cache" \
+    "$SCRIPT" upgrade
+
+  assert_status 1
+  assert_contains "Refusing a source-style upgrade from package-managed or unrecognized executable"
+  assert_contains "pass --prefix explicitly"
+  [[ ! -e "$cache" ]] || fail "unowned upgrade created a source cache"
+  [[ ! -e "$prefix" ]] || fail "unowned upgrade mutated the default prefix"
+
+  rm -rf "$tmp"
+}
+
+test_upgrade_allows_owned_default_source_install() {
+  local tmp repo cache installed
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  cache="$tmp/cache/source"
+  installed="$tmp/home/.local/bin/codex-profile"
+  mkdir -p "$repo" "$(dirname "$installed")"
+  cp "$SCRIPT" "$installed"
+  chmod 755 "$installed"
+  init_git_main_branch "$repo"
+  write_fake_upgrade_repo "$repo" "1.0.0"
+  git -C "$repo" add .
+  git -C "$repo" -c user.name=test -c user.email=test@example.com commit -m "v1" >/dev/null
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_REPO="$repo" \
+    CODEX_PROFILE_UPGRADE_REF=main CODEX_PROFILE_UPGRADE_CACHE="$cache" \
+    "$installed" upgrade
+
+  assert_status 0
+  assert_contains "Installed codex-profile 1.0.0"
+  run_cmd "$installed" version
+  assert_status 0
+  assert_equals "codex-profile 1.0.0"
+
+  rm -rf "$tmp"
+}
+
 test_update_check_notifies_when_newer_version_is_cached() {
   local tmp cache stub now
   tmp="$(mktemp -d)"
@@ -293,6 +339,7 @@ test_update_check_notifies_when_newer_version_is_cached() {
 
   assert_status 0
   assert_contains "9.9.9 available"
+  assert_contains "upgrade with the installation's package manager"
 
   rm -rf "$tmp"
 }
@@ -396,6 +443,8 @@ test_upgrade_defaults_to_latest_immutable_release
 test_upgrade_refuses_nonfinal_latest_release
 test_upgrade_refuses_option_shaped_release_url
 test_upgrade_latest_is_a_noop_when_already_current
+test_upgrade_requires_ownership_or_explicit_prefix
+test_upgrade_allows_owned_default_source_install
 test_update_check_notifies_when_newer_version_is_cached
 test_update_check_is_silent_when_up_to_date
 test_update_check_respects_disable_env

--- a/test/cli/workspace-test.sh
+++ b/test/cli/workspace-test.sh
@@ -249,6 +249,114 @@ test_workspace_uses_xdg_config_and_manages_guard_mode() {
   rm -rf "$tmp"
 }
 
+test_workspace_mutations_are_serialized_and_versioned() {
+  local tmp config first second fake_bin fake_mv real_mv first_pid second_pid first_status second_status
+  tmp="$(mktemp -d)"
+  tmp="$(cd "$tmp" && pwd -P)"
+  config="$tmp/config"
+  first="$tmp/first"
+  second="$tmp/second"
+  fake_bin="$tmp/bin"
+  fake_mv="$fake_bin/mv"
+  real_mv="$(command -v mv)"
+  mkdir -p "$tmp/home/.codex-first" "$tmp/home/.codex-second" "$first" "$second" "$fake_bin"
+  cat > "$fake_mv" <<'FAKE_MV'
+#!/usr/bin/env bash
+destination="${!#}"
+if [[ "$destination" == */workspaces.tsv ]]; then
+  sleep 1
+fi
+exec "${REAL_MV:?}" "$@"
+FAKE_MV
+  chmod 755 "$fake_mv"
+
+  env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    PATH="$fake_bin:$PATH" REAL_MV="$real_mv" \
+    "$SCRIPT" workspace bind "$first" first > "$tmp/first.out" 2> "$tmp/first.err" &
+  first_pid=$!
+  env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    PATH="$fake_bin:$PATH" REAL_MV="$real_mv" \
+    "$SCRIPT" workspace bind "$second" second > "$tmp/second.out" 2> "$tmp/second.err" &
+  second_pid=$!
+
+  set +e
+  wait "$first_pid"
+  first_status=$?
+  wait "$second_pid"
+  second_status=$?
+  set -e
+  [[ "$first_status" -eq 0 ]] || fail "first concurrent bind failed: $(cat "$tmp/first.err")"
+  [[ "$second_status" -eq 0 ]] || fail "second concurrent bind failed: $(cat "$tmp/second.err")"
+  [[ "$(wc -l < "$config/workspaces.tsv" | tr -d ' ')" == "2" ]] || \
+    fail "concurrent workspace mutations lost a binding"
+  grep -Fqx "$first"$'\t'first "$config/workspaces.tsv" || fail "first concurrent binding is missing"
+  grep -Fqx "$second"$'\t'second "$config/workspaces.tsv" || fail "second concurrent binding is missing"
+  [[ "$(cat "$config/state-version")" == "1" ]] || fail "state schema version was not recorded"
+  [[ "$(mode_of "$config/state-version")" == "600" ]] || fail "state version file is not private"
+  [[ ! -e "$config/mutation.lock" ]] || fail "state mutation lock was not released"
+
+  mkdir "$config/mutation.lock"
+  printf '99999999\n' > "$config/mutation.lock/pid"
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace guard strict
+  assert_status 0
+  assert_contains "Workspace guard mode: strict"
+  [[ ! -e "$config/mutation.lock" ]] || fail "stale state mutation lock was not reclaimed"
+
+  rm -rf "$tmp"
+}
+
+test_workspace_rejects_unsupported_state_schema() {
+  local tmp config workspace fake_codex
+  tmp="$(mktemp -d)"
+  tmp="$(cd "$tmp" && pwd -P)"
+  config="$tmp/config"
+  workspace="$tmp/workspace"
+  fake_codex="$tmp/codex"
+  mkdir -p "$tmp/home/.codex-work" "$workspace" "$config"
+  printf '99\n' > "$config/state-version"
+  cat > "$fake_codex" <<'FAKE_CODEX'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'fake-codex 1.0\n'
+  exit 0
+fi
+printf 'Logged out\n'
+FAKE_CODEX
+  chmod 755 "$fake_codex"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace list
+  assert_status 1
+  assert_contains "Unsupported state schema version '99'"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" launcher list --json
+  assert_status 1
+  assert_contains "Unsupported state schema version '99'"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    "$SCRIPT" workspace guard strict
+  assert_status 1
+  assert_contains "Unsupported state schema version '99'"
+  [[ ! -e "$config/mutation.lock" ]] || fail "schema rejection left the mutation lock behind"
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI="$fake_codex" "$SCRIPT" doctor --json
+  assert_status 0
+  assert_contains '"healthy":false'
+  assert_contains '"schema_version":"99"'
+  assert_contains '"registry_valid":false'
+  JSON_PAYLOAD="$output" node -e 'JSON.parse(process.env.JSON_PAYLOAD)'
+
+  run_cmd env HOME="$tmp/home" CODEX_PROFILE_CONFIG_HOME="$config" \
+    CODEX_CLI="$fake_codex" "$SCRIPT" doctor --json --check
+  assert_status 1
+  assert_contains '"healthy":false'
+
+  rm -rf "$tmp"
+}
+
 test_workspace_run_routes_cli_and_signed_app() {
   local tmp config workspace service fake_codex chatgpt_app fake_bin tool_log
   tmp="$(mktemp -d)"
@@ -601,6 +709,8 @@ test_doctor_reports_workspace_binding_health_in_human_and_json_output() {
 test_workspace_bind_list_status_and_nested_resolution
 test_workspace_bind_rejects_unsafe_state_and_reports_stale_bindings
 test_workspace_uses_xdg_config_and_manages_guard_mode
+test_workspace_mutations_are_serialized_and_versioned
+test_workspace_rejects_unsupported_state_schema
 test_workspace_run_routes_cli_and_signed_app
 test_workspace_resolution_errors_are_not_treated_as_unbound
 test_workspace_guards_explicit_profile_commands

--- a/test/install/check-test.sh
+++ b/test/install/check-test.sh
@@ -89,6 +89,7 @@ release_suites=(
   test/release/distribution-test.sh
   test/release/homebrew-test.sh
   test/release/pages-test.sh
+  test/release/pages-source-test.sh
   test/release/workflow-contract-test.mjs
 )
 for suite in "${release_suites[@]}"; do
@@ -110,6 +111,7 @@ release_scripts=(
   scripts/release/verify-distribution.sh
   scripts/release/update-homebrew.sh
   scripts/release/deploy-pages.sh
+  scripts/release/verify-pages-source.sh
 )
 for script in "${release_scripts[@]}"; do
   assert_contains "$list_output" $'shell\t'"$script" "release script inventory"

--- a/test/outreach/migration-test.mjs
+++ b/test/outreach/migration-test.mjs
@@ -175,10 +175,28 @@ printf '%s\\n' '{"ok":true}'
   });
   assert.equal(verified.status, 0, verified.stderr);
   const psqlArguments = readFileSync(psqlArgumentsPath, 'utf8');
+  assert.match(psqlArguments, /^-X\n--dbname\n/);
   assert.match(psqlArguments, /postgresql:\/\/owner@example\.test\/neondb\?sslmode=require/);
   assert.doesNotMatch(psqlArguments, /secret/);
   assert.equal(readFileSync(psqlPasswordPath, 'utf8'), 'secret');
   assert.equal(readFileSync(psqlNeonEnvPath, 'utf8'), 'unset');
+
+  const plainDatabase = await run(['verify', '--in', snapshotPath], {
+    NEON_DATABASE_URL: 'neondb',
+    PATH: `${temporary}:${process.env.PATH}`,
+    PSQL_ARGS_FILE: psqlArgumentsPath,
+    PSQL_PASSWORD_FILE: psqlPasswordPath,
+    PSQL_NEON_ENV_FILE: psqlNeonEnvPath,
+  });
+  assert.equal(plainDatabase.status, 0, plainDatabase.stderr);
+  assert.match(readFileSync(psqlArgumentsPath, 'utf8'), /^-X\n--dbname\nneondb\n/);
+
+  const optionInjection = await run(['verify', '--in', snapshotPath], {
+    NEON_DATABASE_URL: '-o|id',
+    PATH: `${temporary}:${process.env.PATH}`,
+  });
+  assert.equal(optionInjection.status, 2);
+  assert.match(optionInjection.stderr, /PostgreSQL URL or a plain database name/);
 
   const unsafeConninfo = await run(['verify', '--in', snapshotPath], {
     NEON_DATABASE_URL: 'host=example.test dbname=neondb user=owner password=conninfo-secret',

--- a/test/outreach/neon-schema-test.mjs
+++ b/test/outreach/neon-schema-test.mjs
@@ -246,6 +246,20 @@ try {
   assert.equal(sql("SELECT has_table_privilege('outreach_tracker', 'outreach_private.migration_snapshots', 'SELECT')"), 'f');
   assert.equal(sql("SELECT has_function_privilege('public', 'public.tracker_claim(text,text,bigint,uuid)', 'EXECUTE')"), 'f');
   assert.equal(sql("SELECT count(*) FROM pg_proc WHERE proname LIKE 'tracker_%' AND NOT (proconfig @> ARRAY['search_path=pg_catalog, public, outreach_private'])"), '0');
+  assert.equal(sql(`
+    SELECT count(*)
+    FROM pg_constraint AS constraint_row
+    WHERE constraint_row.contype = 'f'
+      AND constraint_row.connamespace = 'public'::regnamespace
+      AND NOT EXISTS (
+        SELECT 1
+        FROM pg_index AS index_row
+        WHERE index_row.indrelid = constraint_row.conrelid
+          AND index_row.indisvalid
+          AND index_row.indpred IS NULL
+          AND index_row.indkey[0] = constraint_row.conkey[1]
+      )
+  `), '0');
 
   const wrongIdentity = run('psql', psqlArgs(trackerTransaction('SELECT count(*) FROM public.tracker_list_targets()', 'wrong')));
   assert.notEqual(wrongIdentity.status, 0);

--- a/test/packaging/aur-test.mjs
+++ b/test/packaging/aur-test.mjs
@@ -404,6 +404,7 @@ const autoResult = run(
 );
 assertSuccess(autoResult, "automatic container verification");
 assert.match(readFileSync(commandLog, "utf8"), /^docker info\ndocker run /m);
+assert.match(readFileSync(commandLog, "utf8"), /docker run --rm -i --platform linux\/amd64 /);
 assert.match(autoResult.stdout, /Container validation: passed/);
 
 writeFileSync(commandLog, "");
@@ -437,7 +438,11 @@ for (const contract of [
   "makepkg --printsrcinfo",
   "makepkg --verifysource",
   "makepkg --cleanbuild",
+  "*-debug-*",
+  "Multiple non-debug packages were predicted",
   "namcap PKGBUILD",
+  "--platform linux/amd64",
+  "DisableSandbox",
   '[[ "$(readlink "$alias")" == codex-profile ]]',
 ]) {
   assert.ok(verifySource.includes(contract), `container verifier should contain ${contract}`);

--- a/test/packaging/aur-test.mjs
+++ b/test/packaging/aur-test.mjs
@@ -282,6 +282,13 @@ case "\${1:-}" in
 esac
 `,
 );
+writeExecutable(
+  "uname",
+  `
+[[ "\${1:-}" == "-m" ]] || exit 2
+printf '%s\n' "\${AUR_TEST_UNAME_M:-x86_64}"
+`,
+);
 for (const command of ["git", "ssh"]) {
   writeExecutable(
     command,
@@ -403,9 +410,26 @@ const autoResult = run(
   verifyEnv,
 );
 assertSuccess(autoResult, "automatic container verification");
-assert.match(readFileSync(commandLog, "utf8"), /^docker info\ndocker run /m);
+assert.match(
+  readFileSync(commandLog, "utf8"),
+  /^docker info\ndocker run /m,
+  `automatic container command log is incomplete:\n${autoResult.stdout}\n${autoResult.stderr}`,
+);
 assert.match(readFileSync(commandLog, "utf8"), /docker run --rm -i --platform linux\/amd64 /);
+assert.match(readFileSync(commandLog, "utf8"), /--env CODEX_PROFILE_AUR_EMULATED=0 /);
 assert.match(autoResult.stdout, /Container validation: passed/);
+
+writeFileSync(commandLog, "");
+const emulatedResult = run(
+  verify,
+  verifyArgs.map((arg) => (arg === "never" ? "auto" : arg)),
+  { ...verifyEnv, AUR_TEST_UNAME_M: "arm64" },
+);
+assertSuccess(emulatedResult, "emulated-host container verification");
+assert.match(
+  readFileSync(commandLog, "utf8"),
+  /docker run --rm -i --platform linux\/amd64 --env CODEX_PROFILE_AUR_EMULATED=1 /,
+);
 
 writeFileSync(commandLog, "");
 const unavailableAuto = run(

--- a/test/packaging/metadata-test.sh
+++ b/test/packaging/metadata-test.sh
@@ -105,15 +105,21 @@ grep -F "github:Ducksss/codex-profiles/v$version" docs/llms.txt >/dev/null \
   || fail "docs/llms.txt Nix install is not pinned to v$version"
 grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" install.sh >/dev/null \
   || fail "install.sh usage is not pinned to v$version"
+installer_reference_probe='https://raw.githubusercontent.com/Ducksss/codex-profiles/feature/nested/install.sh?download=1#fragment'
+[[ "$(printf '%s\n' "$installer_reference_probe" | grep -Eo 'https://raw\.githubusercontent\.com/Ducksss/codex-profiles/[^[:space:]]+')" == "$installer_reference_probe" ]] \
+  || fail "installer reference validation misses nested paths, queries, or fragments"
+nix_reference_probe='github:Ducksss/codex-profiles/feature/path?dir=package#fragment'
+[[ "$(printf '%s\n' "$nix_reference_probe" | grep -Eo 'github:Ducksss/codex-profiles[^[:space:]]*')" == "$nix_reference_probe" ]] \
+  || fail "Nix reference validation misses paths, queries, or fragments"
 for public_document in README.md docs/llms.txt install.sh; do
   while IFS= read -r installer_reference; do
     [[ "$installer_reference" == "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" ]] \
       || fail "$public_document publishes non-release installer reference $installer_reference"
-  done < <(grep -Eo 'https://raw\.githubusercontent\.com/Ducksss/codex-profiles/[^/[:space:]]+/install\.sh' "$public_document" || true)
+  done < <(grep -Eo 'https://raw\.githubusercontent\.com/Ducksss/codex-profiles/[^[:space:]]+' "$public_document" || true)
   while IFS= read -r nix_reference; do
     [[ "$nix_reference" == "github:Ducksss/codex-profiles/v$version" ]] \
       || fail "$public_document publishes non-release Nix reference $nix_reference"
-  done < <(grep -Eo 'github:Ducksss/codex-profiles(/[A-Za-z0-9._/-]+)?' "$public_document" || true)
+  done < <(grep -Eo 'github:Ducksss/codex-profiles[^[:space:]]*' "$public_document" || true)
 done
 grep -F 'make check' CONTRIBUTING.md >/dev/null || fail "CONTRIBUTING omits the canonical check"
 grep -F 'make check' AGENTS.md >/dev/null || fail "AGENTS omits the canonical check"

--- a/test/packaging/metadata-test.sh
+++ b/test/packaging/metadata-test.sh
@@ -99,14 +99,20 @@ grep -F "CODEX_PROFILE_VERSION=v$version sh" README.md >/dev/null \
   || fail "README standalone installer does not request v$version"
 grep -F "github:Ducksss/codex-profiles/v$version" README.md >/dev/null \
   || fail "README Nix install is not pinned to v$version"
-! grep -F 'raw.githubusercontent.com/Ducksss/codex-profiles/main/install.sh' README.md >/dev/null \
-  || fail "README executes the mutable main-branch installer"
 grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" docs/llms.txt >/dev/null \
   || fail "docs/llms.txt standalone installer is not pinned to v$version"
 grep -F "github:Ducksss/codex-profiles/v$version" docs/llms.txt >/dev/null \
   || fail "docs/llms.txt Nix install is not pinned to v$version"
 grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" install.sh >/dev/null \
   || fail "install.sh usage is not pinned to v$version"
+for public_document in README.md docs/llms.txt install.sh; do
+  for mutable_reference in \
+    'raw.githubusercontent.com/Ducksss/codex-profiles/main/install.sh' \
+    'github:Ducksss/codex-profiles/main'; do
+    ! grep -F "$mutable_reference" "$public_document" >/dev/null \
+      || fail "$public_document publishes mutable reference $mutable_reference"
+  done
+done
 grep -F 'make check' CONTRIBUTING.md >/dev/null || fail "CONTRIBUTING omits the canonical check"
 grep -F 'make check' AGENTS.md >/dev/null || fail "AGENTS omits the canonical check"
 grep -F 'https://github.com/Ducksss/codex-profiles/security/advisories/new' SECURITY.md >/dev/null \

--- a/test/packaging/metadata-test.sh
+++ b/test/packaging/metadata-test.sh
@@ -93,8 +93,24 @@ for directory in test/cli test/install test/packaging test/release test/site tes
 done
 [[ -d scripts/release ]] || fail "release script directory is missing"
 grep -F 'make check' README.md >/dev/null || fail "README omits the canonical check"
+grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" README.md >/dev/null \
+  || fail "README standalone installer is not pinned to v$version"
+grep -F "CODEX_PROFILE_VERSION=v$version sh" README.md >/dev/null \
+  || fail "README standalone installer does not request v$version"
+grep -F "github:Ducksss/codex-profiles/v$version" README.md >/dev/null \
+  || fail "README Nix install is not pinned to v$version"
+! grep -F 'raw.githubusercontent.com/Ducksss/codex-profiles/main/install.sh' README.md >/dev/null \
+  || fail "README executes the mutable main-branch installer"
+grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" docs/llms.txt >/dev/null \
+  || fail "docs/llms.txt standalone installer is not pinned to v$version"
+grep -F "github:Ducksss/codex-profiles/v$version" docs/llms.txt >/dev/null \
+  || fail "docs/llms.txt Nix install is not pinned to v$version"
+grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" install.sh >/dev/null \
+  || fail "install.sh usage is not pinned to v$version"
 grep -F 'make check' CONTRIBUTING.md >/dev/null || fail "CONTRIBUTING omits the canonical check"
 grep -F 'make check' AGENTS.md >/dev/null || fail "AGENTS omits the canonical check"
+grep -F 'https://github.com/Ducksss/codex-profiles/security/advisories/new' SECURITY.md >/dev/null \
+  || fail "SECURITY.md omits private vulnerability reporting"
 grep -F '(packaging/aur/README.md)' CHANGELOG.md >/dev/null \
   || fail "CHANGELOG.md does not link the AUR publication runbook"
 grep -F '(packaging/aur/README.md)' CONTRIBUTING.md >/dev/null \

--- a/test/packaging/metadata-test.sh
+++ b/test/packaging/metadata-test.sh
@@ -106,12 +106,14 @@ grep -F "github:Ducksss/codex-profiles/v$version" docs/llms.txt >/dev/null \
 grep -F "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" install.sh >/dev/null \
   || fail "install.sh usage is not pinned to v$version"
 for public_document in README.md docs/llms.txt install.sh; do
-  for mutable_reference in \
-    'raw.githubusercontent.com/Ducksss/codex-profiles/main/install.sh' \
-    'github:Ducksss/codex-profiles/main'; do
-    ! grep -F "$mutable_reference" "$public_document" >/dev/null \
-      || fail "$public_document publishes mutable reference $mutable_reference"
-  done
+  while IFS= read -r installer_reference; do
+    [[ "$installer_reference" == "https://raw.githubusercontent.com/Ducksss/codex-profiles/v$version/install.sh" ]] \
+      || fail "$public_document publishes non-release installer reference $installer_reference"
+  done < <(grep -Eo 'https://raw\.githubusercontent\.com/Ducksss/codex-profiles/[^/[:space:]]+/install\.sh' "$public_document" || true)
+  while IFS= read -r nix_reference; do
+    [[ "$nix_reference" == "github:Ducksss/codex-profiles/v$version" ]] \
+      || fail "$public_document publishes non-release Nix reference $nix_reference"
+  done < <(grep -Eo 'github:Ducksss/codex-profiles(/[A-Za-z0-9._/-]+)?' "$public_document" || true)
 done
 grep -F 'make check' CONTRIBUTING.md >/dev/null || fail "CONTRIBUTING omits the canonical check"
 grep -F 'make check' AGENTS.md >/dev/null || fail "AGENTS omits the canonical check"

--- a/test/release/pages-source-test.sh
+++ b/test/release/pages-source-test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/test/lib/assertions.sh"
+source "$ROOT_DIR/test/lib/command-shims.sh"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
+
+VERIFY="$ROOT_DIR/scripts/release/verify-pages-source.sh"
+fake_bin="$TMP_ROOT/bin"
+log_file="$TMP_ROOT/gh.log"
+output=""
+status=0
+
+run_cmd() {
+  set +e
+  output="$("$@" 2>&1)"
+  status=$?
+  set -e
+}
+
+mkdir -p "$fake_bin"
+write_command_shim "$fake_bin/gh" <<'SH'
+set -eu
+printf '%s\n' "$*" >> "$PAGES_SOURCE_TEST_LOG"
+printf '%s\t%s\t%s\t%s\n' \
+  "${PAGES_SOURCE_TAG:-v1.2.3}" \
+  "${PAGES_SOURCE_IMMUTABLE:-true}" \
+  "${PAGES_SOURCE_DRAFT:-false}" \
+  "${PAGES_SOURCE_PRERELEASE:-false}"
+SH
+
+run_verify() {
+  local ref="$1"
+  local tag="$2"
+  shift 2
+  run_cmd env PATH="$fake_bin:$PATH" PAGES_SOURCE_TEST_LOG="$log_file" \
+    GITHUB_REF="$ref" GITHUB_REPOSITORY="Ducksss/codex-profiles" RELEASE_TAG="$tag" \
+    "$@" "$VERIFY"
+}
+
+: > "$log_file"
+run_verify refs/heads/main ""
+assert_status 0
+[[ ! -s "$log_file" ]] || fail "main documentation deployment queried a release"
+
+run_verify refs/heads/feature ""
+assert_status 1
+assert_contains "Pages must run from main"
+
+run_verify refs/heads/main release-latest
+assert_status 1
+assert_contains "must exactly match vX.Y.Z"
+
+run_verify refs/heads/main v1.2.3
+assert_status 0
+grep -F 'repos/Ducksss/codex-profiles/releases/tags/v1.2.3' "$log_file" >/dev/null \
+  || fail "release validation queried the wrong tag"
+
+run_verify refs/heads/main v1.2.3 env PAGES_SOURCE_IMMUTABLE=false
+assert_status 1
+assert_contains "not an immutable final GitHub Release"
+
+printf '%s\n' 'Pages source validation tests passed.'

--- a/test/release/pages-source-test.sh
+++ b/test/release/pages-source-test.sh
@@ -11,6 +11,7 @@ trap 'rm -rf "$TMP_ROOT"' EXIT HUP INT TERM
 VERIFY="$ROOT_DIR/scripts/release/verify-pages-source.sh"
 fake_bin="$TMP_ROOT/bin"
 log_file="$TMP_ROOT/gh.log"
+github_output="$TMP_ROOT/github-output"
 output=""
 status=0
 
@@ -25,11 +26,37 @@ mkdir -p "$fake_bin"
 write_command_shim "$fake_bin/gh" <<'SH'
 set -eu
 printf '%s\n' "$*" >> "$PAGES_SOURCE_TEST_LOG"
-printf '%s\t%s\t%s\t%s\n' \
-  "${PAGES_SOURCE_TAG:-v1.2.3}" \
-  "${PAGES_SOURCE_IMMUTABLE:-true}" \
-  "${PAGES_SOURCE_DRAFT:-false}" \
-  "${PAGES_SOURCE_PRERELEASE:-false}"
+case "$*" in
+  *repos/*/releases/tags/*)
+    printf '%s\t%s\t%s\t%s\n' \
+      "${PAGES_SOURCE_TAG:-v1.2.3}" \
+      "${PAGES_SOURCE_IMMUTABLE:-true}" \
+      "${PAGES_SOURCE_DRAFT:-false}" \
+      "${PAGES_SOURCE_PRERELEASE:-false}"
+    ;;
+  *repos/*/git/ref/tags/*)
+    printf 'refs/tags/%s\t%s\t%s\n' \
+      "${PAGES_SOURCE_TAG:-v1.2.3}" \
+      "${PAGES_SOURCE_OBJECT_TYPE:-tag}" \
+      "${PAGES_SOURCE_OBJECT_SHA:-1111111111111111111111111111111111111111}"
+    ;;
+  *repos/*/git/tags/*)
+    printf '%s\t%s\n' \
+      "${PAGES_SOURCE_PEELED_TYPE:-commit}" \
+      "${PAGES_SOURCE_TAG_COMMIT:-2222222222222222222222222222222222222222}"
+    ;;
+  *repos/*/compare/*)
+    printf '%s\t%s\t%s\t%s\n' \
+      "${PAGES_SOURCE_COMPARE_STATUS:-ahead}" \
+      "${PAGES_SOURCE_COMPARE_BASE:-${PAGES_SOURCE_TAG_COMMIT:-2222222222222222222222222222222222222222}}" \
+      "${PAGES_SOURCE_MERGE_BASE:-${PAGES_SOURCE_TAG_COMMIT:-2222222222222222222222222222222222222222}}" \
+      "${PAGES_SOURCE_BEHIND_BY:-0}"
+    ;;
+  *)
+    printf 'unexpected gh invocation: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
 SH
 
 run_verify() {
@@ -42,9 +69,11 @@ run_verify() {
 }
 
 : > "$log_file"
+: > "$github_output"
 run_verify refs/heads/main ""
 assert_status 0
 [[ ! -s "$log_file" ]] || fail "main documentation deployment queried a release"
+[[ ! -s "$github_output" ]] || fail "main documentation deployment emitted a release commit"
 
 run_verify refs/heads/feature ""
 assert_status 1
@@ -54,13 +83,47 @@ run_verify refs/heads/main release-latest
 assert_status 1
 assert_contains "must exactly match vX.Y.Z"
 
-run_verify refs/heads/main v1.2.3
+run_verify refs/heads/main v1.2.3 env GITHUB_OUTPUT="$github_output"
 assert_status 0
 grep -F 'repos/Ducksss/codex-profiles/releases/tags/v1.2.3' "$log_file" >/dev/null \
   || fail "release validation queried the wrong tag"
+grep -F 'repos/Ducksss/codex-profiles/git/ref/tags/v1.2.3' "$log_file" >/dev/null \
+  || fail "release validation did not resolve the exact Git tag"
+grep -F 'repos/Ducksss/codex-profiles/compare/2222222222222222222222222222222222222222...main' \
+  "$log_file" >/dev/null \
+  || fail "release validation did not compare the resolved tag commit with main"
+grep -Fx 'commit=2222222222222222222222222222222222222222' \
+  "$github_output" >/dev/null \
+  || fail "release validation did not emit the resolved tag commit"
+
+: > "$log_file"
+: > "$github_output"
+run_verify refs/heads/main v1.2.3 env \
+  GITHUB_OUTPUT="$github_output" \
+  PAGES_SOURCE_OBJECT_TYPE=commit \
+  PAGES_SOURCE_OBJECT_SHA=4444444444444444444444444444444444444444 \
+  PAGES_SOURCE_COMPARE_BASE=4444444444444444444444444444444444444444 \
+  PAGES_SOURCE_MERGE_BASE=4444444444444444444444444444444444444444
+assert_status 0
+if grep -F 'repos/Ducksss/codex-profiles/git/tags/' "$log_file" >/dev/null; then
+  fail "lightweight Git tag unexpectedly queried an annotated tag object"
+fi
+grep -F 'repos/Ducksss/codex-profiles/compare/4444444444444444444444444444444444444444...main' \
+  "$log_file" >/dev/null \
+  || fail "lightweight Git tag did not use its exact commit"
+grep -Fx 'commit=4444444444444444444444444444444444444444' \
+  "$github_output" >/dev/null \
+  || fail "lightweight Git tag did not emit its exact commit"
 
 run_verify refs/heads/main v1.2.3 env PAGES_SOURCE_IMMUTABLE=false
 assert_status 1
 assert_contains "not an immutable final GitHub Release"
+
+run_verify refs/heads/main v1.2.3 env \
+  PAGES_SOURCE_COMPARE_STATUS=diverged \
+  PAGES_SOURCE_MERGE_BASE=3333333333333333333333333333333333333333 \
+  PAGES_SOURCE_BEHIND_BY=1
+assert_status 1
+assert_contains "not contained in main"
 
 printf '%s\n' 'Pages source validation tests passed.'

--- a/test/release/pages-test.sh
+++ b/test/release/pages-test.sh
@@ -24,7 +24,7 @@ case "${1:-}:${2:-}" in
     case " $* " in *' -f release_tag=v0.7.0 '*) ;; *) exit 67 ;; esac
     ;;
   run:list)
-    case " $* " in *' --commit '*) exit 68 ;; esac
+    case " $* " in *' --commit '*|*' --commit='*) exit 68 ;; esac
     count="$(grep -c '^gh:run list' "$RELEASE_TEST_LOG" || true)"
     if [ "$FAKE_PAGES_SCENARIO" = missing ]; then
       exit 0

--- a/test/release/pages-test.sh
+++ b/test/release/pages-test.sh
@@ -24,6 +24,7 @@ case "${1:-}:${2:-}" in
     case " $* " in *' -f release_tag=v0.7.0 '*) ;; *) exit 67 ;; esac
     ;;
   run:list)
+    case " $* " in *' --commit '*) exit 68 ;; esac
     count="$(grep -c '^gh:run list' "$RELEASE_TEST_LOG" || true)"
     if [ "$FAKE_PAGES_SCENARIO" = missing ]; then
       exit 0
@@ -72,7 +73,6 @@ run_pages() {
     GITHUB_RUN_ID="123" \
     GITHUB_RUN_ATTEMPT="4" \
     GITHUB_REPOSITORY="Ducksss/codex-profiles" \
-    GITHUB_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" \
     "$ROOT_DIR/scripts/release/deploy-pages.sh" \
       >"$TMP_ROOT/pages-$scenario.out" 2>&1
   status=$?

--- a/test/release/pages-test.sh
+++ b/test/release/pages-test.sh
@@ -20,6 +20,8 @@ case "${1:-}:${2:-}" in
       *' -f release_correlation=release-123-4 '*) ;;
       *) exit 65 ;;
     esac
+    case " $* " in *' --ref main '*) ;; *) exit 66 ;; esac
+    case " $* " in *' -f release_tag=v0.7.0 '*) ;; *) exit 67 ;; esac
     ;;
   run:list)
     count="$(grep -c '^gh:run list' "$RELEASE_TEST_LOG" || true)"

--- a/test/release/workflow-contract-test.mjs
+++ b/test/release/workflow-contract-test.mjs
@@ -4,6 +4,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const workflow = readFileSync(".github/workflows/release.yml", "utf8");
+const pagesWorkflow = readFileSync(".github/workflows/pages.yml", "utf8");
+const pagesDispatch = readFileSync("scripts/release/deploy-pages.sh", "utf8");
 
 function stepBlock(name) {
   const marker = `      - name: ${name}\n`;
@@ -55,6 +57,13 @@ for (const literal of requiredLiterals) {
 
 const verifyJob = jobBlock("verify");
 const publishJob = jobBlock("publish");
+for (const block of [verifyJob, publishJob]) {
+  assert.ok(block.includes("    environment:\n      name: release"), "release jobs should use the protected release environment");
+}
+assert.ok(
+  verifyJob.includes("    if: ${{ github.ref == 'refs/heads/main' }}"),
+  "release verification must reject non-main dispatches before any step runs",
+);
 assert.ok(verifyJob.includes("    permissions:\n      contents: read"));
 for (const permission of ["contents: write", "id-token: write", "actions: write"]) {
   assert.ok(!verifyJob.includes(permission), `verify job must not grant ${permission}`);
@@ -221,5 +230,25 @@ assert.ok(actionLines.length > 0, "release workflow should use pinned actions");
 for (const line of actionLines) {
   assert.match(line, /@[0-9a-f]{40}\s+# v[0-9]+$/, `action should be pinned: ${line.trim()}`);
 }
+
+for (const literal of [
+  "release_tag:",
+  "if: ${{ github.ref == 'refs/heads/main' }}",
+  "Check out trusted Pages controls",
+  "Validate Pages source",
+  ".pages-control/scripts/release/verify-pages-source.sh",
+  "ref: ${{ inputs.release_tag || github.sha }}",
+  "path: .pages-site/docs",
+]) {
+  assert.ok(pagesWorkflow.includes(literal), `Pages workflow should contain ${literal}`);
+}
+assert.ok(
+  pagesDispatch.includes('gh workflow run pages.yml --repo "$GITHUB_REPOSITORY" --ref main'),
+  "release publication should dispatch the trusted Pages workflow from main",
+);
+assert.ok(
+  pagesDispatch.includes('-f release_tag="$TAG"'),
+  "release publication should pass the immutable artifact tag as data",
+);
 
 console.log("Release workflow wiring tests passed.");

--- a/test/release/workflow-contract-test.mjs
+++ b/test/release/workflow-contract-test.mjs
@@ -236,8 +236,9 @@ for (const literal of [
   "if: ${{ github.ref == 'refs/heads/main' }}",
   "Check out trusted Pages controls",
   "Validate Pages source",
+  "id: source",
   ".pages-control/scripts/release/verify-pages-source.sh",
-  "ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.sha }}",
+  "ref: ${{ steps.source.outputs.commit || github.sha }}",
   "path: .pages-site/docs",
 ]) {
   assert.ok(pagesWorkflow.includes(literal), `Pages workflow should contain ${literal}`);

--- a/test/release/workflow-contract-test.mjs
+++ b/test/release/workflow-contract-test.mjs
@@ -237,11 +237,16 @@ for (const literal of [
   "Check out trusted Pages controls",
   "Validate Pages source",
   ".pages-control/scripts/release/verify-pages-source.sh",
-  "ref: ${{ inputs.release_tag || github.sha }}",
+  "ref: ${{ inputs.release_tag && format('refs/tags/{0}', inputs.release_tag) || github.sha }}",
   "path: .pages-site/docs",
 ]) {
   assert.ok(pagesWorkflow.includes(literal), `Pages workflow should contain ${literal}`);
 }
+assert.equal(
+  (pagesWorkflow.match(/persist-credentials: false/g) ?? []).length,
+  2,
+  "neither Pages checkout should persist the workflow token",
+);
 assert.ok(
   pagesDispatch.includes('gh workflow run pages.yml --repo "$GITHUB_REPOSITORY" --ref main'),
   "release publication should dispatch the trusted Pages workflow from main",
@@ -249,6 +254,10 @@ assert.ok(
 assert.ok(
   pagesDispatch.includes('-f release_tag="$TAG"'),
   "release publication should pass the immutable artifact tag as data",
+);
+assert.ok(
+  !pagesDispatch.includes('--commit "$GITHUB_SHA"'),
+  "Pages run discovery must tolerate main advancing between release verification and dispatch",
 );
 
 console.log("Release workflow wiring tests passed.");

--- a/test/site/geo-test.mjs
+++ b/test/site/geo-test.mjs
@@ -299,7 +299,7 @@ assert.equal(packageJson.homepage, canonicalUrl);
 for (const required of [
   'actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5',
   'actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5',
-  'path: docs',
+  'path: .pages-site/docs',
   'pages: write',
   'id-token: write',
 ]) {


### PR DESCRIPTION
## Summary

- protect Desktop logs and diagnose symlinked or hard-linked private profile state
- resolve default upgrades through immutable final GitHub releases and pin public install examples
- keep release and Pages execution on trusted main-branch controls
- harden PostgreSQL invocation and add foreign-key index coverage
- make AUR verification deterministic across host architectures

## Critical review follow-up

First pass:

- fixed GNU stat fallback output that caused false hard-link detections on Linux
- rejected option-shaped release metadata URLs before invoking network clients

Second pass:

- qualified Pages artifact refs as refs/tags/... so same-named branches cannot shadow releases
- removed a release-to-Pages race when main advances after dispatch
- stopped both Pages checkouts from persisting workflow credentials
- made GNU/BSD stat selection deterministic
- fixed empty-array failure under Intel macOS Bash 3.2 and tested native and emulated AUR paths
- rejected every public installer or Nix source that is not pinned to the exact tracked release

## Verification

- make check on the combined isolated PR tree
- strict ShellCheck warning pass
- GitHub CI: Ubuntu shell checks, macOS smoke test, and Nix package
- PostgreSQL schema integration test
- real Apple Silicon to Arch Linux amd64 package build and verification
- Linux container log and doctor tests
- Semgrep security-audit rules: no findings
- git diff --check

## Repository settings applied

- enabled private vulnerability reporting
- restricted the release and github-pages environments to main

## Deliberately excluded

- Homebrew tap/version synchronization, per request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `doctor --check` with health status and JSON schema information.
  * Added safer upgrade behavior using immutable releases by default, with explicit development-source updates.
  * Added workspace state versioning and serialized mutations.

* **Bug Fixes**
  * Prevented unsafe access to linked log files and profile state.
  * Prevented uninitialized profile commands and unsafe profile removal.
  * Improved database migration argument safety.
  * Strengthened release and Pages publication validation.

* **Documentation**
  * Updated installation, release, security, FAQ, and upgrade guidance with pinned release details and new safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->