### PR TITLE
release(feat): prepare codex-profiles 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project follows semantic versioning for tagged releases.
 
 ## Unreleased
 
+## 0.10.0 - 2026-09-02
+
 ### Added
 
 - Added a dependency-free Airtable-to-Neon migration utility, restricted Neon

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -22,7 +22,7 @@ change and are not per-target state.
   Prefer issue-first unless the target is Codex-specific, explicitly requests
   Codex CLI or ChatGPT Desktop workflow tooling, or has a structured registry
   or package format. See Policy Gates below.
-- Product-copy freeze: do not resume promotion until v0.9.1 is published and
+- Product-copy freeze: do not resume promotion until v0.10.0 is published and
   the signed ChatGPT app test matrix passes. Existing listings that describe
   Codex app clones or Codex-only Desktop switching need correction after the
   release; preserve their historical submission records.
@@ -152,7 +152,7 @@ The actual publish and push remain the authoritative write checks.
 
 ## Channel Copy
 
-Do not publish this copy until the v0.9.1 release gate passes. The word `work`
+Do not publish this copy until the v0.10.0 release gate passes. The word `work`
 in examples is a user-selected name, not the ChatGPT mode named Work.
 
 Hacker News `Show HN` title:

--- a/README.md
+++ b/README.md
@@ -77,15 +77,15 @@ brew install Ducksss/tap/codex-profile
 With the standalone installer:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/install.sh \
-  | CODEX_PROFILE_VERSION=v0.9.1 sh
+curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.10.0/install.sh \
+  | CODEX_PROFILE_VERSION=v0.10.0 sh
 ```
 
 With Nix:
 
 ```sh
-nix run github:Ducksss/codex-profiles/v0.9.1
-nix profile install github:Ducksss/codex-profiles/v0.9.1
+nix run github:Ducksss/codex-profiles/v0.10.0
+nix profile install github:Ducksss/codex-profiles/v0.10.0
 ```
 
 From source:
@@ -504,7 +504,7 @@ directories, and it refuses sensitive-looking configuration keys.
 codex-profile upgrade --dry-run
 codex-profile upgrade
 codex-profile upgrade --prefix /usr/local
-codex-profile upgrade --ref v0.9.1
+codex-profile upgrade --ref v0.10.0
 codex-profile upgrade --ref main
 ```
 

--- a/agent.md
+++ b/agent.md
@@ -67,7 +67,7 @@ Complete the skill's media preflight before long-form copy and verify the
 rendered asset and crop. Write as Chai only when the authenticated project
 context verifies that identity.
 
-Do not resume new promotion until README/LAUNCH identify v0.9.1 as released and
+Do not resume new promotion until README/LAUNCH identify v0.10.0 as released and
 the current ChatGPT app verification gate is recorded as passed. Before
 updating an existing listing, preserve its original submission history and
 correct stale claims about app clones, `--instance`, or Codex-only Desktop

--- a/bin/codex-profile
+++ b/bin/codex-profile
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 PROGRAM="${0##*/}"
-VERSION="0.9.1"
+VERSION="0.10.0"
 CHATGPT_APP="${CHATGPT_APP:-}"
 CODEX_APP="${CODEX_APP:-}"
 CODEX_APP_BIN="${CODEX_APP_BIN:-}"

--- a/docs/geo-audit.md
+++ b/docs/geo-audit.md
@@ -12,7 +12,7 @@ Pages site in `docs/`.
 | Priority URLs return static content | Implemented after deployment | The homepage, `llms.txt`, and sitemap require no client rendering. |
 | Pages are indexable | Implemented | The homepage uses `index,follow` and unrestricted snippet directives. |
 | Canonical URL is stable | Implemented | The site keeps `https://ducksss.github.io/codex-profiles/`; the v0.7 migration does not rebrand or move it. |
-| Sitemap is current | Implemented | The sitemap lists the canonical homepage and LLM summary with 2026-08-30 modification dates. |
+| Sitemap is current | Implemented | The sitemap lists the canonical homepage and LLM summary with 2026-09-02 modification dates. |
 | Stale authenticated media avoided | Implemented | Primary docs no longer embed the pre-integration Codex app screenshot or video. |
 
 ## Structured Data and Machine Understanding
@@ -20,7 +20,7 @@ Pages site in `docs/`.
 | Check | Status | Implementation |
 | --- | --- | --- |
 | Organization schema present | Implemented | JSON-LD includes the publisher and official GitHub/npm links. |
-| Software schema present | Implemented | SoftwareApplication includes repository, install, license, v0.9.1, platforms, and current features. |
+| Software schema present | Implemented | SoftwareApplication includes repository, install, license, v0.10.0, platforms, and current features. |
 | FAQ schema only for visible content | Implemented | Every FAQPage question and exact answer is present in visible HTML. |
 | Two product scopes represented | Implemented | Schema and visible content distinguish Codex-only commands from whole-window ChatGPT Desktop launches. |
 | Profile mappings correct | Implemented | Default, personal, work, and edu map to `~/.codex`, `~/.codex-personal`, `~/.codex-work`, and `~/.codex-edu`. |
@@ -35,7 +35,7 @@ Pages site in `docs/`.
 | Commands and tables | Implemented | The page contains install commands, a scope table, mappings, and citation-ready facts. |
 | Primary contract is explicit | Implemented | Named Desktop profiles apply across Chat, Work, and Codex; CLI/login/env/use stay Codex-only. |
 | Non-claims are explicit | Implemented | The page says account equality is unverified and local paths do not control server-side ChatGPT data. |
-| Facts current | Implemented | Version, package name, URLs, platforms, behavior, and dates reflect the v0.9.1 contract as of 2026-08-30. |
+| Facts current | Implemented | Version, package name, URLs, platforms, behavior, and dates reflect the v0.10.0 contract as of 2026-09-02. |
 
 ## Entity, Trust, and Brand Authority
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,7 @@
         "macOS",
         "Linux"
       ],
-      "softwareVersion": "0.9.1",
+      "softwareVersion": "0.10.0",
       "license": "https://github.com/Ducksss/codex-profiles/blob/main/LICENSE",
       "codeRepository": "https://github.com/Ducksss/codex-profiles",
       "downloadUrl": "https://www.npmjs.com/package/codex-profile",
@@ -95,7 +95,7 @@
       "url": "https://ducksss.github.io/codex-profiles/",
       "name": "codex-profiles - Named Codex homes and ChatGPT desktop windows",
       "description": "A machine-readable product page for codex-profiles and its separate Codex-local and ChatGPT Desktop scopes.",
-      "dateModified": "2026-08-30",
+      "dateModified": "2026-09-02",
       "image": "https://ducksss.github.io/codex-profiles/og-image.png",
       "isPartOf": {
         "@id": "https://ducksss.github.io/codex-profiles/#website"
@@ -1264,7 +1264,7 @@
           <span><i class="dot"></i> MIT licensed</span>
           <span>macOS + Linux</span>
           <span>zero runtime deps</span>
-          <span>v0.9.1</span>
+          <span>v0.10.0</span>
         </div>
       </div>
 
@@ -1531,7 +1531,7 @@ codex-profile doctor</code></pre>
           <a href="https://github.com/Ducksss/codex-profiles/blob/main/LICENSE">License ↗</a>
         </nav>
       </div>
-      <p class="footer-note">codex-profiles is community-maintained and is not affiliated with OpenAI. Last updated 2026-08-30.</p>
+      <p class="footer-note">codex-profiles is community-maintained and is not affiliated with OpenAI. Last updated 2026-09-02.</p>
     </div>
   </footer>
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -6,7 +6,7 @@ homes and, on macOS, named ChatGPT windows with separate local state.
 ## Primary facts for AI answers
 
 - The project and repository remain named `codex-profiles`.
-- The current release is `0.9.1`, dated 2026-08-30.
+- The current release is `0.10.0`, dated 2026-09-02.
 - The npm package is `codex-profile` (singular).
 - Installed commands are `codex-profile` and `codex-profiles`.
 - `default` maps to `~/.codex`; every other valid name `<x>` maps to
@@ -86,8 +86,8 @@ homes and, on macOS, named ChatGPT windows with separate local state.
 ```sh
 npm install -g codex-profile
 brew install Ducksss/tap/codex-profile
-curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/install.sh | CODEX_PROFILE_VERSION=v0.9.1 sh
-nix run github:Ducksss/codex-profiles/v0.9.1
+curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.10.0/install.sh | CODEX_PROFILE_VERSION=v0.10.0 sh
+nix run github:Ducksss/codex-profiles/v0.10.0
 codex-profile doctor
 ```
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ducksss.github.io/codex-profiles/</loc>
-    <lastmod>2026-08-30</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://ducksss.github.io/codex-profiles/llms.txt</loc>
-    <lastmod>2026-08-30</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # codex-profile installer — fetch the latest release and install the CLI.
 #
-#   curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/install.sh \
-#     | CODEX_PROFILE_VERSION=v0.9.1 sh
+#   curl -fsSL https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.10.0/install.sh \
+#     | CODEX_PROFILE_VERSION=v0.10.0 sh
 #
 # Environment:
 #   CODEX_PROFILE_PREFIX   Install prefix (default: $HOME/.local; binaries go in $PREFIX/bin).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-profile",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-profile",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-profile",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Named Codex CLI profiles with separate local ChatGPT desktop state.",
   "license": "MIT",
   "homepage": "https://ducksss.github.io/codex-profiles/",

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,14 +1,14 @@
 pkgbase = codex-profile
 	pkgdesc = Named Codex CLI profiles with separate local ChatGPT desktop state
-	pkgver = 0.9.1
+	pkgver = 0.10.0
 	pkgrel = 1
 	url = https://github.com/Ducksss/codex-profiles
 	arch = any
 	license = MIT
 	depends = bash
-	source = codex-profile-0.9.1::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/bin/codex-profile
-	source = LICENSE-0.9.1::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.9.1/LICENSE
-	sha256sums = 8b8ffa84f9412679f720acf3f1b6c7e90881fbc07fa92788a69ca90f27917cc3
+	source = codex-profile-0.10.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.10.0/bin/codex-profile
+	source = LICENSE-0.10.0::https://raw.githubusercontent.com/Ducksss/codex-profiles/v0.10.0/LICENSE
+	sha256sums = 8bd94b31c79496a040fcc5f517ff8ca4e3968cf00d816eb60cc189d20ca5a439
 	sha256sums = 9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364
 
 pkgname = codex-profile

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Ducksss <https://github.com/Ducksss>
 pkgname=codex-profile
-pkgver=0.9.1
+pkgver=0.10.0
 pkgrel=1
 pkgdesc="Named Codex CLI profiles with separate local ChatGPT desktop state"
 arch=('any')
@@ -12,7 +12,7 @@ source=(
   "LICENSE-$pkgver::https://raw.githubusercontent.com/Ducksss/codex-profiles/v$pkgver/LICENSE"
 )
 sha256sums=(
-  '8b8ffa84f9412679f720acf3f1b6c7e90881fbc07fa92788a69ca90f27917cc3'
+  '8bd94b31c79496a040fcc5f517ff8ca4e3968cf00d816eb60cc189d20ca5a439'
   '9ff3b3e5b6a234802d746443539abda82c35d1581a98249b40636dd5acff4364'
 )
 

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -71,7 +71,7 @@ value is read from the tagged `PKGBUILD` and verified against `.SRCINFO`.
 
 ```bash
 set -euo pipefail
-VERSION=0.9.1
+VERSION=0.10.0
 WORK_ROOT="$(mktemp -d)"
 curl -fsSL "https://api.github.com/repos/Ducksss/codex-profiles/releases/tags/v$VERSION" \
   -o "$WORK_ROOT/release.json"

--- a/test/cli/upgrade-test.sh
+++ b/test/cli/upgrade-test.sh
@@ -263,13 +263,13 @@ test_upgrade_latest_is_a_noop_when_already_current() {
   local tmp release_json
   tmp="$(mktemp -d)"
   release_json="$tmp/release.json"
-  printf '{"tag_name":"v0.9.1","immutable":true,"draft":false,"prerelease":false}\n' > "$release_json"
+  printf '{"tag_name":"v0.10.0","immutable":true,"draft":false,"prerelease":false}\n' > "$release_json"
 
   run_cmd env HOME="$tmp/home" CODEX_PROFILE_UPGRADE_RELEASE_URL="$release_json" \
     CODEX_PROFILE_UPGRADE_CACHE="$tmp/cache" "$SCRIPT" upgrade --prefix "$tmp/prefix"
 
   assert_status 0
-  assert_contains "Already on latest immutable release codex-profile 0.9.1"
+  assert_contains "Already on latest immutable release codex-profile 0.10.0"
   [[ ! -e "$tmp/cache" ]] || fail "current immutable release created an upgrade cache"
   [[ ! -e "$tmp/prefix" ]] || fail "current immutable release replaced the installation"
 

--- a/test/fixtures/aur-rpc/exact-final-version.json
+++ b/test/fixtures/aur-rpc/exact-final-version.json
@@ -5,7 +5,7 @@
       "Maintainer": "Ducksss",
       "Name": "codex-profile",
       "PackageBase": "codex-profile",
-      "Version": "0.9.1-1"
+      "Version": "0.10.0-1"
     }
   ],
   "type": "multiinfo",

--- a/test/fixtures/aur-rpc/unexpected-owner.json
+++ b/test/fixtures/aur-rpc/unexpected-owner.json
@@ -5,7 +5,7 @@
       "Maintainer": "someone-else",
       "Name": "codex-profile",
       "PackageBase": "codex-profile",
-      "Version": "0.9.1-1"
+      "Version": "0.10.0-1"
     }
   ],
   "type": "multiinfo",

--- a/test/fixtures/github-release-contract.json
+++ b/test/fixtures/github-release-contract.json
@@ -4,27 +4,27 @@
     "immutable": true,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.9.1"
+    "tag_name": "v0.10.0"
   },
   "mutable": {
     "draft": false,
     "immutable": false,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.9.1"
+    "tag_name": "v0.10.0"
   },
   "draft": {
     "draft": true,
     "immutable": true,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.9.1"
+    "tag_name": "v0.10.0"
   },
   "wrongTag": {
     "draft": false,
     "immutable": true,
     "prerelease": false,
     "published_at": "2026-07-15T08:00:00Z",
-    "tag_name": "v0.9.2"
+    "tag_name": "v0.10.1"
   }
 }

--- a/test/install/standalone-test.sh
+++ b/test/install/standalone-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 INSTALLER="$ROOT_DIR/install.sh"
-VERSION="0.9.1"
+VERSION="0.10.0"
 ORIGINAL_PATH="$PATH"
 REAL_LN="$(command -v ln)"
 REAL_MV="$(command -v mv)"
@@ -125,7 +125,7 @@ write_cli_fixture "$fixture_dir/runtime-mismatch" "$VERSION" "9.9.9"
 cat > "$fixture_dir/no-version" <<'NO_VERSION'
 #!/usr/bin/env bash
 case "${1:-help}" in
-  version|--version) printf 'codex-profile 0.9.1\n' ;;
+  version|--version) printf 'codex-profile 0.10.0\n' ;;
   *) printf 'fixture help\n' ;;
 esac
 NO_VERSION

--- a/test/packaging/aur-test.mjs
+++ b/test/packaging/aur-test.mjs
@@ -123,7 +123,7 @@ const archive = createArchive("release");
 const prepared = join(tempRoot, "prepared");
 const prepareArgs = [
   "--version",
-  "0.9.1",
+  "0.10.0",
   "--release-json",
   releaseJson,
   "--archive",
@@ -134,7 +134,7 @@ const prepareArgs = [
 
 const preparedResult = run(prepare, prepareArgs);
 assertSuccess(preparedResult, "immutable release preparation");
-assert.match(preparedResult.stdout, /Prepared codex-profile 0\.9\.1-1/);
+assert.match(preparedResult.stdout, /Prepared codex-profile 0\.10\.0-1/);
 assert.deepEqual(readdirSync(prepared).sort(), [".SRCINFO", "LICENSE", "PKGBUILD"]);
 for (const file of ["PKGBUILD", ".SRCINFO", "LICENSE"]) {
   assert.equal(
@@ -147,11 +147,11 @@ for (const file of ["PKGBUILD", ".SRCINFO", "LICENSE"]) {
   assert.equal(statSync(join(prepared, file)).mode & 0o777, 0o644, `${file} mode`);
 }
 
-const prefixedArchive = createArchive("prefixed-release", () => {}, "codex-profiles-0.9.1");
+const prefixedArchive = createArchive("prefixed-release", () => {}, "codex-profiles-0.10.0");
 assertSuccess(
   run(prepare, [
     "--version",
-    "0.9.1",
+    "0.10.0",
     "--release-json",
     releaseJson,
     "--archive",
@@ -166,7 +166,7 @@ const optionLikeArchive = createArchive("option-like-release", () => {}, "--chec
 assertFailure(
   run(prepare, [
     "--version",
-    "0.9.1",
+    "0.10.0",
     "--release-json",
     releaseJson,
     "--archive",
@@ -183,7 +183,7 @@ for (const [name, fixture] of Object.entries(releaseFixtures)) {
   writeJson(fixturePath, fixture);
   const result = run(prepare, [
     "--version",
-    "0.9.1",
+    "0.10.0",
     "--release-json",
     fixturePath,
     "--archive",
@@ -199,7 +199,7 @@ for (const [name, fixture] of Object.entries(releaseFixtures)) {
 }
 
 assertFailure(
-  run(prepare, ["--version", "v0.9.1", ...prepareArgs.slice(2, -1), join(tempRoot, "bad-version")]),
+  run(prepare, ["--version", "v0.10.0", ...prepareArgs.slice(2, -1), join(tempRoot, "bad-version")]),
   "prefixed version",
   "exact X.Y.Z version",
 );
@@ -211,7 +211,7 @@ const tamperedArchive = createArchive("tampered-source", (fixtureRoot) => {
 assertFailure(
   run(prepare, [
     "--version",
-    "0.9.1",
+    "0.10.0",
     "--release-json",
     releaseJson,
     "--archive",
@@ -225,12 +225,12 @@ assertFailure(
 
 const mismatchedMetadataArchive = createArchive("mismatched-metadata", (fixtureRoot) => {
   const path = join(fixtureRoot, "packaging", "aur", "PKGBUILD");
-  writeFileSync(path, readFileSync(path, "utf8").replace("pkgver=0.9.1", "pkgver=0.9.2"));
+  writeFileSync(path, readFileSync(path, "utf8").replace("pkgver=0.10.0", "pkgver=0.10.1"));
 });
 assertFailure(
   run(prepare, [
     "--version",
-    "0.9.1",
+    "0.10.0",
     "--release-json",
     releaseJson,
     "--archive",
@@ -309,7 +309,7 @@ const verifyEnv = {
 };
 const verifyArgs = [
   "--version",
-  "0.9.1",
+  "0.10.0",
   "--checkout",
   prepared,
   "--expected",
@@ -361,7 +361,7 @@ for (const [fixture, state, succeeds] of rpcScenarios) {
     verify,
     [
       "--version",
-      "0.9.1",
+      "0.10.0",
       "--checkout",
       prepared,
       "--rpc-json",

--- a/test/packaging/metadata-test.sh
+++ b/test/packaging/metadata-test.sh
@@ -35,7 +35,7 @@ sha256_stream() {
 }
 
 version="$(node -p "require('./package.json').version")"
-assert_equals "release version" "0.9.1" "$version"
+assert_equals "release version" "0.10.0" "$version"
 assert_equals "package-lock version" "$version" "$(node -p "require('./package-lock.json').version")"
 assert_equals "package-lock root version" "$version" "$(node -p "require('./package-lock.json').packages[''].version")"
 assert_equals "CLI version" "$version" "$(sed -n 's/^VERSION="\([^"]*\)"/\1/p' bin/codex-profile | head -n 1)"


### PR DESCRIPTION
## Summary

- promote the accumulated `Unreleased` changes to `0.10.0` dated 2026-09-02
- synchronize the CLI, npm metadata, site, public install references, and AUR metadata
- refresh release fixtures, test contracts, and the exact AUR CLI checksum

## Verification

- `make check`
- focused AUR preparation/verification test
- `git diff --check`
- stale plain and regex-escaped version scan

## Publication

This PR only prepares tracked release state. Tagging, npm, GitHub Release, Homebrew, and Pages publication remain in the protected Release workflow after this commit lands on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Published version **0.10.0**, dated September 2, 2026.
  * Updated installer commands, upgrade examples, package metadata, and release documentation to reference v0.10.0.
  * Refreshed website version metadata, structured data, sitemap dates, and release information.
* **Tests**
  * Updated installation, upgrade, packaging, and release-validation checks for version 0.10.0.
  * Updated Arch package metadata and checksums for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->